### PR TITLE
showing module wise completed items

### DIFF
--- a/backend/src/modules/users/controllers/ProgressController.ts
+++ b/backend/src/modules/users/controllers/ProgressController.ts
@@ -1,5 +1,5 @@
-import { Progress } from '#users/classes/transformers/Progress.js';
-import { ICurrentProgressPath } from '#shared/interfaces/models.js';
+import {Progress} from '#users/classes/transformers/Progress.js';
+import {ICurrentProgressPath} from '#shared/interfaces/models.js';
 import {
   GetUserProgressParams,
   StartItemParams,
@@ -22,9 +22,9 @@ import {
   LeaderboardNoAuthResponse,
   GetLeaderboardResponse,
 } from '#users/classes/validators/ProgressValidators.js';
-import { ProgressService } from '#users/services/ProgressService.js';
-import { USERS_TYPES } from '#users/types.js';
-import { injectable, inject } from 'inversify';
+import {ProgressService} from '#users/services/ProgressService.js';
+import {USERS_TYPES} from '#users/types.js';
+import {injectable, inject} from 'inversify';
 import {
   JsonController,
   Get,
@@ -44,27 +44,27 @@ import {
   CurrentUser,
   Req,
 } from 'routing-controllers';
-import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
-import { UserNotFoundErrorResponse } from '../classes/validators/UserValidators.js';
+import {OpenAPI, ResponseSchema} from 'routing-controllers-openapi';
+import {UserNotFoundErrorResponse} from '../classes/validators/UserValidators.js';
 import {
   ProgressActions,
   getProgressAbility,
 } from '../abilities/progressAbilities.js';
-import { Ability } from '#root/shared/functions/AbilityDecorator.js';
-import { subject } from '@casl/ability';
-import { QUIZZES_TYPES } from '#root/modules/quizzes/types.js';
-import { QuizService } from '#root/modules/quizzes/services/index.js';
-import { BadRequestErrorResponse, IUser } from '#root/shared/index.js';
-import { InternalServerErrorResponse } from '../../../shared/middleware/errorHandler.js';
-import { COURSES_TYPES } from '#root/modules/courses/types.js';
-import { ItemService } from '#root/modules/courses/services/ItemService.js';
-import { SuccessResponse } from '#root/modules/projects/classes/validators/ProjectValidators.js';
-import { CourseVersionQuery } from '#root/modules/courses/classes/index.js';
+import {Ability} from '#root/shared/functions/AbilityDecorator.js';
+import {subject} from '@casl/ability';
+import {QUIZZES_TYPES} from '#root/modules/quizzes/types.js';
+import {QuizService} from '#root/modules/quizzes/services/index.js';
+import {BadRequestErrorResponse, IUser} from '#root/shared/index.js';
+import {InternalServerErrorResponse} from '../../../shared/middleware/errorHandler.js';
+import {COURSES_TYPES} from '#root/modules/courses/types.js';
+import {ItemService} from '#root/modules/courses/services/ItemService.js';
+import {SuccessResponse} from '#root/modules/projects/classes/validators/ProjectValidators.js';
+import {CourseVersionQuery} from '#root/modules/courses/classes/index.js';
 
 @OpenAPI({
   tags: ['Progress'],
 })
-@JsonController('/users', { transformResponse: true })
+@JsonController('/users', {transformResponse: true})
 @injectable()
 class ProgressController {
   constructor(
@@ -76,7 +76,7 @@ class ProgressController {
 
     @inject(COURSES_TYPES.ItemService)
     private readonly itemService: ItemService,
-  ) { }
+  ) {}
 
   @OpenAPI({
     summary: 'Get user progress in a course version',
@@ -95,13 +95,13 @@ class ProgressController {
   })
   async getUserProgress(
     @Params() params: GetUserProgressParams,
-    @Ability(getProgressAbility) { ability, user },
+    @Ability(getProgressAbility) {ability, user},
   ): Promise<Progress> {
-    const { courseId, versionId } = params;
+    const {courseId, versionId} = params;
     const userId = user._id.toString();
 
     // Create a progress resource object for permission checking
-    const progressResource = subject('Progress', { userId, courseId, versionId });
+    const progressResource = subject('Progress', {userId, courseId, versionId});
 
     // Check permission using ability.can() with the actual progress resource
     if (!ability.can(ProgressActions.View, progressResource)) {
@@ -119,43 +119,43 @@ class ProgressController {
     return progress;
   }
 
-
   @OpenAPI({
     summary: 'Get current progress path for a user',
-    description: 'Retrieves the current learning position (module, section, item) for a specific user in a course version',
+    description:
+      'Retrieves the current learning position (module, section, item) for a specific user in a course version',
   })
   @Authorized()
   @Get('/progress/courses/:courseId/versions/:versionId/current-path')
   @HttpCode(200)
   async getCurrentProgressPath(
     @Params() params: GetUserProgressParams,
-    @Ability(getProgressAbility) { user },
+    @Ability(getProgressAbility) {user},
     @Req() request: any,
   ): Promise<ICurrentProgressPath> {
-    const { courseId, versionId } = params
-    
+    const {courseId, versionId} = params;
+
     // Validate and extract userId with proper error handling
-    const queryUserId = request.query?.userId as string
-    const userId = queryUserId && queryUserId.trim() ? queryUserId : user._id.toString()
-    
+    const queryUserId = request.query?.userId as string;
+    const userId =
+      queryUserId && queryUserId.trim() ? queryUserId : user._id.toString();
+
     if (!userId) {
       return {
         module: null,
         section: null,
         item: null,
-        message: 'Invalid user ID'
-      }
+        message: 'Invalid user ID',
+      };
     }
 
     const result = await this.progressService.getCurrentProgressPath(
       userId,
       courseId,
-      versionId
-    )
+      versionId,
+    );
 
-    return result
+    return result;
   }
-
 
   @OpenAPI({
     summary: 'Get %age progress in a course version',
@@ -174,14 +174,13 @@ class ProgressController {
   })
   async getUserProgressPercentage(
     @Params() params: GetUserProgressParams,
-    @Ability(getProgressAbility) { ability, user },
+    @Ability(getProgressAbility) {ability, user},
   ): Promise<CompletedProgressResponse> {
-    const { courseId, versionId } = params;
+    const {courseId, versionId} = params;
     const userId = user._id.toString();
 
     // Create a progress resource object for permission checking
-    const progressResource = subject('Progress', { userId, courseId, versionId });
-
+    const progressResource = subject('Progress', {userId, courseId, versionId});
 
     if (!ability.can(ProgressActions.View, progressResource)) {
       throw new ForbiddenError('You do not have permission');
@@ -193,7 +192,6 @@ class ProgressController {
       versionId,
     );
   }
-
 
   @OpenAPI({
     summary: 'Start an item for user progress',
@@ -217,14 +215,14 @@ class ProgressController {
   async startItem(
     @Params() params: StartItemParams,
     @Body() body: StartItemBody,
-    @Ability(getProgressAbility) { ability, user },
+    @Ability(getProgressAbility) {ability, user},
   ): Promise<StartItemResponse> {
-    const { courseId, versionId } = params;
-    const { itemId, moduleId, sectionId } = body;
+    const {courseId, versionId} = params;
+    const {itemId, moduleId, sectionId} = body;
     const userId = user._id.toString();
 
     // Create a progress resource object for permission checking
-    const progressResource = subject('Progress', { userId, courseId, versionId });
+    const progressResource = subject('Progress', {userId, courseId, versionId});
 
     // Check permission using ability.can() with the actual progress resource
     if (!ability.can(ProgressActions.Modify, progressResource)) {
@@ -270,10 +268,10 @@ class ProgressController {
   async stopItem(
     @Params() params: StopItemParams,
     @Body() body: StopItemBody,
-    @Ability(getProgressAbility) { ability, user },
+    @Ability(getProgressAbility) {ability, user},
   ): Promise<void> {
-    const { courseId, versionId } = params;
-    const { itemId, sectionId, moduleId, watchItemId, attemptId, isSkipped } =
+    const {courseId, versionId} = params;
+    const {itemId, sectionId, moduleId, watchItemId, attemptId, isSkipped} =
       body;
 
     const userId = String(user._id);
@@ -327,13 +325,13 @@ It returns an empty body with a 200 status code.
   async resetProgress(
     @Params() params: ResetCourseProgressParams,
     @Body() body: ResetCourseProgressBody,
-    @Ability(getProgressAbility) { ability },
+    @Ability(getProgressAbility) {ability},
   ): Promise<void> {
-    const { userId, courseId, versionId } = params;
-    const { moduleId, sectionId, itemId } = body;
+    const {userId, courseId, versionId} = params;
+    const {moduleId, sectionId, itemId} = body;
 
     // Create a progress resource object for permission checking
-    const progressResource = subject('Progress', { userId, courseId, versionId });
+    const progressResource = subject('Progress', {userId, courseId, versionId});
 
     // Check permission using ability.can() with the actual progress resource
     if (!ability.can(ProgressActions.Modify, progressResource)) {
@@ -411,12 +409,12 @@ It returns an empty body with a 200 status code.
   })
   async getWatchTime(
     @Params() params: WatchTimeParams,
-    @Ability(getProgressAbility) { ability },
+    @Ability(getProgressAbility) {ability},
   ): Promise<WatchTimeResponse> {
-    const { userId, courseId, versionId, itemId, type } = params;
+    const {userId, courseId, versionId, itemId, type} = params;
 
     // Create a progress resource object for permission checking
-    const progressResource = subject('Progress', { userId, courseId, versionId });
+    const progressResource = subject('Progress', {userId, courseId, versionId});
     // Check permission using ability.can() with the actual progress resource
     if (!ability.can(ProgressActions.View, progressResource)) {
       throw new ForbiddenError(
@@ -437,11 +435,11 @@ It returns an empty body with a 200 status code.
         itemId,
       );
       if (quizMetrics) {
-        return { watchTime, quizMetrics };
+        return {watchTime, quizMetrics};
       }
     }
 
-    return { watchTime };
+    return {watchTime};
   }
 
   @OpenAPI({
@@ -464,13 +462,12 @@ It returns an empty body with a 200 status code.
     statusCode: 500,
   })
   async getTotalWatchtimeOfUser(
-    @Ability(getProgressAbility) { user },
+    @Ability(getProgressAbility) {user},
   ): Promise<number> {
     const userId = user._id.toString();
 
-    const totalWatchTime = await this.progressService.getTotalWatchtimeOfUser(
-      userId,
-    );
+    const totalWatchTime =
+      await this.progressService.getTotalWatchtimeOfUser(userId);
     return totalWatchTime;
   }
 
@@ -489,16 +486,16 @@ It returns an empty body with a 200 status code.
   })
   async skipOptionalItem(
     @Params() params: ItemIdparams,
-    @Ability(getProgressAbility) { user, ability },
+    @Ability(getProgressAbility) {user, ability},
   ): Promise<void> {
-    const { itemId } = params;
+    const {itemId} = params;
 
     if (!user || (!user.userId && !user._id)) {
       throw new Error('User not authenticated or user ID not found');
     }
 
     const userId = user.userId || user._id;
-    const { courseId, versionId } =
+    const {courseId, versionId} =
       await this.itemService.getCourseAndVersionByItemId(itemId);
 
     await this.progressService.skipItem(userId, courseId, versionId, itemId);
@@ -535,8 +532,8 @@ It returns an empty body with a 200 status code.
     totalPages: number;
     currentPage: number;
   }> {
-    const { courseId, versionId } = params;
-    const { page = 1, limit = 10 } = query;
+    const {courseId, versionId} = params;
+    const {page = 1, limit = 10} = query;
     const userId = user._id?.toString();
     return await this.progressService.getLeaderboard(
       userId,
@@ -559,8 +556,11 @@ It returns an empty body with a 200 status code.
     description: 'Failed to recalculate student progress',
     statusCode: 500,
   })
-  async recalculateStudentProgress(@Body() body: CourseVersionQuery, @CurrentUser() user: IUser): Promise<string> {
-    const { courseId, courseVersionId } = body;
+  async recalculateStudentProgress(
+    @Body() body: CourseVersionQuery,
+    @CurrentUser() user: IUser,
+  ): Promise<string> {
+    const {courseId, courseVersionId} = body;
     const userId = user._id?.toString();
     return this.progressService.recalculateStudentProgress(
       userId,
@@ -569,6 +569,55 @@ It returns an empty body with a 200 status code.
     );
   }
 
+  @OpenAPI({
+    summary: 'Get module wise progress',
+    description:
+      'Returns total items and completed items for each module in a course version for the current user.',
+  })
+  @Authorized()
+  @Get('/progress/courses/:courseId/versions/:versionId/modules')
+  @HttpCode(200)
+  @ResponseSchema(ProgressDataResponse, {
+    description: 'Module wise progress retrieved successfully',
+    isArray: true,
+  })
+  @ResponseSchema(ProgressNotFoundErrorResponse, {
+    description: 'Progress not found',
+    statusCode: 404,
+  })
+  async getModuleWiseProgress(
+    @Params() params: GetUserProgressParams,
+    @Ability(getProgressAbility) {ability, user},
+  ): Promise<
+    Array<{
+      moduleId: string;
+      moduleName: string;
+      totalItems: number;
+      completedItems: number;
+    }>
+  > {
+    const {courseId, versionId} = params;
+    const userId = user._id.toString();
+
+    // Permission check
+    const progressResource = subject('Progress', {
+      userId,
+      courseId,
+      versionId,
+    });
+
+    if (!ability.can(ProgressActions.View, progressResource)) {
+      throw new ForbiddenError(
+        'You do not have permission to view this progress',
+      );
+    }
+
+    return await this.progressService.getModuleWiseProgress(
+      userId,
+      courseId,
+      versionId,
+    );
+  }
 
   ///////////////////////////////////////////////////// TO CORRECT THE WATCHTIME DOC COUNT OF STUDENTS ////////////////////////////////////////////
   @Post('/progress/watch-time/bulk')
@@ -583,8 +632,12 @@ It returns an empty body with a 200 status code.
     statusCode: 500,
   })
   async createBulkWatchiTimeDocs(@Body() body: any): Promise<any> {
-    const { courseId, versionId, userId } = body;
-    return this.progressService.createBulkWatchiTimeDocs(courseId, versionId, userId ?? null);
+    const {courseId, versionId, userId} = body;
+    return this.progressService.createBulkWatchiTimeDocs(
+      courseId,
+      versionId,
+      userId ?? null,
+    );
   }
 
   /////////////////////////////// TEMP ENDPOINT WITHOUT AUTH //////////////////////////////////
@@ -605,7 +658,7 @@ It returns an empty body with a 200 status code.
   async getNoAuthLeaderboard(
     @Params() params: GetUserProgressParams,
   ): Promise<GetLeaderboardResponse> {
-    const { courseId, versionId } = params;
+    const {courseId, versionId} = params;
     // const {page = 1, limit = 10} = query;
 
     return await this.progressService.getLeaderboardNoAuth(
@@ -616,4 +669,4 @@ It returns an empty body with a 200 status code.
     );
   }
 }
-export { ProgressController };
+export {ProgressController};

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -1,10 +1,10 @@
-import { Item, ItemsGroup } from '#courses/classes/transformers/Item.js';
-import { COURSES_TYPES } from '#courses/types.js';
-import { BaseService } from '#root/shared/classes/BaseService.js';
-import { ICourseRepository } from '#root/shared/database/interfaces/ICourseRepository.js';
-import { IItemRepository } from '#root/shared/database/interfaces/IItemRepository.js';
-import { IUserRepository } from '#root/shared/database/interfaces/IUserRepository.js';
-import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {Item, ItemsGroup} from '#courses/classes/transformers/Item.js';
+import {COURSES_TYPES} from '#courses/types.js';
+import {BaseService} from '#root/shared/classes/BaseService.js';
+import {ICourseRepository} from '#root/shared/database/interfaces/ICourseRepository.js';
+import {IItemRepository} from '#root/shared/database/interfaces/IItemRepository.js';
+import {IUserRepository} from '#root/shared/database/interfaces/IUserRepository.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
 import {
   ICourseVersion,
   IWatchTime,
@@ -13,20 +13,20 @@ import {
   IBlogDetails,
   ICurrentProgressPath,
 } from '#root/shared/interfaces/models.js';
-import { GLOBAL_TYPES } from '#root/types.js';
-import { ProgressRepository } from '#shared/database/providers/mongo/repositories/ProgressRepository.js';
-import { Progress } from '#users/classes/transformers/Progress.js';
-import { USERS_TYPES } from '#users/types.js';
-import { injectable, inject } from 'inversify';
-import { ClientSession, ObjectId } from 'mongodb';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {ProgressRepository} from '#shared/database/providers/mongo/repositories/ProgressRepository.js';
+import {Progress} from '#users/classes/transformers/Progress.js';
+import {USERS_TYPES} from '#users/types.js';
+import {injectable, inject} from 'inversify';
+import {ClientSession, ObjectId} from 'mongodb';
 import {
   NotFoundError,
   BadRequestError,
   InternalServerError,
 } from 'routing-controllers';
-import { SubmissionRepository } from '#quizzes/repositories/providers/mongodb/SubmissionRepository.js';
-import { QUIZZES_TYPES } from '#quizzes/types.js';
-import { WatchTime } from '../classes/transformers/WatchTime.js';
+import {SubmissionRepository} from '#quizzes/repositories/providers/mongodb/SubmissionRepository.js';
+import {QUIZZES_TYPES} from '#quizzes/types.js';
+import {WatchTime} from '../classes/transformers/WatchTime.js';
 import {
   CompletedProgressResponse,
   GetLeaderboardResponse,
@@ -36,22 +36,19 @@ import {
   QuizRepository,
   UserQuizMetricsRepository,
 } from '#root/modules/quizzes/repositories/index.js';
-import { EnrollmentRepository } from '#root/shared/index.js';
-import { PROJECTS_TYPES } from '#root/modules/projects/types.js';
-import { IProjectSubmissionRepository } from '#root/modules/projects/interfaces/IProjectSubmissionRepository.js';
-import { FeedbackRepository } from '#root/modules/quizzes/repositories/providers/mongodb/FeedbackRepository.js';
-import { GetCurrentProgressPathResponse } from '../classes/dtos/GetCurrentProgressPathResponse.js';
-import { SETTING_TYPES } from '#root/modules/setting/types.js';
-import { CourseSettingService } from '#root/modules/setting/index.js';
-import { getContainer } from "#root/bootstrap/loadModules.js";
+import {EnrollmentRepository} from '#root/shared/index.js';
+import {PROJECTS_TYPES} from '#root/modules/projects/types.js';
+import {IProjectSubmissionRepository} from '#root/modules/projects/interfaces/IProjectSubmissionRepository.js';
+import {FeedbackRepository} from '#root/modules/quizzes/repositories/providers/mongodb/FeedbackRepository.js';
+import {GetCurrentProgressPathResponse} from '../classes/dtos/GetCurrentProgressPathResponse.js';
+import {SETTING_TYPES} from '#root/modules/setting/types.js';
+import {CourseSettingService} from '#root/modules/setting/index.js';
+import {getContainer} from '#root/bootstrap/loadModules.js';
 
 @injectable()
 class ProgressService extends BaseService {
-
   private getCourseSettingService(): CourseSettingService {
-    return getContainer().get<CourseSettingService>(
-      SETTING_TYPES.SettingRepo
-    );
+    return getContainer().get<CourseSettingService>(SETTING_TYPES.SettingRepo);
   }
 
   constructor(
@@ -96,7 +93,7 @@ class ProgressService extends BaseService {
    * Private helper method for the enrollment process.
    */
 
-  private getFirstByOrder<T extends { order?: string }>(arr?: T[]): T | null {
+  private getFirstByOrder<T extends {order?: string}>(arr?: T[]): T | null {
     if (!arr?.length) return null;
 
     return arr.reduce((min, curr) => {
@@ -145,7 +142,7 @@ class ProgressService extends BaseService {
       }
     }
 
-    return { itemIds, quizItemIds };
+    return {itemIds, quizItemIds};
   }
 
   private async clearWatchTime(
@@ -155,7 +152,7 @@ class ProgressService extends BaseService {
   ) {
     if (!itemIds.length) return 0;
 
-    const { deletedCount } =
+    const {deletedCount} =
       await this.progressRepository.deleteUserWatchTimeByItemIds(
         userId,
         itemIds,
@@ -396,14 +393,14 @@ class ProgressService extends BaseService {
       //   ));
       const [totalItems, completedItems] = await Promise.all([
         totalItemCount ??
-        this.itemRepo.getTotalItemsCount(courseId, courseVersionId, session),
+          this.itemRepo.getTotalItemsCount(courseId, courseVersionId, session),
         completedItemCount ??
-        this.getUserProgressPercentageWithoutTotal(
-          userId,
-          courseId,
-          courseVersionId,
-          session,
-        ),
+          this.getUserProgressPercentageWithoutTotal(
+            userId,
+            courseId,
+            courseVersionId,
+            session,
+          ),
       ]);
 
       percentCompleted = this._calculateProgress(
@@ -532,9 +529,13 @@ class ProgressService extends BaseService {
       return;
     }
 
-    // if linear progression is not enabled then also continue 
-    const linearProgressionEnabled = await this.getCourseSettingService().isLinearProgressionEnabled(courseId, courseVersionId);
-    if(!linearProgressionEnabled){
+    // if linear progression is not enabled then also continue
+    const linearProgressionEnabled =
+      await this.getCourseSettingService().isLinearProgressionEnabled(
+        courseId,
+        courseVersionId,
+      );
+    if (!linearProgressionEnabled) {
       return;
     }
 
@@ -904,7 +905,7 @@ class ProgressService extends BaseService {
     currentItemId: string,
     quizMetrics: any,
     enrollment: any,
-  ): Promise<{ nextItemId?: string }> {
+  ): Promise<{nextItemId?: string}> {
     try {
       if (quizMetrics?.remainingAttempts !== 0) {
         return {}; // No permission update needed
@@ -932,7 +933,7 @@ class ProgressService extends BaseService {
       const nextItem = items[currentIndex + 1];
 
       if (nextItem && nextItem?._id) {
-        return { nextItemId: nextItem?._id?.toString() };
+        return {nextItemId: nextItem?._id?.toString()};
       }
 
       // No next item → check next section/module
@@ -956,7 +957,7 @@ class ProgressService extends BaseService {
         throw new NotFoundError('Invalid course version');
       }
 
-      const { moduleId, sectionId } = groupInfo;
+      const {moduleId, sectionId} = groupInfo;
       if (!moduleId || !sectionId) {
         throw new NotFoundError(
           'Invalid course mapping: Module or Section missing',
@@ -971,7 +972,7 @@ class ProgressService extends BaseService {
       );
 
       if (nextItemDetails?.itemId) {
-        return { nextItemId: nextItemDetails.itemId.toString() };
+        return {nextItemId: nextItemDetails.itemId.toString()};
       }
 
       return {};
@@ -1030,7 +1031,7 @@ class ProgressService extends BaseService {
     );
 
     if (!isBlank) {
-      return { moduleId, sectionId, itemId, skippedBlankQuizIds };
+      return {moduleId, sectionId, itemId, skippedBlankQuizIds};
     }
 
     // Blank quiz → auto-skip
@@ -1181,7 +1182,8 @@ class ProgressService extends BaseService {
     const watchEndTime = new Date(watchTime.endTime);
 
     // Server-side measured duration in seconds
-    const serverDuration = Math.abs(watchEndTime.getTime() - watchStartTime.getTime()) / 1000;
+    const serverDuration =
+      Math.abs(watchEndTime.getTime() - watchStartTime.getTime()) / 1000;
 
     // Buffer for latency/load (add 5 seconds to the server's measured time)
     // This assumes the user actually watched longer, but the server started late or ended early
@@ -1202,7 +1204,8 @@ class ProgressService extends BaseService {
           parseInt(videoDetails.startTime.split(':')[1]) * 60 +
           parseInt(videoDetails.startTime.split(':')[2]);
 
-        const totalVideoDuration = videoEndTimeInSeconds - videoStartTimeInSeconds;
+        const totalVideoDuration =
+          videoEndTimeInSeconds - videoStartTimeInSeconds;
 
         // Security Rule
         // - Must have watched at least 15% of the video
@@ -1215,11 +1218,12 @@ class ProgressService extends BaseService {
       case 'BLOG':
         const blogDetails = item.details as IBlogDetails;
         // Estimated read time is in minutes
-        const readTimeSeconds = (blogDetails.estimatedReadTimeInMinutes || 1) * 60;
+        const readTimeSeconds =
+          (blogDetails.estimatedReadTimeInMinutes || 1) * 60;
 
         // Require at least 10% of estimated time OR 10 seconds
         // This stops instant click-throughs but doesn't punish fast readers
-        const minReadTime = Math.min(readTimeSeconds * 0.10, 10);
+        const minReadTime = Math.min(readTimeSeconds * 0.1, 10);
 
         return adjustedDuration >= minReadTime;
 
@@ -1270,22 +1274,21 @@ class ProgressService extends BaseService {
   async getCurrentProgressPath(
     userId: string,
     courseId: string,
-    versionId: string
+    versionId: string,
   ): Promise<ICurrentProgressPath> {
-
     const progress = await this.progressRepository.findProgress(
       userId,
       courseId,
       versionId,
-    )
+    );
 
     if (!progress) {
       return {
         module: null,
         section: null,
         item: null,
-        message: 'No progress found'
-      }
+        message: 'No progress found',
+      };
     }
 
     if (!progress.currentItem) {
@@ -1293,54 +1296,62 @@ class ProgressService extends BaseService {
         module: null,
         section: null,
         item: null,
-        message: 'Progress not started'
-      }
+        message: 'Progress not started',
+      };
     }
 
-    const { currentModule, currentSection, currentItem } = progress
+    const {currentModule, currentSection, currentItem} = progress;
 
     try {
-      const module = await this.courseRepo.getModulebyId(versionId, currentModule.toString())
-      
+      const module = await this.courseRepo.getModulebyId(
+        versionId,
+        currentModule.toString(),
+      );
+
       if (!module) {
         return {
           module: null,
           section: null,
           item: null,
-          message: 'Module not found'
-        }
+          message: 'Module not found',
+        };
       }
 
-      const section = module.sections.find(s => s.sectionId === currentSection.toString())
-      
+      const section = module.sections.find(
+        s => s.sectionId === currentSection.toString(),
+      );
+
       if (!section) {
         return {
-          module: { id: module.moduleId.toString(), name: module.name },
+          module: {id: module.moduleId.toString(), name: module.name},
           section: null,
           item: null,
-          message: 'Section not found'
-        }
+          message: 'Section not found',
+        };
       }
-      
+
       // Get the actual item details
-      const itemDetails = await this.itemRepo.readItem(versionId, currentItem.toString())
-      
+      const itemDetails = await this.itemRepo.readItem(
+        versionId,
+        currentItem.toString(),
+      );
+
       return {
-        module: { id: module.moduleId.toString(), name: module.name },
-        section: { id: section.sectionId.toString(), name: section.name },
-        item: { 
-          id: itemDetails?._id?.toString() || currentItem.toString(), 
-          name: itemDetails?.name || 'Unknown Item', 
-          type: itemDetails?.type || 'unknown' 
+        module: {id: module.moduleId.toString(), name: module.name},
+        section: {id: section.sectionId.toString(), name: section.name},
+        item: {
+          id: itemDetails?._id?.toString() || currentItem.toString(),
+          name: itemDetails?.name || 'Unknown Item',
+          type: itemDetails?.type || 'unknown',
         },
-      }
+      };
     } catch (error) {
       return {
         module: null,
         section: null,
         item: null,
-        message: 'Error occurred: ' + error.message
-      }
+        message: 'Error occurred: ' + error.message,
+      };
     }
   }
 
@@ -1482,20 +1493,24 @@ class ProgressService extends BaseService {
         session,
       );
 
-      const linearProgressionEnabled = await this.getCourseSettingService().isLinearProgressionEnabled(courseId, courseVersionId);
-      if(!linearProgressionEnabled){
+      const linearProgressionEnabled =
+        await this.getCourseSettingService().isLinearProgressionEnabled(
+          courseId,
+          courseVersionId,
+        );
+      if (!linearProgressionEnabled) {
         const newProgress: Partial<IProgress> = {
           completed: isItemCompleted,
           currentModule: moduleId,
           currentSection: sectionId,
           currentItem: itemId,
-        }
+        };
 
         await this.progressRepository.updateProgress(
           userId,
           courseId,
           courseVersionId,
-          newProgress
+          newProgress,
         );
       }
 
@@ -1762,7 +1777,9 @@ class ProgressService extends BaseService {
       (await this.itemRepo.CalculateTotalItemsCount(courseId, courseVersionId));
 
     const percentCompleted = parseFloat(
-      ((totalItems > 0 ? completedItemsSet.size / totalItems : 0) * 100).toFixed(2),
+      (
+        (totalItems > 0 ? completedItemsSet.size / totalItems : 0) * 100
+      ).toFixed(2),
     );
 
     // Fire-and-forget safe update
@@ -1947,7 +1964,7 @@ class ProgressService extends BaseService {
     );
 
     // Collect attemptIds to delete and bulk ops for all collections
-    const { attemptDeletes, metricsUpdates, submissionDeletes } =
+    const {attemptDeletes, metricsUpdates, submissionDeletes} =
       await this.progressRepository.prepareBulkQuizOperations(
         userId,
         quizItemIds,
@@ -1994,10 +2011,14 @@ class ProgressService extends BaseService {
     courseVersionId: string,
     isPassed: boolean,
   ) {
-    const progress = await this.progressRepository.findProgress(userId, courseId, courseVersionId);
-    console.log("Progress: ", progress);
+    const progress = await this.progressRepository.findProgress(
+      userId,
+      courseId,
+      courseVersionId,
+    );
+    console.log('Progress: ', progress);
     if (!progress) {
-      console.log("Progress not found")
+      console.log('Progress not found');
       return;
     }
 
@@ -2030,8 +2051,7 @@ class ProgressService extends BaseService {
     // }
 
     const courseVersion = await this.courseRepo.readVersion(courseVersionId);
-    console.log("courseVersion: ", courseVersion);
-
+    console.log('courseVersion: ', courseVersion);
 
     if (isPassed) {
       const nextItemDetails = await this.getNextItemInSequence(
@@ -2041,7 +2061,7 @@ class ProgressService extends BaseService {
         quizeId,
       );
 
-      console.log("NextItemDetails Object", nextItemDetails);
+      console.log('NextItemDetails Object', nextItemDetails);
 
       const newProgress = {
         currentModule: nextItemDetails.moduleId,
@@ -2049,7 +2069,7 @@ class ProgressService extends BaseService {
         currentItem: nextItemDetails.itemId,
       };
 
-      console.log("newProgress Object: ", newProgress);
+      console.log('newProgress Object: ', newProgress);
 
       await this.progressRepository.updateProgress(
         userId,
@@ -2065,15 +2085,15 @@ class ProgressService extends BaseService {
         quizeId,
       );
 
-      console.log("PreviousDetails Object: ", previousDetails)
+      console.log('PreviousDetails Object: ', previousDetails);
 
       const previousProgress = {
         currentModule: previousDetails.moduleId,
         currentSection: previousDetails.sectionId,
         currentItem: previousDetails.itemId,
-      }
+      };
 
-      console.log("PreviousProgress Object: ", previousProgress)
+      console.log('PreviousProgress Object: ', previousProgress);
       await this.progressRepository.updateProgress(
         userId,
         courseId,
@@ -2081,7 +2101,6 @@ class ProgressService extends BaseService {
         previousProgress,
       );
     }
-
   }
 
   // Admin Level Endpoint
@@ -2156,11 +2175,11 @@ class ProgressService extends BaseService {
           : Promise.resolve(),
         projectItemIds.length
           ? this.resetUserProjectData(
-            userId,
-            projectItemIds,
-            courseVersionId,
-            session,
-          )
+              userId,
+              projectItemIds,
+              courseVersionId,
+              session,
+            )
           : Promise.resolve(),
       ]);
 
@@ -2276,11 +2295,11 @@ class ProgressService extends BaseService {
         //   : Promise.resolve(),
         projectItemIds.length
           ? this.resetUserProjectData(
-            userId,
-            projectItemIds,
-            courseVersionId,
-            session,
-          )
+              userId,
+              projectItemIds,
+              courseVersionId,
+              session,
+            )
           : Promise.resolve(),
       ]);
     });
@@ -2347,7 +2366,7 @@ class ProgressService extends BaseService {
 
       const itemsGroupIds = module.sections.map(s => s.itemsGroupId as string);
 
-      const { itemIds, quizItemIds } = await this.collectItemsFromGroups(
+      const {itemIds, quizItemIds} = await this.collectItemsFromGroups(
         itemsGroupIds,
         session,
       );
@@ -2418,7 +2437,7 @@ class ProgressService extends BaseService {
         sectionId,
       );
 
-      const { itemIds, quizItemIds } = await this.collectItemsFromGroups(
+      const {itemIds, quizItemIds} = await this.collectItemsFromGroups(
         [section.itemsGroupId as string],
         session,
       );
@@ -2568,7 +2587,7 @@ class ProgressService extends BaseService {
     courseVersionId: string,
     itemId: string,
     session?: ClientSession,
-  ): Promise<{ message: String }> {
+  ): Promise<{message: String}> {
     const item = await this.itemRepo.readItem(courseVersionId, itemId);
     if (!item) {
       throw new NotFoundError(`Item ${itemId} not found`);
@@ -2669,7 +2688,7 @@ class ProgressService extends BaseService {
         session,
       );
 
-      return { message: 'Course completed - reset to start' };
+      return {message: 'Course completed - reset to start'};
     }
 
     // Update progress to the next item
@@ -2685,7 +2704,7 @@ class ProgressService extends BaseService {
       session,
     );
 
-    return { message: 'Item skipped successfully' };
+    return {message: 'Item skipped successfully'};
   }
   async getFirstItem(versionId: string) {
     if (!versionId) {
@@ -2904,6 +2923,70 @@ class ProgressService extends BaseService {
 
     return allItemIds;
   }
+  async getModuleWiseProgress(
+    userId: string,
+    courseId: string,
+    versionId: string,
+  ): Promise<
+    Array<{
+      moduleId: string;
+      moduleName: string;
+      totalItems: number;
+      completedItems: number;
+    }>
+  > {
+    // 1. Fetch course version + completed items in parallel
+    const [courseVersion, completedItemIds] = await Promise.all([
+      this.courseRepo.readVersion(versionId),
+      this.progressRepository.getCompletedItems(userId, courseId, versionId),
+    ]);
+
+    if (!courseVersion) {
+      throw new NotFoundError('Course version not found');
+    }
+
+    const completedSet = new Set(completedItemIds.map(id => id.toString()));
+
+    const moduleStats: Array<{
+      moduleId: string;
+      moduleName: string;
+      totalItems: number;
+      completedItems: number;
+    }> = [];
+
+    for (const module of courseVersion.modules || []) {
+      let moduleItemIds: string[] = [];
+
+      for (const section of module.sections || []) {
+        if (!section.itemsGroupId) continue;
+
+        const group = await this.itemRepo.readItemsGroup(
+          section.itemsGroupId.toString(),
+        );
+
+        if (!group?.items) continue;
+
+        for (const item of group.items) {
+          moduleItemIds.push(item._id.toString());
+        }
+      }
+
+      const totalItems = moduleItemIds.length;
+
+      const completedItems = moduleItemIds.filter(id =>
+        completedSet.has(id),
+      ).length;
+
+      moduleStats.push({
+        moduleId: module.moduleId.toString(),
+        moduleName: module.name,
+        totalItems,
+        completedItems,
+      });
+    }
+
+    return moduleStats;
+  }
 
   async recalculateStudentProgress(
     userId: string,
@@ -2992,9 +3075,11 @@ class ProgressService extends BaseService {
     const percentCompleted =
       totalItemsCount > 0
         ? Math.min(
-          parseFloat(((normalizedTotalItemsCount / totalItemsCount) * 100).toFixed(2)),
-          100,
-        )
+            parseFloat(
+              ((normalizedTotalItemsCount / totalItemsCount) * 100).toFixed(2),
+            ),
+            100,
+          )
         : 0;
 
     // 5. Update enrollment progress
@@ -3199,7 +3284,7 @@ class ProgressService extends BaseService {
         const fullName =
           `${user.firstName || ''} ${user.lastName || ''}`.trim() ||
           'Unknown User';
-        userMap.set(user._id?.toString(), { name: fullName, email: user.email });
+        userMap.set(user._id?.toString(), {name: fullName, email: user.email});
       }
     }
 
@@ -3252,4 +3337,4 @@ class ProgressService extends BaseService {
   }
 }
 
-export { ProgressService };
+export {ProgressService};

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -1482,7 +1482,7 @@ export default function CoursePage() {
                                 <div className="font-medium text-xs truncate">
                                   {module.name.length > 34 ? `${module.name.substring(0, 31)}...` : module.name}
                                 </div>
-                                 <div className="text-[10px] text-muted-foreground">
+                                 <div className={`text-[10px] ${(progress?.completedItems===progress?.totalItems && progress?.totalItems>0) ?`dark:text-green-500 text-green-600 `:` text-muted-foreground` }`}>
                                     {moduleProgressLoading
                                       ? "..."
                                       : `${progress?.completedItems ?? 0}/${progress?.totalItems ?? 0} completed`

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react"; ExternalLink
+import { useState, useEffect, useCallback, useRef, useMemo } from "react"; ExternalLink
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -52,6 +52,7 @@ import { toast } from "sonner";
 import ItemContainer from "@/components/Item-container";
 import logo from "../../../../public/img/vibe_logo_img.ico"
 import { registerStream, unRegisterStream } from "@/lib/MediaRegistry";
+import { useModuleProgress } from "@/hooks/hooks";
 
 // Helper function to get icon for item type
 const getItemIcon = (type: string) => {
@@ -202,6 +203,9 @@ export default function CoursePage() {
   // Fetch user progress
   const { data: progressData, isLoading: progressLoading, error: progressError } =
     useUserProgress(COURSE_ID, VERSION_ID);
+  const { data: moduleProgressData, isLoading: moduleProgressLoading } =
+  useModuleProgress(COURSE_ID, VERSION_ID);
+
 
   // Fetch proctoring settings for the course (fetched once when component loads)
   const [proctoringData, setProctoringData] = useState<StudentProctoringSettings | null>(null);
@@ -570,6 +574,16 @@ export default function CoursePage() {
       setIsFlagModalOpen(false);
     }
   };
+  const moduleProgressMap = useMemo(() => {
+  const map = new Map();
+
+  moduleProgressData?.forEach((m: any) => {
+    map.set(m.moduleId, m);
+  });
+
+  return map;
+}, [moduleProgressData]);
+
 
 
   // Handle item selection
@@ -1445,6 +1459,7 @@ export default function CoursePage() {
                 <SidebarMenu className="space-y-1 text-sm pr-0">
                   {modules.map((module: any) => {
                     const moduleId = module.moduleId;
+                    const progress = moduleProgressMap.get(moduleId);
                     const isModuleExpanded = expandedModules[moduleId];
                     const isCurrentModule = moduleId === selectedModuleId;
 
@@ -1462,8 +1477,17 @@ export default function CoursePage() {
                           <div className="flex-1 text-left min-w-0 ml-2">
                             <Tooltip>
                               <TooltipTrigger asChild>
+                                <div className="flex gap-4 items-center justify-between">
+                                   
                                 <div className="font-medium text-xs truncate">
                                   {module.name.length > 34 ? `${module.name.substring(0, 31)}...` : module.name}
+                                </div>
+                                 <div className="text-[10px] text-muted-foreground">
+                                    {moduleProgressLoading
+                                      ? "..."
+                                      : `${progress?.completedItems ?? 0}/${progress?.totalItems ?? 0} completed`
+                                    }
+                              </div>
                                 </div>
                               </TooltipTrigger>
                               <TooltipContent side="right" align="center">
@@ -1473,6 +1497,7 @@ export default function CoursePage() {
                             <div className="text-[10px] text-muted-foreground truncate">
                               {module.sections?.length || 0} sections
                             </div>
+                            
                           </div>
                         </SidebarMenuButton>
 

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -1465,8 +1465,15 @@ export function useStopItem() {
           predicate: (query) =>
             query.queryKey[0] === "get" &&
             query.queryKey[1] ===
-            "/courses/versions/{versionId}/modules/{moduleId}/sections/{sectionId}/items",
+            `/courses/versions/{versionId}/modules/{moduleId}/sections/{sectionId}/items`,
         });
+      queryClient.invalidateQueries({
+  predicate: (query) =>
+    query.queryKey[0] === "get" &&
+    query.queryKey[1] ===
+      "/users/progress/courses/{courseId}/versions/{versionId}/modules",
+});
+
 
       },
     }
@@ -3698,6 +3705,42 @@ export const exportQuizSubmissions = async (quizId: string) => {
 
   URL.revokeObjectURL(url);
 }
+
+export function useModuleProgress(
+  courseId: string,
+  versionId: string
+): {
+  data: {
+    moduleId: string;
+    moduleName: string;
+    totalItems: number;
+    completedItems: number;
+  }[] | undefined;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+} {
+  const result = api.useQuery(
+    'get',
+    `/users/progress/courses/${courseId}/versions/${versionId}/modules` as any,
+    {
+      params: {
+        path: { courseId, versionId }
+      }
+    },
+    {
+      enabled: !!courseId && !!versionId
+    }
+  );
+
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+    error: result.error ? (result.error.message || "Failed to fetch module progress") : null,
+    refetch: result.refetch
+  };
+}
+
 
 export const useHideModule = (): {
   mutate: (variables: { params: { path: { versionId: string, moduleId: string } }, body: { hide: boolean } }) => void,


### PR DESCRIPTION
### Feature
Adding completed items per module 

### What was done
- created a ` @Get('/progress/courses/:courseId/versions/:versionId/modules')` api in `ProgressController.ts`
- created `getModuleWiseProgress` in `ProgressService` to get calculated items per module
- created a hook to call these controllers and added it to `useStopItem` hook to refetch it when stop api runs. 


### Before
<img width="577" height="219" alt="Screenshot 2026-02-05 at 5 39 04 PM" src="https://github.com/user-attachments/assets/988fe90c-0521-43ce-a543-3be002557587" />

### After
<img width="577" height="312" alt="Screenshot 2026-02-05 at 5 47 56 PM" src="https://github.com/user-attachments/assets/fc7c671c-6181-4cd4-97ef-40283bf97a89" />

