### PR TITLE
fix(tsconfig): update outDir to ensure valid imports during build

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -5,7 +5,7 @@
         "module": "nodenext",
         "moduleResolution": "nodenext",
         "lib": ["ESNext"],
-        "outDir": "build",
+        "outDir": "build/src",
         "rootDir": "src", // Changed back to "." to include scripts directory
         "sourceMap": true,
         "strict": false,


### PR DESCRIPTION
<!-- Description -->

Changed the TypeScript output directory to align with the expected import paths during the pnpm build process. This resolves issues where compiled output was previously in an incorrect location.