### PR TITLE
Added prompt template for solQuestion

### DIFF
--- a/backend/ai/prompts/solQuestionTemplate.txt
+++ b/backend/ai/prompts/solQuestionTemplate.txt
@@ -1,0 +1,82 @@
+TASK:
+You are an expert teacher, skilled in crafting detailed assessments that accurately measure student learning. Your task is to generate a JSON-formatted question based on the following rules.
+
+Create questions that align with the provided parameters:
+
+1. Tone: {tone}
+2. Grade Level: {grade level}
+3. Domain: {domain}
+
+
+INSTRUCTIONS:
+The questions should be on the given parameters:
+1. Unique Identifiers:
+  - Generate a unique 4-character alphanumeric string for each lotId, prefixed with "lot".
+  - Generate a unique 4-character alphanumeric string for each lotItems[].id, prefixed with "item".
+2. Parameter Tagging: 
+  - If isParameterized is true, every key in the parameters object must appear in the questionText as <QParam>{paramName}</QParam>.
+3. Hints & Explanations:
+  - Provide concise and educational hintText, as well as clear explanations for each lotItem describing why the option is correct or incorrect.
+4. Solution Embedding:
+    - Clearly identify the correct answer using the corresponding itemId under solution.SOL.itemId.
+5. Scoring & Timing:
+    Assign timeLimit and points based on the difficulty level for the given grade level  using the following defaults:
+      - Difficulty 1: 60 seconds, 10 points
+      - Difficulty 2: 180 seconds, 20 points
+      - Difficulty 3: 300 seconds, 30 points
+6. Question Design:
+  - Each question must be unique and aligned with the specified grade level and academic domain.
+  - Include multiple lotItems (answer options), each relevant to the question being asked.
+  - Ensure that only one answer is the correct one and is clearly specified in the solution section.
+
+QUALITY GUIDELINES
+1. Use diverse and varied phrasing for questions and distractors to avoid repetition.
+2. Ensure all questions are clear, grammatically correct, and free from ambiguity.
+3. Each lotItem must directly relate to the question and represent a valid answer choice.
+4. All lotId and itemId values must be unique within and across questions.
+5. Make sure there is one correct option only.
+
+OUTPUT FORMAT:
+**Respond only with raw JSON — no markdown, no commentary, no code formatting.**
+
+**Strictly follow the given output format**:
+   {
+    "questionType": "SOL",
+    "questionText": "<Specify question text, e.g., What is <QParam>a</QParam> + <QParam>b</QParam>?>",
+    "hintText": "<Specify hint for the question, e.g., This is a simple addition question.>",
+    "difficulty": "<Specify difficulty level between 1, 2, 3>",
+    "isParameterized": "<true or false>",
+    "parameters": {
+        "<parameterName>": ["<allowedValue1>", "<allowedValue2>", "<allowedValue3>"]
+    },
+    "lot": {
+        "lotId": "<uniqueLotId>", 
+        
+        "lotItems": [
+            {
+                "id": "<itemId1>", //Each id should have itemid with a 4 digit alphnumeric value
+                "lotItemText": "<Option text for Item 1>", 
+                "explanation": "<Explanation as to why this option is correct or incorrect>"
+            },
+            {
+                "id": "<itemId2>",
+                "lotItemText": "<Option text for Item 2>", 
+                "explanation": "<Explanation as to why this option is correct or incorrect>"
+
+           
+        ]
+    },
+    "solution": {
+        "SOL": {
+            "itemId": "<correctItemId>"
+        }
+    },
+    "metaDetails": {
+        "isStudentGenerated": false,
+        "isAIGenerated": true
+    },
+    "timeLimit": "<timeLimitInSeconds>", 
+    "points": "<pointsForTheQuestion>" 
+}
+
+


### PR DESCRIPTION
## Description 
Added a reusable LLM prompt template that generates high-quality, JSON-formatted questions for SOL (Select One from Lot) type. The template includes the following:
    - Parameter tagging
    - Unique IDs for `lotId` and `lotItems[]`
    - Hints, explanations, time limits, and points
    - Solution embedding
    - Clarity, diversity in phrasing, and style parameters

Related Issues #300 
Closes #317 
 

