### PR TITLE
feat(courseVersion): Cascade Delete course version + Deletion Test Scripts.

### DIFF
--- a/backend/src/modules/courses/classes/validators/CourseVersionValidators.ts
+++ b/backend/src/modules/courses/classes/validators/CourseVersionValidators.ts
@@ -70,11 +70,11 @@ class DeleteCourseVersionParams {
    */
   @IsMongoId()
   @IsString()
-  id: string;
+  versionId: string;
 
   @IsMongoId()
   @IsString()
-  cid: string;
+  courseId: string;
 }
 
 export {

--- a/backend/src/modules/courses/classes/validators/CourseVersionValidators.ts
+++ b/backend/src/modules/courses/classes/validators/CourseVersionValidators.ts
@@ -58,8 +58,28 @@ class ReadCourseVersionParams {
   id: string;
 }
 
+/**
+ * Route parameters for deleting a course version by ID.
+ *
+ * @category Courses/Validators/CourseVersionValidators
+ */
+
+class DeleteCourseVersionParams {
+  /**
+   * ID of the course version to delete.
+   */
+  @IsMongoId()
+  @IsString()
+  id: string;
+
+  @IsMongoId()
+  @IsString()
+  cid: string;
+}
+
 export {
   CreateCourseVersionBody,
   CreateCourseVersionParams,
   ReadCourseVersionParams,
+  DeleteCourseVersionParams,
 };

--- a/backend/src/modules/courses/controllers/CourseVersionController.ts
+++ b/backend/src/modules/courses/controllers/CourseVersionController.ts
@@ -132,21 +132,20 @@ export class CourseVersionController {
    */
 
   @Authorized(['admin', 'instructor'])
-  @Delete('/:cid/versions/:id')
+  @Delete('/:courseId/versions/:versionId')
   async delete(@Params() params: DeleteCourseVersionParams) {
-    const {cid, id} = params;
-    if (!id || !cid) {
+    const {courseId, versionId} = params;
+    if (!versionId || !courseId) {
       throw new BadRequestError('Version ID is required');
     }
     try {
-      const version = await this.courseRepo.deleteVersion(cid, id);
-      version._id = version._id.toString();
+      const version = await this.courseRepo.deleteVersion(courseId, versionId);
       return {
-        deletedItem: instanceToPlain(version),
+        message: `Version with the ID ${versionId} has been deleted successfully.`,
       };
     } catch (error) {
-      if (error instanceof BadRequestError) {
-        throw new HttpError(400, error.message);
+      if (error instanceof ItemNotFoundError) {
+        throw new HttpError(404, error.message);
       }
       if (error instanceof DeleteError) {
         throw new HttpError(500, error.message);

--- a/backend/src/modules/courses/tests/CourseVersionController.test.ts
+++ b/backend/src/modules/courses/tests/CourseVersionController.test.ts
@@ -274,4 +274,100 @@ describe('Course Version Controller Integration Tests', () => {
       });
     });
   });
+
+  // Delete course version
+  describe('COURSE VERSION DELETE', () => {
+    const coursePayload = {
+      name: 'New Course',
+      description: 'Course description',
+    };
+
+    const courseVersionPayload = {
+      version: 'New Course Version',
+      description: 'Course version description',
+    };
+
+    const modulePayload = {
+      name: 'New Module',
+      description: 'Module description',
+    };
+
+    const sectionPayload = {
+      name: 'New Section',
+      description: 'Section description',
+    };
+
+    const itemPayload = {
+      name: 'Item1',
+      description: 'This an item',
+      type: 'VIDEO',
+      videoDetails: {
+        URL: 'http://url.com',
+        startTime: '00:00:00',
+        endTime: '00:00:40',
+        points: '10.5',
+      },
+    };
+
+    describe('Success Scenario', () => {
+      it('should delete a course version', async () => {
+        const courseResponse = await request(app)
+          .post('/courses/')
+          .send(coursePayload)
+          .expect(200);
+
+        const courseId = courseResponse.body._id;
+
+        const versionResponse = await request(app)
+          .post(`/courses/${courseId}/versions`)
+          .send(courseVersionPayload)
+          .expect(200);
+
+        const versionId = versionResponse.body.version._id;
+
+        const moduleResponse = await request(app)
+          .post(`/courses/versions/${versionId}/modules`)
+          .send(modulePayload)
+          .expect(200);
+
+        const moduleId = moduleResponse.body.version.modules[0].moduleId;
+
+        const sectionResponse = await request(app)
+          .post(`/versions/${versionId}/modules/${moduleId}/sections`)
+          .send(sectionPayload)
+          .expect(200);
+
+        const sectionId =
+          sectionResponse.body.version.modules[0].sections[0].sectionId;
+
+        const itemsGroupId =
+          sectionResponse.body.version.modules[0].sections[0].itemsGroupId;
+
+        const itemsGroupResponse = await request(app)
+          .post(
+            `/versions/${versionId}/modules/${moduleId}/sections/${sectionId}/items`,
+          )
+          .send(itemPayload)
+          .expect(200);
+
+        const deleteVersion = await request(app)
+          .delete(`/courses/${courseId}/versions/${versionId}`)
+          .expect(200);
+        expect(deleteVersion.body.deletedItem);
+      });
+    });
+    describe('Failure Scenario', () => {
+      it('should not delete a course version', async () => {
+        // invalid MongoId
+        await request(app).delete('/courses/123/versions/123').expect(400);
+
+        // course version or course id not found.
+        await request(app)
+          .delete(
+            '/courses/5f9b1b3c9d1f1f1f1f1f1f1f/versions/5f9b1b3c9d1f1f1f1f1f1f1f',
+          )
+          .expect(404);
+      });
+    });
+  });
 });

--- a/backend/src/modules/courses/tests/ItemsController.test.ts
+++ b/backend/src/modules/courses/tests/ItemsController.test.ts
@@ -1,12 +1,11 @@
-import {coursesModuleOptions, ItemsGroup} from 'modules/courses';
+import {coursesModuleOptions} from 'modules/courses';
 import {MongoMemoryServer} from 'mongodb-memory-server';
-import {RoutingControllersOptions, useExpressServer} from 'routing-controllers';
+import {useExpressServer} from 'routing-controllers';
 import {CourseRepository} from 'shared/database/providers/mongo/repositories/CourseRepository';
 import {MongoDatabase} from 'shared/database/providers/MongoDatabaseProvider';
 import Container from 'typedi';
 import Express from 'express';
 import request from 'supertest';
-import {ReadError} from 'shared/errors/errors';
 
 describe('Item Controller Integration Tests', () => {
   const App = Express();

--- a/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
@@ -230,7 +230,7 @@ export class CourseRepository implements ICourseRepository {
       // 6. Cascade Delete item groups
 
       const itemDeletionResult = await this.itemsGroupCollection.deleteMany({
-        _id: {$in: itemGroupsIds.map(id => new ObjectId(id))},
+        _id: {$in: itemGroupsIds},
       });
 
       if (itemDeletionResult.deletedCount === 0) {
@@ -240,6 +240,9 @@ export class CourseRepository implements ICourseRepository {
       // 7. Return the deleted course version
       return courseVersion;
     } catch (error) {
+      if (error instanceof ItemNotFoundError) {
+        throw error;
+      }
       throw new Error(
         'Failed to delete course version.\n More Details: ' + error,
       );
@@ -251,7 +254,6 @@ export class CourseRepository implements ICourseRepository {
     try {
       const result = await this.itemsGroupCollection.insertOne(itemsGroup);
       if (result) {
-        console.log('Items created', result.insertedId);
         const newItems = await this.itemsGroupCollection.findOne({
           _id: result.insertedId,
         });

--- a/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
@@ -243,7 +243,7 @@ export class CourseRepository implements ICourseRepository {
       if (error instanceof ItemNotFoundError) {
         throw error;
       }
-      throw new Error(
+      throw new DeleteError(
         'Failed to delete course version.\n More Details: ' + error,
       );
     }


### PR DESCRIPTION
Implemented courseVersion deletion endpoint `/courses/:courseId/versions/:versionId`.

What it does:

1.  Deletes the course Version (including sections and modules associated with the version).
2.  Deletes All ItemGroups associated with the courseVersion (Cascade).
3.  Removes the versionId in the corresponding course entity (thus updating the timestamp of course document after update).

**Please let me know if i missed out any, open to changes.**

Closes #272 