### PR TITLE
fix:reset progress issue on student side

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -1118,6 +1118,7 @@ export class EnrollmentRepository {
       courseId: e.courseId,
       courseVersionId: e.courseVersionId,
       isHidden: {$ne: true},
+      isDeleted: {$ne: true},
     }));
 
     const results = await this.watchTimeCollection


### PR DESCRIPTION
When a student screen gets loaded/reloaded, the getEnrollments method in enrollmentservice has a logic that reset the enrollment repository if there is  a mismatch in watched item percentage and already stored percentage value(field: percentCompleted) in enrollment repo item, here when the completed count is fetched from getWatchedItemCountsBatch in enrollmentrepository it fetches the item counts including those where isDeleted is true (which should not be fetched to calculate the current percentage completed).
I have added isDeleted:{$ne:true} in getWatchedItemCountsBatch to fetch only undeleted item counts only.
