### PR TITLE
corrected Frontend start command

### DIFF
--- a/docs/docs/getting-started/intro.md
+++ b/docs/docs/getting-started/intro.md
@@ -44,7 +44,7 @@ If you want to run services manually:
 ### 🖥 Frontend
 
 ```bash
-vibe start frontent
+vibe start frontend
 ```
 
 ### ⚙️ Backend


### PR DESCRIPTION
<!-- Description -->
The earlier command for starting the Frontend in Development mode was-
```bash
vibe start frontent
```
This command is wrong because there is nothing called frontent, else it should be-
```bash
vibe start frontend
```
This command will run the frontend
