### PR TITLE
feat(sidebar): Make ViBe logo clickable to teacher dashboard

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -61,7 +61,7 @@ export function AppSidebar() {
     <Sidebar collapsible="icon" variant="sidebar" className="border-r">
 
       <SidebarHeader className="flex items-center px-4 py-4">
-        <div className="flex items-center gap-3">
+        <Link to="/teacher" className="flex items-center gap-3 focus:outline-none">
           <div className="h-10 w-10 rounded-lg overflow-hidden shrink-0">
             <img
               src="https://continuousactivelearning.github.io/vibe/img/logo.png"
@@ -74,7 +74,7 @@ export function AppSidebar() {
               <AuroraText colors={["#A07CFE", "#FE8FB5", "#FFBE7B"]}><b>ViBe</b></AuroraText>
             </span>
           )}
-        </div>
+        </Link>
       </SidebarHeader>
 
       <SidebarContent>


### PR DESCRIPTION
## Feature: Make ViBe Logo Clickable to Teacher Dashboard

### Summary
This PR makes the ViBe logo and text in the top-left corner of the teacher sidebar clickable. Clicking the logo now routes the user to the Teacher Dashboard (`/teacher`). This improves navigation and aligns with common UX patterns.

### Details
- Wrapped the ViBe logo and text in a `Link` component from `@tanstack/react-router` in `AppSidebar` (`frontend/src/components/app-sidebar.tsx`).
- Clicking the logo/text now navigates to the teacher dashboard.
- The clickable area includes both the logo and the "ViBe" text for better usability.
- No other sidebar or role is affected by this change.

### Motivation
- Users expect to be able to click the logo to return to the main dashboard.
- Reduces the need for a separate "Dashboard" button and streamlines navigation.

### Testing
- Verified that clicking the logo/text in the teacher sidebar routes to `/teacher`.
- Confirmed that the change does not affect other roles or sidebars.

Closes #434 