### PR TITLE
Refactor test: Use valid MongoID in "should return 404 if course not found"

### DIFF
--- a/backend/src/modules/courses/tests/CourseVersionController.test.ts
+++ b/backend/src/modules/courses/tests/CourseVersionController.test.ts
@@ -88,7 +88,8 @@ describe('Course Version Controller Integration Tests', () => {
         };
 
         // log the endpoint to request to
-        const endPoint = '/courses/123/versions';
+        //endpoint id should be a valid mongoId.
+        const endPoint = '/courses/5f9b1b3c9d1f1f1f1f1f1f1f/versions';
         const versionResponse = await request(app)
           .post(endPoint)
           .send(courseVersionPayload)


### PR DESCRIPTION
Hello All,

While setting up the environment using `python setup.py`, I encountered an issue with line 96 of CourseVersionController.test.ts. The test fails due to a response status of 400. Here's a screenshot for reference:
![image](https://github.com/user-attachments/assets/2c08c102-a485-4f1b-99e6-d3f330cd69a0)
After some debugging, I traced the issue to the IsMongoId validator in the CreateCourseVersionParams parameter validator.
To resolve this, I updated the endpoint in the test from:
`const endPoint = '/courses/123/versions';` to 
`const endPoint = '/courses/5f9b1b3c9d1f1f1f1f1f1f1f/versions';` 
in the CourseVersionController.test.ts
With this change, the setup was successfully completed.