### PR TITLE
fix: fixed the watchtime logic in isValidWatchTime function

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -10,6 +10,7 @@ import {
   IWatchTime,
   IProgress,
   IVideoDetails,
+  IBlogDetails,
 } from '#root/shared/interfaces/models.js';
 import { GLOBAL_TYPES } from '#root/types.js';
 import { ProgressRepository } from '#shared/database/providers/mongo/repositories/ProgressRepository.js';
@@ -1122,63 +1123,60 @@ class ProgressService extends BaseService {
   }
 
   private isValidWatchTime(watchTime: IWatchTime, item: Item) {
-    return true;
-    // switch (item.type) {
-    //   case 'VIDEO':
-    //     return true;
-    //     if (watchTime.startTime && watchTime.endTime && item.details) {
-    //       const videoDetails = item.details as IVideoDetails;
-    //       const videoStartTime = videoDetails.startTime; // a string in HH:MM:SS format
-    //       const videoEndTime = videoDetails.endTime; // a string in HH:MM:SS format
-    //       const watchStartTime = new Date(watchTime.startTime);
-    //       const watchEndTime = new Date(watchTime.endTime);
+    // Basic sanity checks
+    if (!watchTime.startTime || !watchTime.endTime || !item.details) {
+      return false;
+    }
 
-    //       // Get Time difference in seconds
-    //       const timeDiff =
-    //         Math.abs(watchEndTime.getTime() - watchStartTime.getTime()) / 1000;
+    const watchStartTime = new Date(watchTime.startTime);
+    const watchEndTime = new Date(watchTime.endTime);
 
-    //       // Get Video duration in seconds
-    //       // Convert HH:MM:SS to seconds
-    //       const videoEndTimeInSeconds =
-    //         parseInt(videoEndTime.split(':')[0]) * 3600 +
-    //         parseInt(videoEndTime.split(':')[1]) * 60 +
-    //         parseInt(videoEndTime.split(':')[2]);
-    //       const videoStartTimeInSeconds =
-    //         parseInt(videoStartTime.split(':')[0]) * 3600 +
-    //         parseInt(videoStartTime.split(':')[1]) * 60 +
-    //         parseInt(videoStartTime.split(':')[2]);
+    // Server-side measured duration in seconds
+    const serverDuration = Math.abs(watchEndTime.getTime() - watchStartTime.getTime()) / 1000;
 
-    //       const videoDuration = videoEndTimeInSeconds - videoStartTimeInSeconds;
+    // Buffer for latency/load (add 5 seconds to the server's measured time)
+    // This assumes the user actually watched longer, but the server started late or ended early
+    // Effectively, we are saying If the server saw 5s, maybe they actually watched 10s
+    const adjustedDuration = serverDuration + 5;
 
-    //       // Check if the watch time is >= 0.2 * video duration
-    //       if (timeDiff >= 0.2 * videoDuration) {
-    //         return true;
-    //       }
-    //       // return false;
-    //       return true; // For now, we assume the watch time is valid
-    //     }
+    switch (item.type) {
+      case 'VIDEO':
+        const videoDetails = item.details as IVideoDetails;
+        if (!videoDetails.startTime || !videoDetails.endTime) return false;
 
-    //     break;
+        const videoEndTimeInSeconds =
+          parseInt(videoDetails.endTime.split(':')[0]) * 3600 +
+          parseInt(videoDetails.endTime.split(':')[1]) * 60 +
+          parseInt(videoDetails.endTime.split(':')[2]);
+        const videoStartTimeInSeconds =
+          parseInt(videoDetails.startTime.split(':')[0]) * 3600 +
+          parseInt(videoDetails.startTime.split(':')[1]) * 60 +
+          parseInt(videoDetails.startTime.split(':')[2]);
 
-    //   case 'BLOG':
-    //     return true;
-    //     // if (watchTime.startTime && watchTime.endTime && item.details) {
-    //     //   const blogDetails = item.details as IBlogDetails;
-    //     //   const watchStartTime = new Date(watchTime.startTime);
-    //     //   const watchEndTime = new Date(watchTime.endTime);
+        const totalVideoDuration = videoEndTimeInSeconds - videoStartTimeInSeconds;
 
-    //     //   // Get Time difference in seconds
-    //     //   const timeDiff =
-    //     //     Math.abs(watchEndTime.getTime() - watchStartTime.getTime()) / 1000;
+        // Security Rule
+        // - Must have watched at least 15% of the video
+        // OR
+        // - If the video is long, must have watched at least 30 seconds
+        const minimumRequired = Math.min(totalVideoDuration * 0.15, 30);
 
-    //     //   // Check if the watch time is >= 0.5 * estimated read time
-    //     //   if (timeDiff >= 0.6 * blogDetails.estimatedReadTimeInMinutes * 60) {
-    //     //     return true;
-    //     //   }
-    //     //   return false;
-    //     // }
-    //     break;
-    // }
+        return adjustedDuration >= minimumRequired;
+
+      case 'BLOG':
+        const blogDetails = item.details as IBlogDetails;
+        // Estimated read time is in minutes
+        const readTimeSeconds = (blogDetails.estimatedReadTimeInMinutes || 1) * 60;
+
+        // Require at least 10% of estimated time OR 10 seconds
+        // This stops instant click-throughs but doesn't punish fast readers
+        const minReadTime = Math.min(readTimeSeconds * 0.10, 10);
+
+        return adjustedDuration >= minReadTime;
+
+      default:
+        return true;
+    }
   }
 
   async getUserProgress(


### PR DESCRIPTION
#### Security Fixes
   * Enabled Watch Time Validation: The isValidWatchTime method in backend/src/modules/users/services/ProgressService.ts now actively validates the duration between startItem and stopItem timestamps.
   * Server-Side Trust: The validation relies strictly on server-generated timestamps stored in the database, preventing client-side manipulation of start/end times.

#### Implementation Details
   1. Latency Buffer: Added a 5-second grace period to the server-calculated duration. This accounts for potential delays between the request hitting the server and the database timestamp being created.
   2. Smart Thresholds:
       * Videos: Users must watch at least 15% of the video duration OR 30 seconds (whichever is smaller).
       * Blogs: Users must spend at least 10% of the estimated read time OR 10 seconds (whichever is smaller).