### PR TITLE
fix: do not throw linear progression error if it's disabled

### DIFF
--- a/backend/src/modules/courses/abilities/itemAbilities.ts
+++ b/backend/src/modules/courses/abilities/itemAbilities.ts
@@ -56,7 +56,7 @@ export async function setupItemAbilities(
           can(ItemActions.ViewAll, 'Item', versionBounded);
 
           // true if linearProgressionEnabled field is not available
-          const linearProgressionEnabled = courseSettingService.isLinearProgressionEnabled(
+          const linearProgressionEnabled = await courseSettingService.isLinearProgressionEnabled(
             enrollment.courseId,
             enrollment.versionId,
           );

--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -294,70 +294,91 @@ export class ItemService extends BaseService {
         return itemsGroup.items;
       }
 
-      // All items completed if module is before current module
-      if (moduleIndex < currentModuleIndex) {
-        itemsGroup.items = itemsGroup.items.map(item => ({
+      const completionEntries = await Promise.all(
+        itemsGroup.items.map(async (item) => {
+          const isCompleted = await this.progressRepo.isItemCompleted(
+            userId,
+            course.courseId.toString(),
+            versionId,
+            item._id.toString()
+          );
+
+          return [item._id.toString(), isCompleted] as const;
+        })
+      );
+      const completionMap = new Map<string, boolean>(completionEntries);
+
+      itemsGroup.items = itemsGroup.items.map(item => ({
           ...item,
-          isCompleted: true,
+          // isCompleted: true,
+          isCompleted:completionMap.get(item._id.toString()) ?? false
         }));
-        return itemsGroup.items;
-      }
+      return itemsGroup.items;
 
-      const currentSectionIndex = course.modules[
-        currentModuleIndex
-      ]?.sections.findIndex(
-        sec => sec.sectionId.toString() === progress.currentSection?.toString(),
-      );
+      // // All items completed if module is before current module
+      // if (moduleIndex < currentModuleIndex) {
+      //   itemsGroup.items = itemsGroup.items.map(item => ({
+      //     ...item,
+      //     isCompleted: true,
+      //   }));
+      //   return itemsGroup.items;
+      // }
 
-      const sectionIndex = course.modules[moduleIndex]?.sections.findIndex(
-        sec => sec.sectionId.toString() === sectionId.toString(),
-      );
+      // const currentSectionIndex = course.modules[
+      //   currentModuleIndex
+      // ]?.sections.findIndex(
+      //   sec => sec.sectionId.toString() === progress.currentSection?.toString(),
+      // );
 
-      // Guard against invalid section indices
-      if (currentSectionIndex === -1 || sectionIndex === -1) {
-        return itemsGroup.items;
-      }
+      // const sectionIndex = course.modules[moduleIndex]?.sections.findIndex(
+      //   sec => sec.sectionId.toString() === sectionId.toString(),
+      // );
 
-      // All items completed if section is before current section in same module
-      if (
-        moduleIndex === currentModuleIndex &&
-        sectionIndex < currentSectionIndex
-      ) {
-        itemsGroup.items = itemsGroup.items.map(item => ({
-          ...item,
-          isCompleted: true,
-        }));
-        return itemsGroup.items;
-      }
+      // // Guard against invalid section indices
+      // if (currentSectionIndex === -1 || sectionIndex === -1) {
+      //   return itemsGroup.items;
+      // }
 
-      const currentItemIndex = itemsGroup.items.findIndex(
-        itm => itm._id.toString() === progress.currentItem?.toString(),
-      );
+      // // All items completed if section is before current section in same module
+      // if (
+      //   moduleIndex === currentModuleIndex &&
+      //   sectionIndex < currentSectionIndex
+      // ) {
+      //   itemsGroup.items = itemsGroup.items.map(item => ({
+      //     ...item,
+      //     isCompleted: true,
+      //   }));
+      //   return itemsGroup.items;
+      // }
 
-      // If current item belongs to another section, nothing here is completed
-      if (currentItemIndex === -1) {
-        return itemsGroup.items;
-      }
+      // const currentItemIndex = itemsGroup.items.findIndex(
+      //   itm => itm._id.toString() === progress.currentItem?.toString(),
+      // );
 
-      itemsGroup.items = itemsGroup.items.map((item, index) => {
-        if (
-          moduleIndex === currentModuleIndex &&
-          sectionIndex === currentSectionIndex &&
-          index < currentItemIndex
-        ) {
-          return {...item, isCompleted: true};
-        }
+      // // If current item belongs to another section, nothing here is completed
+      // if (currentItemIndex === -1) {
+      //   return itemsGroup.items;
+      // }
 
-        if (
-          moduleIndex === currentModuleIndex &&
-          sectionIndex === currentSectionIndex &&
-          index === currentItemIndex
-        ) {
-          return {...item, isCompleted: progress.completed};
-        }
+      // itemsGroup.items = itemsGroup.items.map((item, index) => {
+      //   if (
+      //     moduleIndex === currentModuleIndex &&
+      //     sectionIndex === currentSectionIndex &&
+      //     index < currentItemIndex
+      //   ) {
+      //     return {...item, isCompleted: true};
+      //   }
 
-        return {...item, isCompleted: false};
-      });
+      //   if (
+      //     moduleIndex === currentModuleIndex &&
+      //     sectionIndex === currentSectionIndex &&
+      //     index === currentItemIndex
+      //   ) {
+      //     return {...item, isCompleted: progress.completed};
+      //   }
+
+      //   return {...item, isCompleted: false};
+      // });
     }
 
     console.log(

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -41,9 +41,19 @@ import { PROJECTS_TYPES } from '#root/modules/projects/types.js';
 import { IProjectSubmissionRepository } from '#root/modules/projects/interfaces/IProjectSubmissionRepository.js';
 import { FeedbackRepository } from '#root/modules/quizzes/repositories/providers/mongodb/FeedbackRepository.js';
 import { GetCurrentProgressPathResponse } from '../classes/dtos/GetCurrentProgressPathResponse.js';
+import { SETTING_TYPES } from '#root/modules/setting/types.js';
+import { CourseSettingService } from '#root/modules/setting/index.js';
+import { getContainer } from "#root/bootstrap/loadModules.js";
 
 @injectable()
 class ProgressService extends BaseService {
+
+  private getCourseSettingService(): CourseSettingService {
+    return getContainer().get<CourseSettingService>(
+      SETTING_TYPES.SettingRepo
+    );
+  }
+
   constructor(
     @inject(USERS_TYPES.ProgressRepo)
     private readonly progressRepository: ProgressRepository,
@@ -519,6 +529,12 @@ class ProgressService extends BaseService {
     );
 
     if (isItemCompleted) {
+      return;
+    }
+
+    // if linear progression is not enabled then also continue 
+    const linearProgressionEnabled = await this.getCourseSettingService().isLinearProgressionEnabled(courseId, courseVersionId);
+    if(!linearProgressionEnabled){
       return;
     }
 
@@ -1465,6 +1481,23 @@ class ProgressService extends BaseService {
         itemId,
         session,
       );
+
+      const linearProgressionEnabled = await this.getCourseSettingService().isLinearProgressionEnabled(courseId, courseVersionId);
+      if(!linearProgressionEnabled){
+        const newProgress: Partial<IProgress> = {
+          completed: isItemCompleted,
+          currentModule: moduleId,
+          currentSection: sectionId,
+          currentItem: itemId,
+        }
+
+        await this.progressRepository.updateProgress(
+          userId,
+          courseId,
+          courseVersionId,
+          newProgress
+        );
+      }
 
       return result;
     });


### PR DESCRIPTION
- When linear progression is disabled, the start or stop api won't throw any error, start api will switch the progress's current item to latest item clicked.
- Added logic to mark green tick on completed items as per availability of both startitem and endtime in watchitem repo.
