### PR TITLE
refactor(validators): rename payload validators and add MongoDB ID validation for params

### DIFF
--- a/backend/src/modules/courses/classes/transformers/Item.ts
+++ b/backend/src/modules/courses/classes/transformers/Item.ts
@@ -14,7 +14,7 @@ import {
   IBlogDetails,
 } from 'shared/interfaces/IUser';
 import {ID} from 'shared/types';
-import {CreateItemPayloadValidator} from '../validators/ItemValidators';
+import {CreateItemBody} from '../validators/ItemValidators';
 /**
  * Item data transformation.
  *
@@ -40,20 +40,20 @@ class Item implements IBaseItem {
 
   itemDetails: IVideoDetails | IQuizDetails | IBlogDetails;
 
-  constructor(itemPayload: CreateItemPayloadValidator, existingItems: Item[]) {
-    if (itemPayload) {
-      this.name = itemPayload.name;
-      this.description = itemPayload.description;
-      this.type = itemPayload.type;
+  constructor(itemBody: CreateItemBody, existingItems: Item[]) {
+    if (itemBody) {
+      this.name = itemBody.name;
+      this.description = itemBody.description;
+      this.type = itemBody.type;
       switch (this.type) {
         case ItemType.VIDEO:
-          this.itemDetails = itemPayload.videoDetails;
+          this.itemDetails = itemBody.videoDetails;
           break;
         case ItemType.QUIZ:
-          this.itemDetails = itemPayload.quizDetails;
+          this.itemDetails = itemBody.quizDetails;
           break;
         case ItemType.BLOG:
-          this.itemDetails = itemPayload.blogDetails;
+          this.itemDetails = itemBody.blogDetails;
           break;
         default:
           break;
@@ -66,8 +66,8 @@ class Item implements IBaseItem {
     this.order = calculateNewOrder(
       sortedItems,
       'itemId',
-      itemPayload.afterItemId,
-      itemPayload.beforeItemId,
+      itemBody.afterItemId,
+      itemBody.beforeItemId,
     );
   }
 }

--- a/backend/src/modules/courses/classes/transformers/Module.ts
+++ b/backend/src/modules/courses/classes/transformers/Module.ts
@@ -8,7 +8,7 @@ import {
 } from 'shared/constants/transformerConstants';
 import {IModule} from 'shared/interfaces/IUser';
 import {ID} from 'shared/types';
-import {CreateModulePayloadValidator} from '../validators/ModuleValidators';
+import {CreateModuleBody} from '../validators/ModuleValidators';
 import {Section} from './Section';
 
 /**
@@ -43,13 +43,10 @@ class Module implements IModule {
   @Type(() => Date)
   updatedAt: Date;
 
-  constructor(
-    modulePayload: CreateModulePayloadValidator,
-    existingModules: IModule[],
-  ) {
-    if (modulePayload) {
-      this.name = modulePayload.name;
-      this.description = modulePayload.description;
+  constructor(moduleBody: CreateModuleBody, existingModules: IModule[]) {
+    if (moduleBody) {
+      this.name = moduleBody.name;
+      this.description = moduleBody.description;
     }
     const sortedModules = existingModules.sort((a, b) =>
       a.order.localeCompare(b.order),
@@ -58,8 +55,8 @@ class Module implements IModule {
     this.order = calculateNewOrder(
       sortedModules,
       'moduleId',
-      modulePayload.afterModuleId,
-      modulePayload.beforeModuleId,
+      moduleBody.afterModuleId,
+      moduleBody.beforeModuleId,
     );
     this.sections = [];
     this.createdAt = new Date();

--- a/backend/src/modules/courses/classes/transformers/Section.ts
+++ b/backend/src/modules/courses/classes/transformers/Section.ts
@@ -8,7 +8,7 @@ import {
 } from 'shared/constants/transformerConstants';
 import {ISection} from 'shared/interfaces/IUser';
 import {ID} from 'shared/types';
-import {CreateSectionPayloadValidator} from '../validators/SectionValidators';
+import {CreateSectionBody} from '../validators/SectionValidators';
 
 /**
  * Section data transformation.
@@ -41,13 +41,10 @@ class Section implements ISection {
   @Type(() => Date)
   updatedAt: Date;
 
-  constructor(
-    sectionPayload: CreateSectionPayloadValidator,
-    existingSections: ISection[],
-  ) {
-    if (sectionPayload) {
-      this.name = sectionPayload.name;
-      this.description = sectionPayload.description;
+  constructor(sectionBody: CreateSectionBody, existingSections: ISection[]) {
+    if (sectionBody) {
+      this.name = sectionBody.name;
+      this.description = sectionBody.description;
     }
     const sortedSections = existingSections.sort((a, b) =>
       a.order.localeCompare(b.order),
@@ -56,8 +53,8 @@ class Section implements ISection {
     this.order = calculateNewOrder(
       sortedSections,
       'sectionId',
-      sectionPayload.afterSectionId,
-      sectionPayload.beforeSectionId,
+      sectionBody.afterSectionId,
+      sectionBody.beforeSectionId,
     );
     this.createdAt = new Date();
     this.updatedAt = new Date();

--- a/backend/src/modules/courses/classes/validators/CourseValidators.ts
+++ b/backend/src/modules/courses/classes/validators/CourseValidators.ts
@@ -7,6 +7,7 @@ import {
   IsEmpty,
   IsOptional,
   ValidateIf,
+  IsMongoId,
 } from 'class-validator';
 import {ICourse} from 'shared/interfaces/IUser';
 
@@ -15,7 +16,7 @@ import {ICourse} from 'shared/interfaces/IUser';
  *
  * @category Courses/Validators/CourseValidators
  */
-class CreateCoursePayloadValidator implements ICourse {
+class CreateCourseBody implements ICourse {
   @IsNotEmpty()
   @IsString()
   @MaxLength(255)
@@ -45,7 +46,7 @@ class CreateCoursePayloadValidator implements ICourse {
  *
  * @category Courses/Validators/CourseValidators
  */
-class UpdateCoursePayloadValidator implements Partial<ICourse> {
+class UpdateCourseBody implements Partial<ICourse> {
   @IsOptional()
   @IsString()
   @MaxLength(255)
@@ -65,4 +66,20 @@ class UpdateCoursePayloadValidator implements Partial<ICourse> {
   nameOrDescription: string;
 }
 
-export {CreateCoursePayloadValidator, UpdateCoursePayloadValidator};
+class ReadCourseParams {
+  @IsMongoId()
+  @IsString()
+  id: string;
+}
+class UpdateCourseParams {
+  @IsMongoId()
+  @IsString()
+  id: string;
+}
+
+export {
+  CreateCourseBody,
+  UpdateCourseBody,
+  ReadCourseParams,
+  UpdateCourseParams,
+};

--- a/backend/src/modules/courses/classes/validators/CourseVersionValidators.ts
+++ b/backend/src/modules/courses/classes/validators/CourseVersionValidators.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import {IsEmpty, IsNotEmpty, IsString} from 'class-validator';
+import {IsEmpty, IsMongoId, IsNotEmpty, IsString} from 'class-validator';
 import {ICourseVersion, IModule} from 'shared/interfaces/IUser';
 
 /**
@@ -7,7 +7,7 @@ import {ICourseVersion, IModule} from 'shared/interfaces/IUser';
  *
  * @category Courses/Validators/CourseVersionValidators
  */
-class CreateCourseVersionPayloadValidator implements ICourseVersion {
+class CreateCourseVersionBody implements ICourseVersion {
   @IsEmpty()
   courseId: string;
 
@@ -29,4 +29,19 @@ class CreateCourseVersionPayloadValidator implements ICourseVersion {
   updatedAt: Date;
 }
 
-export {CreateCourseVersionPayloadValidator};
+class CreateCourseVersionParams {
+  @IsMongoId()
+  @IsString()
+  id: string;
+}
+class ReadCourseVersionParams {
+  @IsMongoId()
+  @IsString()
+  id: string;
+}
+
+export {
+  CreateCourseVersionBody,
+  CreateCourseVersionParams,
+  ReadCourseVersionParams,
+};

--- a/backend/src/modules/courses/classes/validators/ItemValidators.ts
+++ b/backend/src/modules/courses/classes/validators/ItemValidators.ts
@@ -88,7 +88,7 @@ class BlogDetailsPayloadValidator implements IBlogDetails {
 /**
  * @category Courses/Validators/ItemValidators
  */
-class CreateItemPayloadValidator implements IBaseItem {
+class CreateItemBody implements IBaseItem {
   @IsEmpty()
   _id?: string;
 
@@ -152,7 +152,7 @@ class CreateItemPayloadValidator implements IBaseItem {
 /**
  * @category Courses/Validators/ItemValidators
  */
-class UpdateItemPayloadValidator implements IBaseItem {
+class UpdateItemBody implements IBaseItem {
   @IsEmpty()
   _id?: string;
 
@@ -216,7 +216,7 @@ class UpdateItemPayloadValidator implements IBaseItem {
 /**
  * @category Courses/Validators/ItemValidators
  */
-class MoveItemPayloadValidator {
+class MoveItemBody {
   @IsOptional()
   @IsMongoId()
   @IsString()
@@ -226,13 +226,93 @@ class MoveItemPayloadValidator {
   @IsMongoId()
   @IsString()
   beforeItemId?: string;
+
+  @ValidateIf(o => !o.afterItemId && !o.beforeItemId)
+  @IsNotEmpty({
+    message: 'At least one of "afterItemId" or "beforeItemId" must be provided',
+  })
+  onlyOneAllowed: string;
+
+  @ValidateIf(o => o.afterItemId && o.beforeItemId)
+  @IsNotEmpty({
+    message: 'Only one of "afterItemId" or "beforeItemId" must be provided',
+  })
+  bothNotAllowed: string;
+}
+
+class CreateItemParams {
+  @IsMongoId()
+  @IsString()
+  versionId: string;
+
+  @IsMongoId()
+  @IsString()
+  moduleId: string;
+
+  @IsMongoId()
+  @IsString()
+  sectionId: string;
+}
+
+class ReadAllItemsParams {
+  @IsMongoId()
+  @IsString()
+  versionId: string;
+
+  @IsMongoId()
+  @IsString()
+  moduleId: string;
+
+  @IsMongoId()
+  @IsString()
+  sectionId: string;
+}
+
+class UpdateItemParams {
+  @IsMongoId()
+  @IsString()
+  versionId: string;
+
+  @IsMongoId()
+  @IsString()
+  moduleId: string;
+
+  @IsMongoId()
+  @IsString()
+  sectionId: string;
+
+  @IsMongoId()
+  @IsString()
+  itemId: string;
+}
+
+class MoveItemParams {
+  @IsMongoId()
+  @IsString()
+  versionId: string;
+
+  @IsMongoId()
+  @IsString()
+  moduleId: string;
+
+  @IsMongoId()
+  @IsString()
+  sectionId: string;
+
+  @IsMongoId()
+  @IsString()
+  itemId: string;
 }
 
 export {
-  CreateItemPayloadValidator,
-  UpdateItemPayloadValidator,
-  MoveItemPayloadValidator,
+  CreateItemBody,
+  UpdateItemBody,
+  MoveItemBody,
   VideoDetailsPayloadValidator,
   QuizDetailsPayloadValidator,
   BlogDetailsPayloadValidator,
+  CreateItemParams,
+  ReadAllItemsParams,
+  UpdateItemParams,
+  MoveItemParams,
 };

--- a/backend/src/modules/courses/classes/validators/ModuleValidators.ts
+++ b/backend/src/modules/courses/classes/validators/ModuleValidators.ts
@@ -6,7 +6,6 @@ import {
   MaxLength,
   IsOptional,
   IsMongoId,
-  Validate,
   ValidateIf,
 } from 'class-validator';
 import {IModule, ISection} from 'shared/interfaces/IUser';

--- a/backend/src/modules/courses/classes/validators/ModuleValidators.ts
+++ b/backend/src/modules/courses/classes/validators/ModuleValidators.ts
@@ -6,13 +6,15 @@ import {
   MaxLength,
   IsOptional,
   IsMongoId,
+  Validate,
+  ValidateIf,
 } from 'class-validator';
 import {IModule, ISection} from 'shared/interfaces/IUser';
 
 /**
  * @category Courses/Validators/ModuleValidators
  */
-class CreateModulePayloadValidator implements IModule {
+class CreateModuleBody implements IModule {
   @IsEmpty()
   moduleId?: string | undefined;
 
@@ -49,4 +51,80 @@ class CreateModulePayloadValidator implements IModule {
   updatedAt: Date;
 }
 
-export {CreateModulePayloadValidator};
+class UpdateModuleBody implements Partial<IModule> {
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description: string;
+
+  @ValidateIf(o => !o.name && !o.description)
+  @IsNotEmpty({
+    message: 'At least one of "name" or "description" must be provided',
+  })
+  nameOrDescription: string;
+}
+
+class MoveModuleBody {
+  @IsOptional()
+  @IsMongoId()
+  @IsString()
+  afterModuleId?: string;
+
+  @IsOptional()
+  @IsMongoId()
+  @IsString()
+  beforeModuleId?: string;
+
+  @ValidateIf(o => !o.afterModuleId && !o.beforeModuleId)
+  @IsNotEmpty({
+    message:
+      'At least one of "afterModuleId" or "beforeModuleId" must be provided',
+  })
+  onlyOneAllowed: string;
+
+  @ValidateIf(o => o.afterModuleId && o.beforeModuleId)
+  @IsNotEmpty({
+    message: 'Only one of "afterModuleId" or "beforeModuleId" must be provided',
+  })
+  bothNotAllowed: string;
+}
+
+class CreateModuleParams {
+  @IsMongoId()
+  @IsString()
+  versionId: string;
+}
+
+class UpdateModuleParams {
+  @IsMongoId()
+  @IsString()
+  versionId: string;
+
+  @IsMongoId()
+  @IsString()
+  moduleId: string;
+}
+
+class MoveModuleParams {
+  @IsMongoId()
+  @IsString()
+  versionId: string;
+
+  @IsMongoId()
+  @IsString()
+  moduleId: string;
+}
+
+export {
+  CreateModuleBody,
+  UpdateModuleBody,
+  CreateModuleParams,
+  UpdateModuleParams,
+  MoveModuleParams,
+  MoveModuleBody,
+};

--- a/backend/src/modules/courses/classes/validators/SectionValidators.ts
+++ b/backend/src/modules/courses/classes/validators/SectionValidators.ts
@@ -6,6 +6,8 @@ import {
   MaxLength,
   IsOptional,
   IsMongoId,
+  Validate,
+  ValidateIf,
 } from 'class-validator';
 import {ISection} from 'shared/interfaces/IUser';
 import {ID} from 'shared/types';
@@ -13,7 +15,7 @@ import {ID} from 'shared/types';
 /**
  * @category Courses/Validators/ModuleValidators
  */
-class CreateSectionPayloadValidator implements ISection {
+class CreateSectionBody implements ISection {
   @IsEmpty()
   sectionId?: string | undefined;
 
@@ -50,4 +52,101 @@ class CreateSectionPayloadValidator implements ISection {
   updatedAt: Date;
 }
 
-export {CreateSectionPayloadValidator};
+class UpdateSectionBody implements Partial<ISection> {
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description: string;
+
+  @ValidateIf(o => !o.name && !o.description)
+  @IsNotEmpty({
+    message: 'At least one of "name" or "description" must be provided',
+  })
+  nameOrDescription: string;
+}
+
+class MoveSectionBody {
+  @IsOptional()
+  @IsMongoId()
+  @IsString()
+  afterSectionId?: string;
+
+  @IsOptional()
+  @IsMongoId()
+  @IsString()
+  beforeSectionId?: string;
+
+  @ValidateIf(o => !o.afterSectionId && !o.beforeSectionId)
+  @IsNotEmpty({
+    message:
+      'At least one of "afterSectionId" or "beforeSectionId" must be provided',
+  })
+  onlyOneAllowed: string;
+
+  @ValidateIf(o => o.afterSectionId && o.beforeSectionId)
+  @IsNotEmpty({
+    message:
+      'Only one of "afterSectionId" or "beforeSectionId" must be provided',
+  })
+  bothNotAllowed: string;
+}
+
+class CreateSectionParams {
+  @IsMongoId()
+  @IsString()
+  @IsNotEmpty()
+  versionId: string;
+
+  @IsMongoId()
+  @IsString()
+  @IsNotEmpty()
+  moduleId: string;
+}
+
+class MoveSectionParams {
+  @IsMongoId()
+  @IsString()
+  @IsNotEmpty()
+  versionId: string;
+
+  @IsMongoId()
+  @IsString()
+  @IsNotEmpty()
+  moduleId: string;
+
+  @IsMongoId()
+  @IsString()
+  @IsNotEmpty()
+  sectionId: string;
+}
+
+class UpdateSectionParams {
+  @IsMongoId()
+  @IsString()
+  @IsNotEmpty()
+  versionId: string;
+
+  @IsMongoId()
+  @IsString()
+  @IsNotEmpty()
+  moduleId: string;
+
+  @IsMongoId()
+  @IsString()
+  @IsNotEmpty()
+  sectionId: string;
+}
+
+export {
+  CreateSectionBody,
+  UpdateSectionBody,
+  MoveSectionBody,
+  CreateSectionParams,
+  MoveSectionParams,
+  UpdateSectionParams,
+};

--- a/backend/src/modules/courses/controllers/CourseController.ts
+++ b/backend/src/modules/courses/controllers/CourseController.ts
@@ -7,16 +7,18 @@ import {
   Body,
   HttpError,
   Get,
-  Param,
   Put,
+  Params,
 } from 'routing-controllers';
 import {CourseRepository} from 'shared/database/providers/mongo/repositories/CourseRepository';
 import {Service, Inject} from 'typedi';
 import {Course} from '../classes/transformers/Course';
 import {ItemNotFoundError} from 'shared/errors/errors';
 import {
-  CreateCoursePayloadValidator,
-  UpdateCoursePayloadValidator,
+  CreateCourseBody,
+  ReadCourseParams,
+  UpdateCourseParams,
+  UpdateCourseBody,
 } from '../classes/validators/CourseValidators';
 
 /**
@@ -32,8 +34,8 @@ export class CourseController {
 
   @Authorized(['admin', 'instructor'])
   @Post('/')
-  async create(@Body({validate: true}) payload: CreateCoursePayloadValidator) {
-    let course = new Course(payload);
+  async create(@Body() body: CreateCourseBody) {
+    let course = new Course(body);
     try {
       course = await this.courseRepo.create(course);
       return instanceToPlain(course);
@@ -44,7 +46,8 @@ export class CourseController {
 
   @Authorized(['admin', 'instructor'])
   @Get('/:id')
-  async read(@Param('id') id: string) {
+  async read(@Params() params: ReadCourseParams) {
+    const {id} = params;
     try {
       const courses = await this.courseRepo.read(id);
       return instanceToPlain(courses);
@@ -59,11 +62,12 @@ export class CourseController {
   @Authorized(['admin', 'instructor'])
   @Put('/:id')
   async update(
-    @Param('id') id: string,
-    @Body({validate: true}) payload: UpdateCoursePayloadValidator,
+    @Params() params: UpdateCourseParams,
+    @Body() body: UpdateCourseBody,
   ) {
+    const {id} = params;
     try {
-      const course = await this.courseRepo.update(id, payload);
+      const course = await this.courseRepo.update(id, body);
       return instanceToPlain(course);
     } catch (error) {
       if (error instanceof ItemNotFoundError) {

--- a/backend/src/modules/courses/controllers/CourseVersionController.ts
+++ b/backend/src/modules/courses/controllers/CourseVersionController.ts
@@ -7,14 +7,18 @@ import {
   Get,
   HttpError,
   JsonController,
-  Param,
+  Params,
   Post,
 } from 'routing-controllers';
 import {CourseRepository} from 'shared/database/providers/mongo/repositories/CourseRepository';
 import {ItemNotFoundError, ReadError} from 'shared/errors/errors';
 import {Inject, Service} from 'typedi';
 import {CourseVersion} from '../classes/transformers/CourseVersion';
-import {CreateCourseVersionPayloadValidator} from '../classes/validators/CourseVersionValidators';
+import {
+  CreateCourseVersionParams,
+  CreateCourseVersionBody,
+  ReadCourseVersionParams,
+} from '../classes/validators/CourseVersionValidators';
 
 /**
  *
@@ -29,9 +33,10 @@ export class CourseVersionController {
   @Authorized(['admin', 'instructor'])
   @Post('/:id/versions')
   async create(
-    @Param('id') id: string,
-    @Body({validate: true}) payload: CreateCourseVersionPayloadValidator,
+    @Params() params: CreateCourseVersionParams,
+    @Body() body: CreateCourseVersionBody,
   ) {
+    const {id} = params;
     try {
       // console.log("id", id);
       // console.log("payload", payload);
@@ -39,7 +44,7 @@ export class CourseVersionController {
       const course = await this.courseRepo.read(id);
 
       //Create Version
-      let version = new CourseVersion(payload);
+      let version = new CourseVersion(body);
       version.courseId = new ObjectId(id);
       version = (await this.courseRepo.createVersion(version)) as CourseVersion;
 
@@ -70,7 +75,8 @@ export class CourseVersionController {
 
   @Authorized(['admin', 'instructor', 'student'])
   @Get('/versions/:id')
-  async read(@Param('id') id: string) {
+  async read(@Params() params: ReadCourseVersionParams) {
+    const {id} = params;
     try {
       const version = await this.courseRepo.readVersion(id);
       return instanceToPlain(version);

--- a/backend/src/modules/courses/index.ts
+++ b/backend/src/modules/courses/index.ts
@@ -35,6 +35,7 @@ export const coursesModuleOptions: RoutingControllersOptions = {
   authorizationChecker: async function () {
     return true;
   },
+  validation: true,
 };
 
 export * from './classes/validators/index';


### PR DESCRIPTION
Rename validator classes from "Payload" to "Body" for consistency with naming conventions across item, module, and section components. Introduce MongoDB ID validation for relevant request parameters to ensure data integrity. Refactor controller methods to use consolidated parameter objects for cleaner and more maintainable request handling.
