### PR TITLE
matching eye icon color with text color in teacher's manage courses section

### DIFF
--- a/frontend/src/app/pages/teacher/teacher-course-page.tsx
+++ b/frontend/src/app/pages/teacher/teacher-course-page.tsx
@@ -1401,13 +1401,17 @@ function TeacherCourseContent() {
                                                         })}
                                                       </span>
                                                     </SidebarMenuSubButton>
-                                                    <Button className="absolute top-0 right-0" size="icon" variant="ghost" onClick={(e) => handleHideItem(item._id, !item.isHidden)} disabled={section.isHidden || module.isHidden || hidingItemId === item._id}>
+                                                    <Button className="absolute  top-0 right-0" size="icon" variant="ghost" onClick={(e) => handleHideItem(item._id, !item.isHidden)} disabled={section.isHidden || module.isHidden || hidingItemId === item._id}>
                                                       {hidingItemId === item._id ? (
                                                         <Loader2 className="h-4 w-4 animate-spin" />
                                                       ) : !item.isHidden ? (
-                                                        <Eye className="h-4 w-4" />
+                                                        <Eye className={`h-4 w-4 ${selectedItem.id == item._id
+                                                        ? "text-gray-200"
+                                                        : "text-muted-foreground"}` } />
                                                       ) : (
-                                                        <EyeOff className="h-4 w-4" />
+                                                        <EyeOff className={`h-4 w-4 ${selectedItem.id == item._id
+                                                        ? "text-gray-200"
+                                                        : "text-muted-foreground"}` } />
                                                       )}
                                                       <span className="sr-only">Hide Item</span>
                                                     </Button>


### PR DESCRIPTION
Issue:
In selected item inside the sections of the course, the text color wasn't watching with the eye icon

Fixed: 
Based on selected item, now the text color matches with the icon.