### PR TITLE
Fix report sorting at instructor side and improve sorting state handling

### DIFF
--- a/backend/src/modules/reports/classes/validators/ReportValidators.ts
+++ b/backend/src/modules/reports/classes/validators/ReportValidators.ts
@@ -10,6 +10,7 @@ import {
   IsArray,
   IsIn,
 } from 'class-validator';
+import {ReportSortColumn} from '../../types.js';
 import {Type} from 'class-transformer';
 import {JSONSchema} from 'class-validator-jsonschema';
 import {ID} from '#root/shared/interfaces/models.js';
@@ -188,6 +189,13 @@ export class ReportFiltersQuery {
   @IsInt()
   @Min(0)
   currentPage?: number = 1;
+
+  @IsOptional()
+  sortBy?: ReportSortColumn;
+
+  @IsOptional()
+  @IsEnum(['asc', 'desc'])
+  sortOrder?: 'asc' | 'desc' = 'desc';
 }
 
 class ReportDataResponse {

--- a/backend/src/modules/reports/constants.ts
+++ b/backend/src/modules/reports/constants.ts
@@ -18,3 +18,11 @@ export const ENTITY_TYPE_VALUES = Object.values(EntityTypeEnum);
 export enum ReportPermissionSubject  {
   REPORT = 'Report'
 }
+
+export const SORT_FIELD_MAP: Record<string, string> = {
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt',
+  entityType: 'entityType',
+  reason: 'reason',
+  latestStatus: 'latestStatus',
+};

--- a/backend/src/modules/reports/repositories/providers/mongodb/ReportsRepository.ts
+++ b/backend/src/modules/reports/repositories/providers/mongodb/ReportsRepository.ts
@@ -15,7 +15,8 @@ import {
   ReportFiltersQuery,
   ReportResponse,
 } from '#root/modules/reports/classes/index.js';
-import {instanceToPlain, plainToInstance} from 'class-transformer';
+import { instanceToPlain, plainToInstance } from 'class-transformer';
+import { SORT_FIELD_MAP } from '#root/modules/reports/constants.js';
 @injectable()
 class ReportRepository {
   private reportCollection: Collection<IReport>;
@@ -64,11 +65,23 @@ class ReportRepository {
       },
     ];
 
+    const sortStage: any = {};
+
+    const sortField =
+      filters.sortBy && SORT_FIELD_MAP[filters.sortBy]
+        ? SORT_FIELD_MAP[filters.sortBy]
+        : 'createdAt';
+
+    sortStage[sortField] = filters.sortOrder === 'asc' ? 1 : -1;
+
+    
+
+
     const aggregationPipeline = [
       matchStage,
       ...sortStatusStages,
       ...(status ? [{$match: {latestStatus: status}}] : []),
-      {$sort: {createdAt: -1}},
+      { $sort: sortStage }, 
       {$skip: skip},
       {$limit: limit},
       {

--- a/backend/src/modules/reports/types.ts
+++ b/backend/src/modules/reports/types.ts
@@ -6,4 +6,12 @@ const TYPES = {
   ReportRepo: Symbol.for('ReportRepo'),
 };
 
+export type ReportSortColumn =
+  | 'reason'
+  | 'entityType'
+  | 'latestStatus'
+  | 'reportedBy.firstName'
+  | 'createdAt';
+
+  
 export {TYPES as REPORT_TYPES};

--- a/frontend/src/app/pages/teacher/FlaggedList.tsx
+++ b/frontend/src/app/pages/teacher/FlaggedList.tsx
@@ -47,14 +47,19 @@ export default function FlaggedList() {
   const { currentCourseFlag } = useFlagStore()
   const courseId = currentCourseFlag?.courseId
   const versionId = currentCourseFlag?.versionId
+  // Sorting state
+  type SortField = (typeof SORT_MAP)[keyof typeof SORT_MAP]
 
+  const [sortBy, setSortBy] = useState<SortField>('createdAt')
+
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
   if (!currentCourseFlag || !courseId || !versionId) {
     navigate({ to: '/teacher' });
     return null
   }
   const [currentPage, setCurrentPage] = useState(1)
   // Fetch reports based on course id and version id
-  const { data: flagsData, isLoading: reportLoading, error: reportError } = useGetReports(courseId || "", versionId || "", pageLimit, currentPage, selectedStatus, selectedEntityType)
+  const { data: flagsData, isLoading: reportLoading, error: reportError } = useGetReports(courseId || "", versionId || "", pageLimit, currentPage, selectedStatus, selectedEntityType, sortBy, sortOrder);
 
   const { data: course, isLoading: courseLoading, error: courseError } = useCourseById(courseId || "")
   const { data: version, isLoading: versionLoading, error: versionError } = useCourseVersionById(versionId || "")
@@ -88,9 +93,6 @@ export default function FlaggedList() {
   const totalDocuments = flagsData?.totalDocuments || 0
   const totalPages = flagsData?.totalPages || 1
 
-  // Sorting state
-  const [sortBy, setSortBy] = useState<'name' | 'enrollmentDate' | 'progress'>('name')
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
 
 
 
@@ -122,15 +124,30 @@ export default function FlaggedList() {
     }
   }
 
-  // Sorting handler
-  const handleSort = (column: 'name' | 'enrollmentDate' | 'progress') => {
-    if (sortBy === column) {
-      setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'))
+  const SORT_MAP = {
+    reason: 'reason',
+    entityType: 'entityType',
+    status: 'latestStatus',
+    reportedBy: 'reportedBy.firstName',
+    createdDate: 'createdAt',
+  } as const
+
+  type SortKey = keyof typeof SORT_MAP
+
+  const handleSort = (columnKey: SortKey) => {
+    const backendField = SORT_MAP[columnKey]
+
+    setCurrentPage(1)
+
+    if (sortBy === backendField) {
+      setSortOrder(prev => (prev === 'asc' ? 'desc' : 'asc'))
     } else {
-      setSortBy(column)
+      setSortBy(backendField)
       setSortOrder('asc')
     }
   }
+
+
 
   const handlePageChange = (newPage: number) => {
     if (newPage >= 1 && newPage <= totalPages) {
@@ -279,15 +296,16 @@ export default function FlaggedList() {
                         <TableHead
                           key={key}
                           className={`font-bold text-foreground cursor-pointer select-none text-center align-middle ${className}`}
-                          onClick={() => handleSort(key as 'name' | 'enrollmentDate' | 'progress')}
+                          onClick={() => handleSort(key as SortKey)}
                         >
                           <span className="flex items-center gap-1">
                             {label}
-                            {sortBy === key && (
+                            {sortBy === SORT_MAP[key as SortKey] && (
                               sortOrder === 'asc'
-                                ? <ArrowUp size={16} className="text-foreground" />
-                                : <ArrowDown size={16} className="text-foreground" />
+                                ? <ArrowUp size={16} />
+                                : <ArrowDown size={16} />
                             )}
+
                           </span>
                         </TableHead>
                       ))}
@@ -366,7 +384,7 @@ export default function FlaggedList() {
                         </TableCell>
                         <TableCell className="py-6">
                           <div className="text-muted-foreground font-medium ">
-                            {new Date(report.updatedAt).toLocaleDateString("en-US", {
+                            {new Date(report.createdAt).toLocaleDateString("en-US", {
                               month: "short",
                               day: "numeric",
                               year: "numeric",

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -2766,7 +2766,8 @@ export function useSubmitFlag(): {
   };
 }
 
-export function useGetReports(courseId: string, versionId: string, limit = 10, currentPage = 1, status?: string, entityType?: string,): {
+export function useGetReports(courseId: string, versionId: string, limit = 10, currentPage = 1, status?: string, entityType?: string, sortBy?: string,
+  sortOrder?: 'asc' | 'desc'): {
   data: IReport[],
   isLoading: boolean,
   error: string | null,
@@ -2787,6 +2788,8 @@ export function useGetReports(courseId: string, versionId: string, limit = 10, c
           ...(status && status !== "ALL" ? { status } : {}),
           limit,
           currentPage,
+          sortBy,
+          sortOrder
         }
       },
     },

--- a/frontend/src/types/report.types.ts
+++ b/frontend/src/types/report.types.ts
@@ -1,0 +1,6 @@
+export type ReportSortColumn =
+    | 'reason'
+    | 'entityType'
+    | 'latestStatus'
+    | 'reportedBy.firstName'
+    | 'createdDate';


### PR DESCRIPTION
## Description

This PR fixes issues in the **Course Flags listing page** related to table sorting and improves overall sorting stability.

### What was fixed

* Corrected `sortBy` state to use **backend-supported sort fields** instead of UI-only keys.
* Fixed sorting logic so clicking a column:

  * Toggles sort order when the same column is clicked
  * Resets to ascending order when a new column is selected
* Updated sort icon rendering to correctly reflect the active sorted column.
* Ensured sorting parameters are consistently passed to the reports API.

### Why this change

* Backend sorting fields were mismatched with frontend state, leading to incorrect API queries.