### PR TITLE
removed "explaination" from response in "/attempt"

### DIFF
--- a/backend/src/modules/quizzes/repositories/providers/mongodb/QuestionRepository.ts
+++ b/backend/src/modules/quizzes/repositories/providers/mongodb/QuestionRepository.ts
@@ -19,9 +19,8 @@ class QuestionRepository {
   ) {}
 
   private async init() {
-    this.questionCollection = await this.db.getCollection<BaseQuestion>(
-      'questions',
-    );
+    this.questionCollection =
+      await this.db.getCollection<BaseQuestion>('questions');
     this.flaggedQuestionCollection =
       await this.db.getCollection<FlaggedQuestion>('flagged_questions');
   }
@@ -47,6 +46,29 @@ class QuestionRepository {
     );
     return result;
   }
+
+  public async getByIdWithoutExplanation(
+    questionId: string,
+    session?: ClientSession,
+  ): Promise<BaseQuestion | null> {
+    await this.init();
+
+    const result = await this.questionCollection.findOne(
+      {_id: new ObjectId(questionId)},
+      {
+        projection: {
+          'correctLotItem.explaination': 0,
+          'incorrectLotItems.explaination': 0,
+          'correctLotItems.explaination': 0,
+          'ordering.lotItem.explaination': 0,
+        },
+        session,
+      },
+    );
+
+    return result;
+  }
+
   public async getByIds(
     questionIds: string[],
     session?: ClientSession,

--- a/backend/src/modules/quizzes/services/AttemptService.ts
+++ b/backend/src/modules/quizzes/services/AttemptService.ts
@@ -14,14 +14,14 @@ import {
   QuestionAnswerFeedback,
   Submission,
 } from '#quizzes/classes/transformers/Submission.js';
-import { IQuestionRenderView } from '#quizzes/question-processing/index.js';
-import { QuestionProcessor } from '#quizzes/question-processing/QuestionProcessor.js';
+import {IQuestionRenderView} from '#quizzes/question-processing/index.js';
+import {QuestionProcessor} from '#quizzes/question-processing/QuestionProcessor.js';
 
 import {
   generateRandomParameterMap,
   getSelectedItemTexts,
 } from '#quizzes/utils/index.js';
-import { GLOBAL_TYPES } from '#root/types.js';
+import {GLOBAL_TYPES} from '#root/types.js';
 import {
   BaseService,
   IItemRepository,
@@ -30,35 +30,35 @@ import {
   MongoDatabase,
   ILotItem,
 } from '#shared/index.js';
-import { injectable, inject } from 'inversify';
-import { ClientSession, ObjectId } from 'mongodb';
-import { NotFoundError, BadRequestError } from 'routing-controllers';
-import { QuestionBankService } from './QuestionBankService.js';
-import { QuestionService } from './QuestionService.js';
-import { QUIZZES_TYPES } from '../types.js';
-import { instanceToPlain } from 'class-transformer';
-import { QuizRepository } from '../repositories/providers/mongodb/QuizRepository.js';
-import { AttemptRepository } from '../repositories/providers/mongodb/AttemptRepository.js';
-import { SubmissionRepository } from '../repositories/providers/mongodb/SubmissionRepository.js';
-import { UserQuizMetricsRepository } from '../repositories/providers/mongodb/UserQuizMetricsRepository.js';
+import {injectable, inject} from 'inversify';
+import {ClientSession, ObjectId} from 'mongodb';
+import {NotFoundError, BadRequestError} from 'routing-controllers';
+import {QuestionBankService} from './QuestionBankService.js';
+import {QuestionService} from './QuestionService.js';
+import {QUIZZES_TYPES} from '../types.js';
+import {instanceToPlain} from 'class-transformer';
+import {QuizRepository} from '../repositories/providers/mongodb/QuizRepository.js';
+import {AttemptRepository} from '../repositories/providers/mongodb/AttemptRepository.js';
+import {SubmissionRepository} from '../repositories/providers/mongodb/SubmissionRepository.js';
+import {UserQuizMetricsRepository} from '../repositories/providers/mongodb/UserQuizMetricsRepository.js';
 import {
   BaseQuestion,
   NATQuestion,
   SMLQuestion,
   SOLQuestion,
 } from '../classes/transformers/Question.js';
-import { UserQuizMetrics } from '../classes/transformers/UserQuizMetrics.js';
-import { Attempt } from '../classes/transformers/Attempt.js';
+import {UserQuizMetrics} from '../classes/transformers/UserQuizMetrics.js';
+import {Attempt} from '../classes/transformers/Attempt.js';
 import {
   FeedbackSubmissionItem,
   QuizItem,
 } from '#root/modules/courses/classes/transformers/Item.js';
-import { QuestionRepository } from '../repositories/index.js';
-import { FeedbackRepository } from '../repositories/providers/mongodb/FeedbackRepository.js';
-import { COURSES_TYPES } from '#root/modules/courses/types.js';
-import { USERS_TYPES } from '#root/modules/users/types.js';
-import { ProgressRepository } from '#root/shared/database/providers/mongo/repositories/ProgressRepository.js';
-import { ICourseRepository } from '#root/shared/database/interfaces/ICourseRepository.js';
+import {QuestionRepository} from '../repositories/index.js';
+import {FeedbackRepository} from '../repositories/providers/mongodb/FeedbackRepository.js';
+import {COURSES_TYPES} from '#root/modules/courses/types.js';
+import {USERS_TYPES} from '#root/modules/users/types.js';
+import {ProgressRepository} from '#root/shared/database/providers/mongo/repositories/ProgressRepository.js';
+import {ICourseRepository} from '#root/shared/database/interfaces/ICourseRepository.js';
 @injectable()
 class AttemptService extends BaseService {
   constructor(
@@ -109,9 +109,8 @@ class AttemptService extends BaseService {
     const selectedQuestionIds: string[] = [];
 
     for (const questionBankRef of questionsBankRefs) {
-      const questionIdsForBank = await this.questionBankService.getQuestions(
-        questionBankRef,
-      );
+      const questionIdsForBank =
+        await this.questionBankService.getQuestions(questionBankRef);
       selectedQuestionIds.push(...questionIdsForBank);
     }
 
@@ -120,7 +119,7 @@ class AttemptService extends BaseService {
 
     // Loop through selectedQuestionIds and fetch each question
     for (const questionId of selectedQuestionIds) {
-      const question = (await this.questionService.getById(
+      const question = (await this.questionService.getByIdWithoutExplanation(
         questionId,
         true,
       )) as BaseQuestion;
@@ -135,7 +134,7 @@ class AttemptService extends BaseService {
         new QuestionProcessor(question).render(questionDetail.parameterMap),
       );
     }
-    return { questionDetails, questionRenderViews };
+    return {questionDetails, questionRenderViews};
   }
 
   private _buildGradingResult(
@@ -239,7 +238,9 @@ class AttemptService extends BaseService {
       return false;
     }
 
-    return watchTimes.some(wt => wt.endTime !== null && wt.endTime !== undefined);
+    return watchTimes.some(
+      wt => wt.endTime !== null && wt.endTime !== undefined,
+    );
   }
 
   /**
@@ -254,7 +255,11 @@ class AttemptService extends BaseService {
     gradingStatus: 'PASSED' | 'FAILED',
     session?: ClientSession,
   ): Promise<void> {
-    const alreadyCompleted = await this._isQuizAlreadyCompleted(userId, quizId, session);
+    const alreadyCompleted = await this._isQuizAlreadyCompleted(
+      userId,
+      quizId,
+      session,
+    );
 
     if (alreadyCompleted) {
       return;
@@ -264,7 +269,7 @@ class AttemptService extends BaseService {
   async attempt(
     userId: string | ObjectId,
     quizId: string,
-  ): Promise<{ attemptId: string; questionRenderViews: IQuestionRenderView[] }> {
+  ): Promise<{attemptId: string; questionRenderViews: IQuestionRenderView[]}> {
     return this._withTransaction(async session => {
       //1. Check if UserQuizMetrics exists for the user and quiz
       let metrics = await this.userQuizMetricsRepository.get(
@@ -320,8 +325,10 @@ class AttemptService extends BaseService {
       }
 
       //4. Fetch questions for the quiz attempt
-      const { questionDetails, questionRenderViews } =
+      const {questionDetails, questionRenderViews} =
         await this._getQuestionsForAttempt(quiz);
+
+      console.log('questionRenderViews:', questionRenderViews);
 
       //5. Create a new attempt
 
@@ -341,7 +348,7 @@ class AttemptService extends BaseService {
       // if the quiz maxAttempts is -1, the no need to changes remainingAttempts
       metrics.remainingAttempts =
         quiz.details.maxAttempts === -1 ? -1 : metrics.remainingAttempts - 1;
-      metrics.attempts.push({ attemptId: attemptObjectId });
+      metrics.attempts.push({attemptId: attemptObjectId});
       const updatedMetrics = await this.userQuizMetricsRepository.update(
         metrics._id.toString(),
         metrics,
@@ -363,7 +370,6 @@ class AttemptService extends BaseService {
     answers: IQuestionAnswer[],
     isSkipped?: boolean,
   ): Promise<Partial<IGradingResult> | null> {
-
     /* -------------------- READS OUTSIDE TRANSACTION -------------------- */
 
     // 1. Fetch quiz
@@ -442,7 +448,7 @@ class AttemptService extends BaseService {
 
       metrics.attempts = metrics.attempts.map(attempt =>
         attempt.attemptId.toString() === attemptId
-          ? { ...attempt, submissionResultId: new ObjectId(submissionId) }
+          ? {...attempt, submissionResultId: new ObjectId(submissionId)}
           : attempt,
       );
 
@@ -463,16 +469,12 @@ class AttemptService extends BaseService {
 
     /* -------------------- UPDATE SUBMISSION (SMALL WRITE) -------------------- */
 
-    await this.submissionRepository.update(
-      submissionId,
-      { gradingResult },
-    );
+    await this.submissionRepository.update(submissionId, {gradingResult});
 
     /* -------------------- RETURN BASED ON QUIZ SETTINGS -------------------- */
 
     return this._buildGradingResult(quiz, gradingResult);
   }
-
 
   async submitFeedBackForm(
     userId: string,
@@ -601,11 +603,7 @@ class AttemptService extends BaseService {
     const lastAnswer = answers?.at(-1);
 
     // 4. Fetch question only if needed
-    let question:
-      | NATQuestion
-      | SOLQuestion
-      | SMLQuestion
-      | undefined;
+    let question: NATQuestion | SOLQuestion | SMLQuestion | undefined;
 
     if (lastAnswer) {
       question = (await this.questionService.getById(
@@ -659,7 +657,7 @@ class AttemptService extends BaseService {
 
     switch (lastAnswer.questionType) {
       case 'NUMERIC_ANSWER_TYPE': {
-        const submittedValue = (lastAnswer.answer as { value: number }).value;
+        const submittedValue = (lastAnswer.answer as {value: number}).value;
         const natQuestion = question as NATQuestion;
 
         if (
@@ -698,7 +696,7 @@ class AttemptService extends BaseService {
       }
 
       case 'SELECT_MANY_IN_LOT': {
-        const answer = lastAnswer.answer as { lotItemIds: string[] };
+        const answer = lastAnswer.answer as {lotItemIds: string[]};
         const smlQuestion = question as SMLQuestion;
 
         const isCorrect = smlQuestion.correctLotItems.every(item =>
@@ -709,8 +707,8 @@ class AttemptService extends BaseService {
           result: isCorrect ? 'CORRECT' : 'INCORRECT',
           explanation: isCorrect
             ? smlQuestion.correctLotItems
-              .map(item => item.explaination)
-              .join(', ')
+                .map(item => item.explaination)
+                .join(', ')
             : 'Some of the selected answers are incorrect.',
         };
       }
@@ -723,7 +721,6 @@ class AttemptService extends BaseService {
         };
     }
   }
-
 
   async getAttempt(
     userId: string | ObjectId,
@@ -786,7 +783,7 @@ class AttemptService extends BaseService {
           // Step 3: Add to bulk operations
           bulkOperations.push({
             updateOne: {
-              filter: { _id: new ObjectId(metric._id) },
+              filter: {_id: new ObjectId(metric._id)},
               update: {
                 $set: {
                   // latestAttemptId: latestAttempt?._id.toString(),
@@ -809,7 +806,8 @@ class AttemptService extends BaseService {
                 session,
               );
               console.log(
-                `✅ Batch ${++batchCount}: Updated ${bulkOperations.length
+                `✅ Batch ${++batchCount}: Updated ${
+                  bulkOperations.length
                 } user_quiz_metrics`,
               );
               bulkOperations.length = 0;
@@ -835,7 +833,7 @@ class AttemptService extends BaseService {
     }
 
     console.log(`🔹 Done! Updated ${updatedCount} / ${totalCount} records`);
-    return { updatedCount, totalCount };
+    return {updatedCount, totalCount};
   }
 
   async exportQuizSubmissions(
@@ -974,4 +972,4 @@ class AttemptService extends BaseService {
   }
 }
 
-export { AttemptService };
+export {AttemptService};

--- a/backend/src/modules/quizzes/services/QuestionService.ts
+++ b/backend/src/modules/quizzes/services/QuestionService.ts
@@ -142,6 +142,52 @@ class QuestionService extends BaseService {
       };
     });
   }
+  public async getByIdWithoutExplanation(
+    questionId: string,
+    raw?: boolean,
+    parameterMap?: ParameterMap,
+  ): Promise<BaseQuestion | IQuestionRenderView> {
+    return this._withTransaction(async session => {
+      const question = await this.questionRepository.getByIdWithoutExplanation(
+        questionId,
+        session,
+      );
+
+      if (!question) {
+        throw new NotFoundError(`Question with ID ${questionId} not found`);
+      }
+
+      const [attemptCount, attemptedByUsersCount] = await Promise.all([
+        this.attemptRepository.countByQuestionId(questionId, session),
+        this.attemptRepository.countDistinctUsersByQuestionId(
+          questionId,
+          session,
+        ),
+      ]);
+
+      if (raw) {
+        const skipCount = await this._getQuestionSkipCount(questionId, session);
+
+        return {
+          ...(question as BaseQuestion),
+          attemptCount,
+          attemptedByUsersCount,
+          skipCount,
+        } as unknown as BaseQuestion;
+      }
+
+      const questionProcessor = new QuestionProcessor(question);
+      const rendered = questionProcessor.render(
+        parameterMap,
+      ) as IQuestionRenderView;
+
+      return {
+        ...rendered,
+        attemptCount,
+        attemptedByUsersCount,
+      };
+    });
+  }
 
   public async update(
     questionId: string,


### PR DESCRIPTION
### Task: Remove explanation from quiz attempt response
Currently, for each quiz, an initial API call is made to create and store the student’s quiz attempt (/attempt). The response of this API includes an explanation field for each option/lot.
This introduces a security vulnerability. The explanation text often contains explicit keywords such as “Correct”, “Incorrect”, “Sorry”, or “Congratulations”, which makes it easy for students to identify the correct answer simply by inspecting the network response—without actually attempting the question.
Because the explanation is returned during an active quiz attempt, students can exploit this by checking the API response in DevTools and determining the right or wrong options instantly.
To prevent this, the explanation field must be removed from the attempt API response. Explanations should never be exposed while the quiz is in progress. If explanations are required, they should only be returned through a /save endpoint
 
### Expected Outcome:
Students should not be able to infer correct or incorrect answers from any quiz attempt API response. This change will protect quiz integrity and ensure fair assessment across the platform.

### What was done:
A new function `getByIdWithoutExplanation` was created in `QuestionRepository` in order to remove `explaination` from `lotItems` inside the `questionRenderViews` part of the response while querying the database. Also, created `getByIdWithoutExplanation` in service. This is called in `_getQuestionsForAttempt` in place of `getById`. Now the students cannot get access to `explaination` to get the potential answer until `/save` is called. 

This new function was used in the `/attempt` endpoint and return the response without `explaination`.

## Before:
<img width="627" height="752" alt="before" src="https://github.com/user-attachments/assets/85ea26cd-d69a-45c6-84fa-7215c5653781" />


## After:
<img width="391" height="660" alt="after" src="https://github.com/user-attachments/assets/bc2f41b7-39c1-4c72-b454-040d4254e7ef" />
