### PR TITLE
Fix/search pagination inconsistent results

### DIFF
--- a/backend/src/modules/users/controllers/EnrollmentController.ts
+++ b/backend/src/modules/users/controllers/EnrollmentController.ts
@@ -203,7 +203,7 @@ export class EnrollmentController {
     // 🚀 Run DB queries in parallel
     const [enrollments, totalDocuments] = await Promise.all([
       this.enrollmentService.getEnrollments(userId, skip, limit, role, search),
-      this.enrollmentService.countEnrollments(userId, role),
+      this.enrollmentService.countEnrollments(userId, role, search),
     ]);
 
     if (!enrollments || enrollments.length === 0) {

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -717,9 +717,9 @@ export class EnrollmentService extends BaseService {
     }
   }
 
-  async countEnrollments(userId: string, role: EnrollmentRole) {
+  async countEnrollments(userId: string, role: EnrollmentRole, search: string) {
     return this._withTransaction(async (session: ClientSession) => {
-      const result = await this.enrollmentRepo.countEnrollments(userId, role);
+      const result = await this.enrollmentRepo.countEnrollments(userId, role, search);
       return result;
     });
   }

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -795,8 +795,8 @@ export class EnrollmentRepository {
       },
 
       { $sort: { enrollmentDate: -1 } },
-      { $skip: skip },
-      { $limit: limit },
+      // { $skip: skip },
+      // { $limit: limit },
 
       /* ---------- COURSE LOOKUP (OPTIMIZED) ---------- */
       {
@@ -858,6 +858,8 @@ export class EnrollmentRepository {
 
       /* ---------- REMOVE NON-MATCHED COURSES ---------- */
       { $unwind: '$course' },
+      { $skip: skip },
+      { $limit: limit },
 
       /* ---------- FINAL SHAPE ---------- */
       {

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -1552,18 +1552,62 @@ export class EnrollmentRepository {
   /**
    * Count total enrollments for a user
    */
-  async countEnrollments(userId: string, role: EnrollmentRole) {
+  // async countEnrollments(userId: string, role: EnrollmentRole, search: string) {
+  //   await this.init();
+
+  //   const userObjectid = new ObjectId(userId);
+
+  //   return await this.enrollmentCollection.countDocuments({
+  //     userId: userObjectid,
+  //     role,
+  //     isDeleted: { $ne: true },
+  //     status: { $regex: /^active$/i },
+  //   });
+  // }
+  async countEnrollments(userId: string,role: EnrollmentRole,search?: string,) {
     await this.init();
 
-    const userObjectid = new ObjectId(userId);
+    const pipeline: any[] = [
+      {
+        $match: {
+          userId: new ObjectId(userId),
+          role,
+          isDeleted: { $ne: true },
+          status: { $regex: /^active$/i },
+        },
+      },
 
-    return await this.enrollmentCollection.countDocuments({
-      userId: userObjectid,
-      role,
-      isDeleted: { $ne: true },
-      status: { $regex: /^active$/i },
-    });
+      {
+        $lookup: {
+          from: 'newCourse',
+          let: { courseId: '$courseId' },
+          pipeline: [
+            {
+              $match: {
+                $expr: { $eq: ['$_id', '$$courseId'] },
+                ...(search?.trim()
+                  ? { name: { $regex: search, $options: 'i' } }
+                  : {}),
+              },
+            },
+          ],
+          as: 'course',
+        },
+      },
+
+      // remove enrollments whose course did not match search
+      { $unwind: '$course' },
+
+      { $count: 'total' },
+    ];
+
+    const result = await this.enrollmentCollection
+      .aggregate(pipeline)
+      .toArray();
+
+    return result[0]?.total || 0;
   }
+
   /*Update enrollments for all records in db */
   async bulkUpdateEnrollments(
     bulkOperations: any[],


### PR DESCRIPTION
###  Fix: Correct pagination total count for enrollment search

#### Problem
When searching enrollments by course name:
- Pagination showed incorrect total counts
- Page numbers were calculated using all enrollments instead of filtered results
- This caused empty pages and inconsistent results across pagination

The issue occurred because `countDocuments()` was used on the enrollment collection, while the search filter was applied on the related `course` collection.

---

####  Solution
- Replaced `countDocuments()` with an aggregation pipeline
- Applied `$lookup` on the `course` collection and filtered by course name
- Used `$count` after filtering to return the correct total enrollment count
- Ensured the same search logic is applied for both data retrieval and total count

---

####  Result
- Pagination count matches search results
- No empty or invalid pages
- Search + pagination behaves consistently
- Backend-only fix (no UI changes)

---