### PR TITLE
move "quiz passed" popup below "verifying answers" popup

### DIFF
--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -1650,7 +1650,7 @@ const handleSelectItem = useCallback((moduleId: string, sectionId: string, itemI
                 {/* Quiz Passed/Failed */}
 
                 {quizPassed !== 2 && !isQuizSkipped && (
-                  <div className="fixed top-6 right-6 z-50 animate-in slide-in-from-top-5 fade-in duration-200">
+                  <div className={`fixed right-6 z-50 animate-in slide-in-from-top-5 fade-in duration-200 ${quizPassed === 1 ? 'top-60' : 'top-6'}`}>
                     <div
                       className={`relative w-[380px] rounded-2xl shadow-2xl overflow-hidden transform transition-all duration-300 
         ${quizPassed === 1
@@ -1668,7 +1668,7 @@ const handleSelectItem = useCallback((moduleId: string, sectionId: string, itemI
                         className="absolute top-3 right-3 p-2 rounded-full bg-white/20 hover:bg-white/30 transition-colors duration-200 group"
                         aria-label="Close"
                       >
-                        <X className="h-5 w-5 text-white group-hover:rotate-90 transition-transform duration-200" />
+                        <X className="h-5 w-5 text-white group-hover:rotate-90 transition-transform duration-200 hover:cursor-pointer" />
                       </button>
 
                       <div className="p-6 space-y-4">


### PR DESCRIPTION
Quiz passed! popup is overlapping verifying answers popup, which also ask us to wait for some time, if user moves to another tab then the passing  of quiz may not recorded at backend.

Also added pointer cursor while hovering on close button.

### Before modification:
<img width="893" height="814" alt="Before modification" src="https://github.com/user-attachments/assets/fa0380f5-74e5-49b0-9584-ba75e8f5b8cf" />

### After modification
<img width="618" height="839" alt="After modification" src="https://github.com/user-attachments/assets/90cbf79e-0c1a-4463-8927-c645f470d657" />


