### PR TITLE
fix: prevent student role from rendering in instructor dashboard

### DIFF
--- a/frontend/src/app/pages/teacher/course-page.tsx
+++ b/frontend/src/app/pages/teacher/course-page.tsx
@@ -62,10 +62,11 @@ export default function TeacherCoursesPage() {
   const enrollments = enrollmentsResponse?.enrollments || []
   const totalPages = enrollmentsResponse?.totalPages || 1
   const totalDocuments = enrollmentsResponse?.totalDocuments || 0
+  const filteredEnrollements = enrollments.filter((enrollment)=>enrollment.role !== "STUDENT");
 
   // Get unique courses (in case user is enrolled in multiple versions of same course)
   // Since we're using pagination, we'll work with the current page data
-  const uniqueCourses = enrollments.reduce((acc: any[], enrollment: any) => {
+  const uniqueCourses = filteredEnrollements.reduce((acc: any[], enrollment: any) => {
     const courseIdHex = bufferToHex(enrollment.courseId)
     const existingCourse = acc.find((e) => bufferToHex(e.courseId) === courseIdHex)
     if (!existingCourse) {


### PR DESCRIPTION

 Filters enrollment loading in the instructor dashboard to prevent displaying courses where the user is only enrolled as a STUDENT.

## Changes Made
- Modified course rendering in `teacher/course-page.tsx` to only show courses where the user has instructor privileges.


## Problem resolved
Previously, users with both student and instructor enrollments were seeing student-level courses in the instructor dashboard, which created confusion. This change ensures clear role separation.
