### PR TITLE
Fix/total documents count

### DIFF
--- a/frontend/src/app/pages/teacher/course-instructors.tsx
+++ b/frontend/src/app/pages/teacher/course-instructors.tsx
@@ -138,7 +138,7 @@ export default function CourseInstructors() {
   const { data: course, error: courseError } = useCourseById(courseId || "")
   const { data: version, error: versionError } = useCourseVersionById(versionId || "")
 
-  const totalDocuments = instructorEnrollments?.totalDocuments || 0
+  const totalDocuments = enrollmentsData?.totalDocuments || 0
   const totalPages = enrollmentsData?.totalPages || 1
   const handlePageChange = (newPage: number) => {
     setCurrentPage(newPage);
@@ -208,7 +208,7 @@ export default function CourseInstructors() {
                   className="h-8 rounded-md border border-input bg-background px-3 py-1 text-sm"
                 >
                   <option value={10}>10</option>
-                  <option value={25}>25</option>
+                  <option value={1}>25</option>
                   <option value={50}>50</option>
                 </select>
                 <span className="text-sm text-muted-foreground whitespace-nowrap">per page</span>

--- a/frontend/src/app/pages/teacher/course-instructors.tsx
+++ b/frontend/src/app/pages/teacher/course-instructors.tsx
@@ -208,7 +208,7 @@ export default function CourseInstructors() {
                   className="h-8 rounded-md border border-input bg-background px-3 py-1 text-sm"
                 >
                   <option value={10}>10</option>
-                  <option value={1}>25</option>
+                  <option value={25}>25</option>
                   <option value={50}>50</option>
                 </select>
                 <span className="text-sm text-muted-foreground whitespace-nowrap">per page</span>


### PR DESCRIPTION
### Description
Fixed pagination total count on the course instructor page, which was always showing `0`, to now display the correct count.

### Screenshot
<img width="1885" height="888" alt="Screenshot 2026-02-03 110429" src="https://github.com/user-attachments/assets/420c517a-cf44-420c-9a63-3ac5aa5b87ab" />

