### PR TITLE
Implement sorting in “My Flags” issues list

### DIFF
--- a/backend/src/modules/reports/classes/validators/ReportValidators.ts
+++ b/backend/src/modules/reports/classes/validators/ReportValidators.ts
@@ -333,18 +333,12 @@ export class IssueFilterQuery {
   @Type(() => Number)
   @IsInt()
   @Min(1)
-  @JSONSchema({
-    description:'number of pages to be shown'
-  })
   page: number = 1;
 
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
-  @JSONSchema({
-    description:'limit of entries displayed in single page'
-  })
   limit: number = 10;
 
   @IsOptional()
@@ -356,9 +350,10 @@ export class IssueFilterQuery {
   search: string = '';
 
   @IsOptional()
-  @IsEnum(IssueSortEnum)
-  sort: IssueSortEnum = IssueSortEnum.ALL;
+  @IsString()
+  sort?: string;
 }
+
 
 class IssueReportResponse{
   @JSONSchema({

--- a/backend/src/modules/reports/repositories/providers/mongodb/ReportsRepository.ts
+++ b/backend/src/modules/reports/repositories/providers/mongodb/ReportsRepository.ts
@@ -274,9 +274,14 @@ class ReportRepository {
     }
 
     // sort filter (by entityType)
-    const sortQuery: any = {createdAt: -1}; // default newest first
-    if (filter.sort && filter.sort !== 'ALL') {
-      query.entityType = filter.sort;
+    let sortQuery: any = { createdAt: -1 }; // default
+
+    if (filter.sort) {
+      const [field, order] = filter.sort.split(':');
+
+      sortQuery = {
+        [field]: order === 'asc' ? 1 : -1,
+      };
     }
 
     // const results = await this.reportCollection

--- a/backend/src/modules/reports/services/ReportService.ts
+++ b/backend/src/modules/reports/services/ReportService.ts
@@ -94,7 +94,7 @@ export class ReportService extends BaseService {
   limit: number,
   status: IssueStatusEnum,
   search: string,
-  sort: IssueSortEnum,
+  sort: any,
 ) {
   return this._withTransaction(async session => {
     const skip = (page - 1) * limit;

--- a/frontend/src/app/pages/student/FlagResponse.tsx
+++ b/frontend/src/app/pages/student/FlagResponse.tsx
@@ -562,7 +562,7 @@
 
 
 
-
+import { ArrowUp, ArrowDown, Search as SearchIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
   Card,
@@ -642,21 +642,21 @@ export default function CourseIssueReports() {
   const [currentPage, setCurrentPage] = useState(1);
   const { currentCourse } = useCourseStore()
   const versionId = currentCourse?.versionId
-
+  const [sortBy, setSortBy] = useState<'reason' | 'createdAt'>('createdAt');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const PAGE_LIMIT = 15;
 
   const params = useMemo(() => ({
     status: filterStatus,
     search: debouncedSearchTerm,
-    sort: issueSort,
+    sort: `${sortBy}:${sortOrder}`,
     page: currentPage,
     limit: PAGE_LIMIT,
-  }), [filterStatus, debouncedSearchTerm, issueSort, currentPage]);
+  }), [filterStatus, debouncedSearchTerm, sortBy, sortOrder, currentPage]);
+
   const { data: issuesData, isLoading, refetch: issuesRefetch } = useGetCourseIssueReports(versionId as string, params);
   const issues = issuesData?.issues || []
-  useEffect(() => {
-    issuesRefetch();
-  }, [params, issuesRefetch]);
+
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -667,11 +667,22 @@ export default function CourseIssueReports() {
 
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchTerm]);
+  }, [filterStatus]);
 
   const handlePageChange = (newPage: number) => {
     setCurrentPage(newPage);
   };
+
+  const handleSort = (column: 'reason' | 'createdAt') => {
+    if (sortBy === column) {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortBy(column);
+      setSortOrder('asc');
+    }
+    setCurrentPage(1);
+  };
+
 
   return (
     <div className="min-h-screen bg-background">
@@ -711,11 +722,16 @@ export default function CourseIssueReports() {
                       </span>
                     </TableHead>
 
-                    <TableHead className="font-bold text-foreground">
-                      <span className="inline-flex items-center gap-2">
-                        <AlertCircle className="h-4 w-4 text-muted-foreground" />
+                    <TableHead
+                      className="cursor-pointer hover:text-primary transition-colors"
+                      onClick={() => handleSort('reason')}
+                    >
+                      <div className="flex items-center gap-2">
                         Reason
-                      </span>
+                        {sortBy === 'reason' && (
+                          sortOrder === 'asc' ? <ArrowUp size={14} /> : <ArrowDown size={14} />
+                        )}
+                      </div>
                     </TableHead>
 
                     <TableHead className="font-bold text-foreground">
@@ -739,11 +755,16 @@ export default function CourseIssueReports() {
                       </span>
                     </TableHead>
 
-                    <TableHead className="font-bold text-foreground w-[200px]">
-                      <span className="inline-flex items-center gap-2">
-                        <Calendar className="h-4 w-4 text-muted-foreground" />
+                    <TableHead
+                      className="cursor-pointer hover:text-primary transition-colors"
+                      onClick={() => handleSort('createdAt')}
+                    >
+                      <div className="flex items-center gap-2">
                         Reported On
-                      </span>
+                        {sortBy === 'createdAt' && (
+                          sortOrder === 'asc' ? <ArrowUp size={14} /> : <ArrowDown size={14} />
+                        )}
+                      </div>
                     </TableHead>
 
                     <TableHead className="font-bold text-foreground pr-6 w-[150px]">

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -3333,6 +3333,14 @@ export type IssueSort = "ALL" | "VIDEO" | "QUIZ" | "ARTICLE" | "QUESTION";
 
 export type EntityType = "VIDEO" | "QUIZ" | "ARTICLE" | "QUESTION";
 
+export interface IssueQueryParams {
+  page?: number;
+  limit?: number;
+  status?: string;
+  search?: string;
+  sort?: string; // Add this line
+}
+
 export interface IssueStatusHistory {
   status: IssueStatus;
   comment: string;


### PR DESCRIPTION
This PR adds sorting functionality to the My Flags / My Issues page to improve usability and data clarity.

Users can now sort issues based on the Reason column and Reported on column, making it easier to view raised issues efficiently.
<img width="1880" height="588" alt="image" src="https://github.com/user-attachments/assets/e93957ff-930a-4357-b6e1-518568c38b4a" />
