### PR TITLE
fetch single field linearProgressionEnabled from course settings

### DIFF
--- a/backend/src/modules/courses/abilities/itemAbilities.ts
+++ b/backend/src/modules/courses/abilities/itemAbilities.ts
@@ -55,14 +55,11 @@ export async function setupItemAbilities(
         case 'STUDENT':
           can(ItemActions.ViewAll, 'Item', versionBounded);
 
-          // fetch courseVersion (to get linearProgression flag)
-          const courseSettings = await courseSettingService.readCourseSettings(
+          // true if linearProgressionEnabled field is not available
+          const linearProgressionEnabled = courseSettingService.isLinearProgressionEnabled(
             enrollment.courseId,
             enrollment.versionId,
           );
-
-          const linearProgressionEnabled =
-            courseSettings?.settings?.linearProgressionEnabled ?? true;
 
           let progress: any;
           try {

--- a/backend/src/modules/setting/services/CourseSettingService.ts
+++ b/backend/src/modules/setting/services/CourseSettingService.ts
@@ -236,6 +236,27 @@ class CourseSettingService extends BaseService {
     });
   }
     */
+
+
+  /**   
+   * Checks if linear progression is enabled for a specific course and version.
+   * @param courseId - The ID of the course
+   * @param courseVersionId - The ID of the course version
+   * @returns False if linear progression field is false, true otherwise
+   */
+  async isLinearProgressionEnabled(
+    courseId: string,
+    courseVersionId: string,
+  ): Promise<boolean> {
+    return this._withTransaction(async session => {
+      const isCourseEnabled = await this.settingsRepo.isLinearProgressionEnabled(
+        courseId,
+        courseVersionId,
+        session,
+      );
+      return isCourseEnabled;
+    });
+  }
 }
 
 export { CourseSettingService };

--- a/backend/src/shared/database/interfaces/ISettingRepository.ts
+++ b/backend/src/shared/database/interfaces/ISettingRepository.ts
@@ -151,4 +151,17 @@ export interface ISettingRepository {
     courseVersionId: string,
     session?: ClientSession,
   ): Promise<boolean>;
+
+  /**
+   * Checks if linear progression is enabled for a specific course and version.
+   * @param courseId - The ID of the course
+   * @param courseVersionId - The ID of the course version
+   * @param session - Optional MongoDB session for transactions
+   * @returns True if linear progression is enabled, false otherwise
+   */
+  isLinearProgressionEnabled(
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<boolean>;
 }

--- a/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
@@ -457,4 +457,37 @@ export class SettingRepository implements ISettingRepository {
     );
     return result.deletedCount > 0;
   }
+
+  /**
+   * Checks if linear progression is enabled for a specific course and version.
+   * @param courseId - The ID of the course
+   * @param courseVersionId - The ID of the course version
+   * @param session - Optional MongoDB session for transactions
+   * @returns False if linear progression field is false, true otherwise
+   */
+  async isLinearProgressionEnabled(
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<boolean> {
+    await this.init();
+    const courseSettings = await this.courseSettingsCollection.findOne(
+      {
+        courseId: new ObjectId(courseId),
+        courseVersionId: new ObjectId(courseVersionId),
+      },
+      {
+        projection: {
+          'settings.linearProgressionEnabled': 1, _id: 0 
+        },
+        session,
+      },
+    );
+
+    if (courseSettings?.settings?.linearProgressionEnabled == null) {
+      return true;
+    }
+
+    return courseSettings.settings.linearProgressionEnabled;
+  }
 }


### PR DESCRIPTION
Previously itemAbilities was fetching full courseSettings object to see whether linearProgressionEnabled in a course's version is true or false.

Now a new method is created in repository to fetch only linearProgressionEnabled field and use in itemAbilities. This method returns true if linearProgressionEnabled field is not available in the courseSettings object.
