### PR TITLE
chore: ensure media devices are stopped when leaving pages

### DIFF
--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -51,6 +51,7 @@ import { EntityType } from "@/types/flag.types";
 import { toast } from "sonner";
 import ItemContainer from "@/components/Item-container";
 import logo from "../../../../public/img/vibe_logo_img.ico"
+import {registerStream, unRegisterStream} from "@/lib/MediaRegistry";
 
 // Helper function to get icon for item type
 const getItemIcon = (type: string) => {
@@ -79,7 +80,12 @@ const sortItemsByOrder = (items: any[]) => {
   });
 };
 export default function CoursePage() {
-
+  useEffect(() => {
+    return () => {
+      unRegisterStream("course-page-stream");
+      unRegisterStream("course-page-retrystream");
+    };
+  }, []);
   const [attemptId, setAttemptId] = useState<string | null>(null);
   // Dialog state for proctoring declaration
   const [showProctorDialog, setShowProctorDialog] = useState(true);
@@ -104,11 +110,15 @@ export default function CoursePage() {
       try {
         // Try to get both camera and microphone access
         const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+        unRegisterStream("course-page-stream");
+        registerStream("course-page-stream", stream);
         streamRef.current = stream;
       } catch (err) {
         alert("Please allow camera and microphone access to continue. You will be redirected to the dashboard if access is denied.");
         try {
           const retryStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+          unRegisterStream("course-page-retrystream");
+          registerStream("course-page-retrystream", retryStream);
           streamRef.current = retryStream;
         } catch (err) {
           router.navigate({ to: '/student' });
@@ -123,9 +133,6 @@ export default function CoursePage() {
       if (streamRef.current) {
         streamRef.current.getTracks().forEach(track => track.stop());
         streamRef.current = null;
-        setTimeout(() => {
-          window.location.reload();
-        }, 1500)
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1264,9 +1271,6 @@ export default function CoursePage() {
         if (!open) {
           setShowProctorDialog(false);
           router.navigate({ to: '/student' });
-          setTimeout(() => {
-            window.location.reload()
-          }, 1000)
         }
       }}>
         <DialogContent className="sm:max-w-lg w-[calc(100%-2rem)] max-w-full">

--- a/frontend/src/app/pages/student/courses.tsx
+++ b/frontend/src/app/pages/student/courses.tsx
@@ -10,8 +10,12 @@ import { CourseCard } from "@/components/course/CourseCard";
 import { Pagination } from "@/components/ui/Pagination";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Input } from "@/components/ui/input";
+import { stopAllStreams} from "@/lib/MediaRegistry";
 
 export default function StudentCourses() {
+  useEffect(() => {
+    setTimeout(stopAllStreams, 1000);
+  }, []);
   const [activeTab, setActiveTab] = useState("enrolled");
   const [currentPage, setCurrentPage] = useState(1);
   const [searchQuery, setSearchQuery] = useState("")

--- a/frontend/src/app/pages/student/dashboard.tsx
+++ b/frontend/src/app/pages/student/dashboard.tsx
@@ -10,8 +10,12 @@ import { DashboardSidebar } from "@/components/dashboard/DashboardSidebar";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { getGreeting } from "@/utils/helpers";
 import type { CoursePctCompletion } from '@/types/course.types';
+import { stopAllStreams} from "@/lib/MediaRegistry";
 
 export default function Page() {
+  useEffect(() => {
+    setTimeout(stopAllStreams, 1000);
+  }, []);
   const { isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
 

--- a/frontend/src/components/ai/CameraProcessor.ts
+++ b/frontend/src/components/ai/CameraProcessor.ts
@@ -1,4 +1,5 @@
 import { MLProcessor } from "@/types/ai.types";
+import {registerStream, unRegisterStream} from "@/lib/MediaRegistry";
 
 class CameraProcessor {
   private videoElement: HTMLVideoElement | null = null;
@@ -17,6 +18,8 @@ class CameraProcessor {
 
     this.videoElement = videoElement;
     const stream = await navigator.mediaDevices.getUserMedia({ video: { frameRate: { max: 30 } } });
+    unRegisterStream("CameraProcessor-stream");
+    registerStream("CameraProcessor-stream", stream);
     this.videoElement.srcObject = stream;
 
     await new Promise((resolve) => (this.videoElement!.onloadedmetadata = () => resolve(null)));

--- a/frontend/src/components/ai/SpeechDetector.tsx
+++ b/frontend/src/components/ai/SpeechDetector.tsx
@@ -2,8 +2,14 @@ import React, { useEffect, useRef, useState } from "react";
 import { AudioClassifier, FilesetResolver } from "@mediapipe/tasks-audio";
 
 import type { SpeechDetectorProps } from "@/types/ai.types";
+import {registerStream, unRegisterStream } from "@/lib/MediaRegistry";
 
 const SpeechDetector: React.FC<SpeechDetectorProps> = ({ setIsSpeaking }) => {
+  useEffect(() => {
+    return () => {
+       unRegisterStream("SpeechDetector-audio-stream");
+    };
+  }, []);
   const [modelReady, setModelReady] = useState(false);
   const classifierRef = useRef<AudioClassifier | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
@@ -43,7 +49,8 @@ const SpeechDetector: React.FC<SpeechDetectorProps> = ({ setIsSpeaking }) => {
   const startMicrophone = async () => {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-
+      unRegisterStream("SpeechDetector-audio-stream");
+      registerStream("SpeechDetector-audio-stream", stream);
       audioCtxRef.current = new AudioContext({ sampleRate: 16000 });
       sourceRef.current = audioCtxRef.current.createMediaStreamSource(stream);
       scriptNodeRef.current = audioCtxRef.current.createScriptProcessor(4096, 1, 1); // Reduced buffer size

--- a/frontend/src/components/ai/WhisperManager.tsx
+++ b/frontend/src/components/ai/WhisperManager.tsx
@@ -7,6 +7,7 @@ import { webmFixDuration, formatAudioTimestamp } from "@/utils/AudioUtils";
 import { ArrowRight, Loader2, RefreshCw, PlayCircle, Upload } from "lucide-react";
 import { Button } from "../ui/button";
 import { toast } from "sonner";
+import { registerStream, unRegisterStream} from "@/lib/MediaRegistry";  
 
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -121,6 +122,11 @@ function getMimeType() {
 function AudioRecorder(props: {
     onRecordingComplete: (blob: Blob) => void;
 }) {
+      useEffect(() => {
+        return () => {
+            unRegisterStream("AudioRecorder-audio-stream");
+        };
+      }, []);
     const [recording, setRecording] = useState(false);
     const [duration, setDuration] = useState(0);
     const [recordedBlob, setRecordedBlob] = useState<Blob | null>(null);
@@ -143,6 +149,8 @@ function AudioRecorder(props: {
                 streamRef.current = await navigator.mediaDevices.getUserMedia({
                     audio: true,
                 });
+                unRegisterStream("AudioRecorder-audio-stream");
+                registerStream("AudioRecorder-audio-stream", streamRef.current);
             }
 
             const mimeType = getMimeType();

--- a/frontend/src/components/ai/useCameraProcessor.ts
+++ b/frontend/src/components/ai/useCameraProcessor.ts
@@ -3,8 +3,14 @@ import CameraProcessor from "./CameraProcessor";
 import * as faceDetection from "@tensorflow-models/face-detection";
 
 import type { MLProcessor } from "@/types/ai.types";
+import { unRegisterStream } from "@/lib/MediaRegistry";
 
 const useCameraProcessor = (frameRate = 3) => {
+  useEffect(() => {
+    return () => {
+      unRegisterStream("CameraProcessor-stream");
+    };
+  }, []);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [imageSrcs, setImageSrcs] = useState<string[]>([]);

--- a/frontend/src/components/floating-video.tsx
+++ b/frontend/src/components/floating-video.tsx
@@ -14,6 +14,7 @@ import { useAuthStore } from '@/store/auth-store';
 import { useCourseStore } from '@/store/course-store';
 import type { FloatingVideoProps } from '@/types/video.types';
 import { useReportAnomalyAudio, useReportAnomalyImage } from '@/hooks/hooks';
+import {registerStream, unRegisterStream} from "@/lib/MediaRegistry";
 
 // let flag = 0;
 function FloatingVideo({
@@ -29,6 +30,12 @@ function FloatingVideo({
   setReadyToDetect,
   anomalies = []
 }: FloatingVideoProps): JSX.Element | null {
+  useEffect(() => {
+    return () => {
+       unRegisterStream("floating-video-restart-stream")
+       unRegisterStream("floating-video-audio-stream")
+    };
+  }, []);
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -331,6 +338,8 @@ const lastCalledRef = useRef<number>(0);
     if (isSpeaking === "Yes" && isVoiceDetectionEnabled && !mediaRecorder) {
       // Start recording
       navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+        unRegisterStream("floating-video-audio-stream")
+        registerStream("floating-video-audio-stream", stream);
         const recorder = new window.MediaRecorder(stream);
         setAudioChunks([]);
         setAudioStream(stream);
@@ -417,6 +426,8 @@ const lastCalledRef = useRef<number>(0);
           height: { ideal: 480 }
         }
       });
+      unRegisterStream("floating-video-restart-stream")
+      registerStream("floating-video-restart-stream", stream);
 
       video.srcObject = stream;
       setCurrentStream(stream);

--- a/frontend/src/lib/MediaRegistry.ts
+++ b/frontend/src/lib/MediaRegistry.ts
@@ -1,0 +1,18 @@
+const mediaRegister = new Map<string, MediaStream>();
+
+export function registerStream(id: string, stream: MediaStream) {
+  mediaRegister.set(id, stream);
+}
+
+export function unRegisterStream(id: string) {
+  mediaRegister.get(id)?.getTracks().forEach(t => t.stop());
+  mediaRegister.delete(id);
+}
+
+export function stopAllStreams() {
+  for(const id of mediaRegister.keys()) {
+    mediaRegister.get(id)?.getTracks().forEach(t => t.stop());
+    mediaRegister.delete(id);
+  }
+  mediaRegister.clear();
+}


### PR DESCRIPTION
Removed the existing window reload logic used to release media access and used a registry to register all access streams and unregister when pages unmount.
