### PR TITLE
Fix/course registration requests api refetch debounce

### DIFF
--- a/frontend/src/app/pages/teacher/CourseRegistrationRequests.tsx
+++ b/frontend/src/app/pages/teacher/CourseRegistrationRequests.tsx
@@ -61,12 +61,12 @@ export default function CourseRegistrationRequests() {
   const PAGE_LIMIT = 15;
 
   const params = useMemo(() => ({
-    status: filterStatus,
+    // status: filterStatus,
     search: searchTerm,
     sort: sortOrder,
     page: currentPage,
     limit: PAGE_LIMIT,
-  }), [filterStatus, searchTerm, sortOrder, currentPage]);
+  }), [ searchTerm, sortOrder, currentPage]);
 
   const { data: registrationsData, isLoading, refetch: registrationsRefetch } = useGetCourseRegistrationRequests(versionId as string, params);
   const { mutateAsync: updateStatus, isPending: isUpdatingStatus } = useUpdateRegistrationStatus();
@@ -75,6 +75,11 @@ export default function CourseRegistrationRequests() {
 
   const FRONTEND_URL = window.location.origin;
   const registrationUrl = `${FRONTEND_URL}/student/course-registration/${versionId}`;
+
+  const filteredRegistrations = useMemo(() => {
+  if (filterStatus === "ALL") return registrations;
+  return registrations.filter((reg) => reg.status === filterStatus);
+  }, [registrations, filterStatus]);
 
   const registrationMessage = `🎓 Course Registration - ViBe Platform
 
@@ -573,7 +578,7 @@ useEffect(() => {
                         </div>
                       </TableCell>
                     </TableRow>
-                  ) : registrations?.length === 0 ? (
+                  ) : filteredRegistrations?.length === 0 ? (
                     <TableRow>
                       <TableCell colSpan={6} className="text-center py-16">
                         <div className="w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-br from-muted to-muted/50 flex items-center justify-center">
@@ -588,7 +593,7 @@ useEffect(() => {
                       </TableCell>
                     </TableRow>
                   ) : (
-                    registrations?.map((reg: Registration, index: number) => (
+                    filteredRegistrations?.map((reg: Registration, index: number) => (
                       <TableRow
                         key={reg._id}
                         className="border-border hover:bg-muted/20 transition-colors duration-200 group"

--- a/frontend/src/app/pages/teacher/CourseRegistrationRequests.tsx
+++ b/frontend/src/app/pages/teacher/CourseRegistrationRequests.tsx
@@ -42,6 +42,7 @@ export default function CourseRegistrationRequests() {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [selectedRegistration, setSelectedRegistration] = useState<any>(null);
   const [searchTerm, setSearchTerm] = useState('');
+  const [searchInput, setSearchInput] = useState('');
   const [filterStatus, setFilterStatus] = useState<RegistrationStatus>('ALL');
   const [sortOrder, setSortOrder] = useState<'older' | 'latest'>('latest');
   const [currentPage, setCurrentPage] = useState(1);
@@ -66,6 +67,7 @@ export default function CourseRegistrationRequests() {
     page: currentPage,
     limit: PAGE_LIMIT,
   }), [filterStatus, searchTerm, sortOrder, currentPage]);
+
   const { data: registrationsData, isLoading, refetch: registrationsRefetch } = useGetCourseRegistrationRequests(versionId as string, params);
   const { mutateAsync: updateStatus, isPending: isUpdatingStatus } = useUpdateRegistrationStatus();
   const { mutateAsync: updateBulkStatus, isPending: isUpdatingBulkStatus } = useBulkUpdateRegistrationStatus();
@@ -81,6 +83,14 @@ Hello,
 Register for the course using the link below:
 
 ${registrationUrl}`;
+
+useEffect(() => {
+  const t = setTimeout(() => {
+    setSearchTerm(searchInput);
+  }, 1000);
+
+  return () => clearTimeout(t);
+}, [searchInput]);
 
 
   useEffect(() => {
@@ -487,8 +497,8 @@ ${registrationUrl}`;
           </Select>
         </div> */}
         <RegistrationFilters
-          searchTerm={searchTerm}
-          setSearchTerm={setSearchTerm}
+          searchTerm={searchInput}
+          setSearchTerm={setSearchInput}
           filterStatus={filterStatus}
           setFilterStatus={setFilterStatus}
           sortOrder={sortOrder}

--- a/frontend/src/app/pages/teacher/CourseRegistrationRequests.tsx
+++ b/frontend/src/app/pages/teacher/CourseRegistrationRequests.tsx
@@ -57,29 +57,30 @@ export default function CourseRegistrationRequests() {
   const [isRefresh, setIsRefresh] = useState(false);
   const { currentCourse } = useCourseStore()
   const versionId = currentCourse?.versionId
+  const [initialFetchDone, setInitialFetchDone] = useState(false);
+  const [hasAnyRegistrations, setHasAnyRegistrations] = useState(true);
+  const shouldFetch = !initialFetchDone || hasAnyRegistrations;
 
   const PAGE_LIMIT = 15;
 
   const params = useMemo(() => ({
-    // status: filterStatus,
+    status: filterStatus,
     search: searchTerm,
     sort: sortOrder,
     page: currentPage,
     limit: PAGE_LIMIT,
-  }), [ searchTerm, sortOrder, currentPage]);
+  }), [filterStatus, searchTerm, sortOrder, currentPage]);
 
-  const { data: registrationsData, isLoading, refetch: registrationsRefetch } = useGetCourseRegistrationRequests(versionId as string, params);
+ const { data: registrationsData, isLoading, refetch: registrationsRefetch,} = useGetCourseRegistrationRequests(versionId as string, params, shouldFetch);
+
+
+
   const { mutateAsync: updateStatus, isPending: isUpdatingStatus } = useUpdateRegistrationStatus();
   const { mutateAsync: updateBulkStatus, isPending: isUpdatingBulkStatus } = useBulkUpdateRegistrationStatus();
   const registrations = registrationsData?.registrations || []
 
   const FRONTEND_URL = window.location.origin;
   const registrationUrl = `${FRONTEND_URL}/student/course-registration/${versionId}`;
-
-  const filteredRegistrations = useMemo(() => {
-  if (filterStatus === "ALL") return registrations;
-  return registrations.filter((reg) => reg.status === filterStatus);
-  }, [registrations, filterStatus]);
 
   const registrationMessage = `🎓 Course Registration - ViBe Platform
 
@@ -95,12 +96,17 @@ useEffect(() => {
   }, 1000);
 
   return () => clearTimeout(t);
-}, [searchInput]);
+  }, [searchInput]);
 
+useEffect(() => {
+  if (!isLoading && registrationsData && !initialFetchDone) {
+    setInitialFetchDone(true);
 
-  useEffect(() => {
-    registrationsRefetch();
-  }, [params, registrationsRefetch]);
+    const total = registrationsData.totalDocuments ?? 0;
+    setHasAnyRegistrations(total > 0);
+  }
+  }, [isLoading, registrationsData, initialFetchDone]);
+
 
   const handleSelectRow = (id: string, checked: boolean) => {
     setSelectedIds(prev =>
@@ -578,7 +584,7 @@ useEffect(() => {
                         </div>
                       </TableCell>
                     </TableRow>
-                  ) : filteredRegistrations?.length === 0 ? (
+                  ) : registrations?.length === 0 ? (
                     <TableRow>
                       <TableCell colSpan={6} className="text-center py-16">
                         <div className="w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-br from-muted to-muted/50 flex items-center justify-center">
@@ -593,7 +599,7 @@ useEffect(() => {
                       </TableCell>
                     </TableRow>
                   ) : (
-                    filteredRegistrations?.map((reg: Registration, index: number) => (
+                    registrations?.map((reg: Registration, index: number) => (
                       <TableRow
                         key={reg._id}
                         className="border-border hover:bg-muted/20 transition-colors duration-200 group"

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -3021,37 +3021,39 @@ export interface RegistrationRequestQuery {
 export const useGetCourseRegistrationRequests = (
   versionId: string,
   query: RegistrationRequestQuery = {},
-): {
-  data: { totalDocuments: number, totalPages: number, currentPage: number, registrations: Registration[] };
-  isLoading: boolean;
-  error: string | null;
-  refetch: () => void;
-} => {
+  enabled: boolean = true,
+) => {
   const result = api.useQuery(
-    'get',
-    '/course/registration/requests/version/{versionId}' as any,
+    "get",
+    "/course/registration/requests/version/{versionId}" as any,
     {
       params: {
         path: { versionId },
-        query
-      }
+        query,
+      },
     },
     {
-      enabled: !!versionId,
+      enabled: !!versionId && enabled,
       retry: 1,
-      refetchOnWindowFocus: false
+      refetchOnWindowFocus: false,
     }
   );
 
   return {
-    data: result.data as { totalDocuments: number, totalPages: number, currentPage: number, registrations: Registration[] },
+    data: (result.data as any) ?? {
+      totalDocuments: 0,
+      totalPages: 0,
+      currentPage: 1,
+      registrations: [],
+    },
     isLoading: result.isLoading,
     error: result.error
-      ? result.error.message || 'Failed to fetch course registration requests'
+      ? result.error.message || "Failed to fetch course registration requests"
       : null,
     refetch: result.refetch,
   };
 };
+
 
 
 export const useUpdateRegistrationStatus = (): {


### PR DESCRIPTION
<!-- Description -->
Implemented debounced search in the **CourseRegistrationRequests page** to avoid frequent API calls while typing. The search query is now sent only after the user stops typing for the configured debounce delay.

Also updated the status filter (ALL / PENDING / APPROVED / REJECTED) to work locally on already fetched registrations, preventing unnecessary API refetch calls when switching filters. This improves performance, reduces network usage, and provides a smoother UI experience.

<img width="1896" height="910" alt="image" src="https://github.com/user-attachments/assets/3fe420ec-0540-4abd-a47a-2890f8a5e522" />
