### PR TITLE
Disable reset button when no valid emails are entered

### DIFF
--- a/frontend/src/app/pages/teacher/invite.tsx
+++ b/frontend/src/app/pages/teacher/invite.tsx
@@ -614,11 +614,12 @@ const addInviteRow = () => {
               <Button
                 variant="outline"
                 onClick={() => setInviteEmails([{ email: "", role: "STUDENT" }])}
-                disabled={inviteUsers.isPending}
+                disabled={inviteUsers.isPending || inviteEmails.filter(invite => invite.email.trim() !== "").length === 0}
               >
                 <RotateCcw className="w-4 h-4 mr-2" />
                 Reset
               </Button>
+
               <Button
                 onClick={handleSendInvites}
                 disabled={inviteUsers.isPending || inviteEmails.filter(invite => invite.email.trim() !== "").length === 0 }


### PR DESCRIPTION
**Disable 'Reset' Button:**
Implemented a UI fix on the **Invite Users** page to improve user experience. The "Reset" button is now disable by default and only becomes visible when the user has actually entered a valid email address.

Changed in Files:
'invite.tsx'