### PR TITLE
chore:improve quiz result page

### DIFF
--- a/frontend/src/components/quiz.tsx
+++ b/frontend/src/components/quiz.tsx
@@ -9,7 +9,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
-import { Clock, Trophy, ChevronLeft, ChevronRight, RotateCcw, GripVertical, PlayCircle, BookOpen, Target, Timer, Users, AlertCircle, Eye, FileQuestion } from "lucide-react";
+import { Clock, Trophy, ChevronLeft, ChevronRight, RotateCcw, GripVertical, PlayCircle, BookOpen, Target, Timer, Users, AlertCircle, Eye, FileQuestion, ChevronDown } from "lucide-react";
 import { useAttemptQuiz, useSubmitQuiz, useSaveQuiz, useStartItem, useStopItem, CreateAttemptResponse, SaveQuizResponse } from '@/hooks/hooks';
 import { useCourseStore } from "@/store/course-store";
 import MathRenderer from "./math-renderer";
@@ -75,6 +75,7 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
   }>({ open: false, text: "" });
   const [showExplanation, setShowExplanation] = useState(false)
   const [failedRedirectCountdown, setFailedRedirectCountdown] = useState<number | null>(null);
+  const [openQuestionId, setOpenQuestionId] = useState<string | null>(null);
 
   // ===== REFS AND CONSTANTS =====
   const itemStartedRef = useRef(false);
@@ -1241,19 +1242,19 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
               {submissionResults?.gradingStatus && (
                 <Badge
                   variant={
-                    submissionResults.gradingStatus === 'PASSED' ? 'default' :
+                    submissionResults.gradingStatus === 'PASSED' ? 'success' :
                       submissionResults.gradingStatus === 'FAILED' ? 'destructive' :
                         'secondary'
                   }
-                  className="text-lg px-4 py-2"
+                  className="text-lg px-4 py-2 mx-2"
                 >
                   {submissionResults.gradingStatus === 'PASSED' && '🎉 Passed!'}
-                  {submissionResults.gradingStatus === 'FAILED' && 'Failed - Try Again'}
+                  {submissionResults.gradingStatus === 'FAILED' && 'Attempt Unsuccessful'}
                   {submissionResults.gradingStatus === 'PENDING' && '⏳ Pending Review'}
                 </Badge>
               )}
               {(submissionResults?.totalScore === submissionResults?.totalMaxScore) && (
-                <Badge variant="default" className="text-lg px-4 py-2 bg-gradient-to-r from-primary to-chart-2 text-primary-foreground">
+                <Badge variant="success" className="text-lg px-4 py-2 from-primary to-chart-2 mx-2">
                   Perfect Score! 🎉
                 </Badge>
               )}
@@ -1349,7 +1350,13 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
                           : 'border-gray-200'
                     }
                   >
-                    <CardContent className="p-4">
+                    <CardContent className="px-4 py-2">
+                      <div
+                        className="flex items-center justify-between cursor-pointer select-none"
+                        onClick={() =>
+                          setOpenQuestionId(openQuestionId === question.id ? null : question.id)
+                        }
+                      >
                       <div className="flex items-center justify-between">
                         <div className="flex items-center space-x-3">
                           <Badge variant="outline">
@@ -1367,6 +1374,8 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
                             </Badge>
                           )}
                         </div>
+                      </div>
+                      <div className='flex justify-center items-center'>
                         <Badge variant={
                           questionFeedback
                             ? questionFeedback.status === 'CORRECT' ? 'default' : 'destructive'
@@ -1377,8 +1386,12 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
                             : hasAnswer ? `+${question.points}` : '0'
                           }
                         </Badge>
+                          <ChevronDown className={`w-5 h-5 ml-5 transition-transform ${
+                              openQuestionId === question.id ? 'rotate-180' : ''}`}/>
                       </div>
-                      <p className="text-sm text-muted-foreground mt-2">
+                    </div>
+                    {openQuestionId === question.id && (<>
+                      <p className="text-sm text-muted-foreground my-3 ml-2">
                         <MathRenderer>
                           {preprocessMathContent(question.question)}
                         </MathRenderer>
@@ -1393,13 +1406,13 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
                         </div>
                       )}
                       {/* Show correct answers if enabled and available */}
-                      {showCorrectAnswersAfterSubmission && questionFeedback && (
+                      {/* {showCorrectAnswersAfterSubmission && questionFeedback && (
                         <div className="mt-3 p-2 bg-green-50 dark:bg-green-950/20 rounded">
                           <p className="text-sm font-medium text-green-700 dark:text-green-300">
                             Status: {questionFeedback.status}
                           </p>
                         </div>
-                      )}
+                      )} */}
                       {/* Show explanation if enabled and available */}
                       {showExplanationAfterSubmission && questionFeedback?.answerFeedback && (
                         <div className="mt-3 p-2 bg-amber-50 dark:bg-amber-950/20 rounded">
@@ -1408,6 +1421,7 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
                           </p>
                         </div>
                       )}
+                    </>)}
                     </CardContent>
                   </Card>
                 );


### PR DESCRIPTION
-Improved spacing and color on result page.
-Commented out "Show correct answers if enabled and available" as it was showing status instead of answer.
-Added accordion for question details section. 
-On failure changed text from "Failed - Try " to "Attempt Unsuccessful"

# Before:
<img width="683" height="308" alt="quiz-failed-before" src="https://github.com/user-attachments/assets/a6395725-5534-41ab-9db5-e24d06bfd83f" />
<img width="683" height="308" alt="quiz-passed-before" src="https://github.com/user-attachments/assets/209aee7d-d3ba-476f-ac8f-4297bbc7ac54" />

# After:
<img width="683" height="308" alt="after-dark-failed" src="https://github.com/user-attachments/assets/baabd926-f9c4-4aa6-bd22-d9f59ee2245b" />
<img width="683" height="308" alt="after-dark-passed-opened" src="https://github.com/user-attachments/assets/887a0cca-078f-422a-b8dd-93a70f8ba436" />




