### PR TITLE
Avoid unnecessary enrollment fetches

### DIFF
--- a/backend/src/modules/users/classes/validators/ContentCountsValidators.ts
+++ b/backend/src/modules/users/classes/validators/ContentCountsValidators.ts
@@ -1,34 +1,103 @@
-import {
-  IsNotEmpty,
-  IsInt,
-} from 'class-validator';
+import {IsInt, IsOptional} from 'class-validator';
 import {JSONSchema} from 'class-validator-jsonschema';
 
 export class ContentCountsValidator {
+  @JSONSchema({
+    description: 'Total number of items in the course',
+    example: 45,
+    type: 'integer',
+  })
+  @IsOptional()
+  @IsInt()
+  totalItems?: number;
+
   @JSONSchema({
     description: 'Number of video items in the course',
     example: 24,
     type: 'integer',
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsInt()
-  videos: number;
+  videos?: number;
 
   @JSONSchema({
     description: 'Number of quiz items in the course',
     example: 12,
     type: 'integer',
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsInt()
-  quizzes: number;
+  quizzes?: number;
 
   @JSONSchema({
     description: 'Number of blog/article items in the course',
     example: 9,
     type: 'integer',
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsInt()
-  articles: number;
+  articles?: number;
+
+  @JSONSchema({
+    description: 'Number of project items in the course',
+    example: 2,
+    type: 'integer',
+  })
+  @IsOptional()
+  @IsInt()
+  project?: number;
+
+  @JSONSchema({
+    description: 'Total quiz score achieved by the student',
+    example: 85,
+    type: 'number',
+  })
+  @IsOptional()
+  @IsInt()
+  totalQuizScore?: number;
+
+  @JSONSchema({
+    description: 'Total maximum quiz score possible',
+    example: 100,
+    type: 'number',
+  })
+  @IsOptional()
+  @IsInt()
+  totalQuizMaxScore?: number;
+
+  @JSONSchema({
+    description: 'Number of completed video items',
+    example: 20,
+    type: 'integer',
+  })
+  @IsOptional()
+  @IsInt()
+  completedVideos?: number;
+
+  @JSONSchema({
+    description: 'Number of completed quiz items',
+    example: 10,
+    type: 'integer',
+  })
+  @IsOptional()
+  @IsInt()
+  completedQuizzes?: number;
+
+  @JSONSchema({
+    description: 'Number of completed article items',
+    example: 8,
+    type: 'integer',
+  })
+  @IsOptional()
+  @IsInt()
+  completedArticles?: number;
+
+  @JSONSchema({
+    description: 'Number of completed project items',
+    example: 1,
+    type: 'integer',
+  })
+  @IsOptional()
+  @IsInt()
+  completedProjects?: number;
 }

--- a/backend/src/modules/users/classes/validators/EnrollmentValidators.ts
+++ b/backend/src/modules/users/classes/validators/EnrollmentValidators.ts
@@ -21,8 +21,8 @@ import {
   ICourse,
   ID,
 } from '#root/shared/interfaces/models.js';
-import { CourseDataResponse } from '#root/modules/courses/classes/index.js';
-import { ContentCountsValidator } from './ContentCountsValidators.js';
+import {CourseDataResponse} from '#root/modules/courses/classes/index.js';
+import {ContentCountsValidator} from './ContentCountsValidators.js';
 
 export class EnrollmentParams {
   @JSONSchema({
@@ -70,13 +70,13 @@ export class BulkUnenrollBody {
     description: 'Array of user IDs to unenroll (maximum 50)',
     example: ['60d5ec49b3f1c8e4a8f8b8d2', '60d5ec49b3f1c8e4a8f8b8d3'],
     type: 'array',
-    items: { type: 'string' },
+    items: {type: 'string'},
     maxItems: 50,
   })
   @IsArray()
   @IsNotEmpty()
-  @ArrayMaxSize(50, { message: 'Cannot unenroll more than 50 students at once' })
-  @IsMongoId({ each: true })
+  @ArrayMaxSize(50, {message: 'Cannot unenroll more than 50 students at once'})
+  @IsMongoId({each: true})
   userIds: string[];
 }
 export class EnrollmentDataResponse {
@@ -185,7 +185,7 @@ export class EnrollUserResponseData {
   @JSONSchema({
     description: 'Enrollment data for the user',
     type: 'object',
-    items: { $ref: '#/components/schemas/EnrollmentDataResponse' },
+    items: {$ref: '#/components/schemas/EnrollmentDataResponse'},
   })
   @ValidateNested()
   @Type(() => EnrollmentDataResponse)
@@ -195,7 +195,7 @@ export class EnrollUserResponseData {
   @JSONSchema({
     description: 'Progress data for the user',
     type: 'object',
-    items: { $ref: '#/components/schemas/ProgressDataResponse' },
+    items: {$ref: '#/components/schemas/ProgressDataResponse'},
   })
   @IsNotEmpty()
   @ValidateNested()
@@ -366,7 +366,7 @@ class AllEnrollmentsResponse {
   @JSONSchema({
     description: 'User data associated with the enrollment',
     type: 'object',
-    items: { $ref: '#/components/schemas/EnrolledUserResponseData' },
+    items: {$ref: '#/components/schemas/EnrolledUserResponseData'},
   })
   @IsNotEmpty()
   @ValidateNested()
@@ -468,7 +468,7 @@ export class BulkUnenrollResponse {
   @JSONSchema({
     description: 'Array of error messages for failed unenrollments',
     type: 'array',
-    items: { type: 'string' },
+    items: {type: 'string'},
   })
   @IsArray()
   @IsOptional()
@@ -521,5 +521,5 @@ export const ENROLLMENT_VALIDATORS = [
   EnrollmentNotFoundErrorResponse,
   UpdateEnrollmentProgressResponse,
   BulkUnenrollBody,
-  BulkUnenrollResponse
+  BulkUnenrollResponse,
 ];

--- a/backend/src/modules/users/controllers/EnrollmentController.ts
+++ b/backend/src/modules/users/controllers/EnrollmentController.ts
@@ -687,8 +687,6 @@ export class EnrollmentController {
     const [enrollments, totalDocuments] = await Promise.all([
       this.enrollmentService.getDetailedEnrollments(
         userId,
-        skip,
-        limit,
         role,
         search,
         courseVersionId,

--- a/backend/src/modules/users/controllers/EnrollmentController.ts
+++ b/backend/src/modules/users/controllers/EnrollmentController.ts
@@ -177,7 +177,7 @@ export class EnrollmentController {
   @OpenAPI({
     summary: 'Bulk unenroll users from a course version',
     description:
-      'Removes multiple users\' enrollments and progress from a specific course version.',
+      "Removes multiple users' enrollments and progress from a specific course version.",
   })
   @Authorized()
   @Post('/enrollments/courses/:courseId/versions/:versionId/bulk-unenroll')
@@ -194,12 +194,14 @@ export class EnrollmentController {
     @Param('courseId') courseId: string,
     @Param('versionId') versionId: string,
     @Body() body: BulkUnenrollBody,
-    @Ability(getEnrollmentAbility) { ability },
+    @Ability(getEnrollmentAbility) {ability},
   ): Promise<BulkUnenrollResponse> {
-    const { userIds } = body;
+    const {userIds} = body;
 
     if (!userIds || userIds.length === 0) {
-      throw new BadRequestError('User IDs array is required and cannot be empty');
+      throw new BadRequestError(
+        'User IDs array is required and cannot be empty',
+      );
     }
 
     // Check permissions for bulk unenroll
@@ -272,7 +274,7 @@ export class EnrollmentController {
         message: 'No enrollments found for the user',
       };
     }
-    
+
     return {
       totalDocuments,
       totalPages: Math.ceil(totalDocuments / limit),
@@ -419,8 +421,8 @@ export class EnrollmentController {
           status: enrollment.status,
           isDeleted: enrollment.isDeleted || false,
           enrollmentDate: enrollment.enrollmentDate,
-         unenrolledAt: enrollment.unenrolledAt,
-          user: { ...enrollment.userInfo, _id: enrollment.userId },
+          unenrolledAt: enrollment.unenrolledAt,
+          user: {...enrollment.userInfo, _id: enrollment.userId},
           progress: enrollment.percentCompleted,
           completedItemsCount: enrollment.completedItemsCount || 0,
           totalQuizScore: enrollment.totalQuizScore || 0,
@@ -504,7 +506,7 @@ export class EnrollmentController {
         averageProgressPercent: 0,
       };
     }
-    
+
     return stats;
   }
   // @Authorized()
@@ -651,5 +653,63 @@ export class EnrollmentController {
         error.message || 'Failed to bulk update watchtime and progress',
       );
     }
+  }
+
+  @OpenAPI({
+    summary: 'Get all detailed enrollments for a user',
+    description:
+      'Retrieves a paginated list of all course enrollments for a user.',
+  })
+  @Authorized()
+  @Get('/enrollments/details')
+  @HttpCode(200)
+  @ResponseSchema(EnrollmentResponse, {
+    description: 'Paginated list of user enrollments',
+  })
+  @ResponseSchema(EnrollmentNotFoundErrorResponse, {
+    description: 'No enrollments found for the user',
+    statusCode: 404,
+  })
+  @ResponseSchema(BadRequestErrorResponse, {
+    description: 'Invalid page or limit parameters',
+    statusCode: 400,
+  })
+  async getUserEnrollmentsDetails(
+    @QueryParams() query: EnrollmentFilterQuery,
+    @Ability(getEnrollmentAbility) {user},
+    @Req() req: any,
+  ): Promise<EnrollmentResponse> {
+    const {page, limit, search = '', role} = query;
+    const userId = user._id.toString();
+    const skip = (page - 1) * limit;
+
+    // 🚀 Run DB queries in parallel
+    const [enrollments, totalDocuments] = await Promise.all([
+      this.enrollmentService.getDetailedEnrollments(
+        userId,
+        skip,
+        limit,
+        role,
+        search,
+      ),
+      this.enrollmentService.countEnrollments(userId, role, search),
+    ]);
+
+    if (!enrollments || enrollments.length === 0) {
+      return {
+        totalDocuments: 0,
+        totalPages: 0,
+        currentPage: page,
+        enrollments: [],
+        message: 'No enrollments found for the user',
+      };
+    }
+
+    return {
+      totalDocuments,
+      totalPages: Math.ceil(totalDocuments / limit),
+      currentPage: page,
+      enrollments,
+    };
   }
 }

--- a/backend/src/modules/users/controllers/EnrollmentController.ts
+++ b/backend/src/modules/users/controllers/EnrollmentController.ts
@@ -679,7 +679,7 @@ export class EnrollmentController {
     @Ability(getEnrollmentAbility) {user},
     @Req() req: any,
   ): Promise<EnrollmentResponse> {
-    const {page, limit, search = '', role} = query;
+    const {page, limit, search = '', role, courseVersionId} = query;
     const userId = user._id.toString();
     const skip = (page - 1) * limit;
 
@@ -691,8 +691,14 @@ export class EnrollmentController {
         limit,
         role,
         search,
+        courseVersionId,
       ),
-      this.enrollmentService.countEnrollments(userId, role, search),
+      this.enrollmentService.countEnrollments(
+        userId,
+        role,
+        search,
+        courseVersionId,
+      ),
     ]);
 
     if (!enrollments || enrollments.length === 0) {

--- a/backend/src/modules/users/controllers/EnrollmentController.ts
+++ b/backend/src/modules/users/controllers/EnrollmentController.ts
@@ -685,16 +685,14 @@ export class EnrollmentController {
 
     // 🚀 Run DB queries in parallel
     const [enrollments, totalDocuments] = await Promise.all([
-      this.enrollmentService.getDetailedEnrollments(
+      this.enrollmentService.getDetailedEnrollment(
         userId,
         role,
-        search,
         courseVersionId,
       ),
-      this.enrollmentService.countEnrollments(
+      this.enrollmentService.detailedCountEnrollment(
         userId,
         role,
-        search,
         courseVersionId,
       ),
     ]);

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -376,7 +376,7 @@ export class EnrollmentService extends BaseService {
       const allItemGroupIds = Array.from(versionToItemGroups.values()).flat();
 
       const quizInfo = await this.itemRepo.getQuizInfo(allItemGroupIds);
-      console.log(quizInfo[0]);
+
       // Extract actual quiz item IDs from quizInfo
       const allQuizIds = quizInfo
         .filter(quiz => quiz.items?._id)
@@ -435,7 +435,6 @@ export class EnrollmentService extends BaseService {
         // ratio is calculated as (watchedItems / totalItems) * 100
 
         const completedCount = watchedItemsMap.get(watchedKey) || 0;
-        console.log('completedCount==========================', completedCount);
 
         const ratio = completedCount / (enr.totalItems || 1); // avoid division by zero
         // const calculatedPercent = Math.floor(ratio * 100);
@@ -458,13 +457,10 @@ export class EnrollmentService extends BaseService {
 
           enr.percentCompleted = calculatedPercent;
           enr.completedItemsCount = completedCount;
-          console.log('enr=============== 1', enr);
         }
-        console.log('enr=============== 2', enr);
 
         if (enr.percentCompleted >= 0) {
           const itemCounts = enr.itemCounts || {};
-          console.log('enr=============== 3', enr);
 
           // const completedByType = {
           //   videos: 0,
@@ -571,7 +567,7 @@ export class EnrollmentService extends BaseService {
       const allItemGroupIds = Array.from(versionToItemGroups.values()).flat();
 
       const quizInfo = await this.itemRepo.getQuizInfo(allItemGroupIds);
-      console.log(quizInfo[0]);
+
       // Extract actual quiz item IDs from quizInfo
       const allQuizIds = quizInfo
         .filter(quiz => quiz.items?._id)

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -641,6 +641,10 @@ export class EnrollmentService extends BaseService {
             articles: 0,
             projects: 0,
           };
+          console.log(
+            'completedByType-----------------------------',
+            completedByType,
+          );
 
           return {
             _id: enr._id.toString(),

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -530,6 +530,7 @@ export class EnrollmentService extends BaseService {
     limit: number,
     role: EnrollmentRole,
     search: string,
+    courseVersionId?: string,
   ): Promise<EnrollmentDataResponse[]> {
     let enrollments = [];
     if (role === 'INSTRUCTOR') {
@@ -547,10 +548,18 @@ export class EnrollmentService extends BaseService {
         limit,
         role,
         search,
+        courseVersionId,
       );
     }
 
     if (!enrollments.length) return [];
+
+    //  If courseVersionId is provided, filter to only that version
+    if (courseVersionId) {
+      enrollments = enrollments.filter(
+        e => e.courseVersionId.toString() === courseVersionId,
+      );
+    }
 
     const enrolledVersionIds: Set<string> = new Set(
       enrollments.map(e => e.courseVersionId.toString()),
@@ -963,12 +972,18 @@ export class EnrollmentService extends BaseService {
     }
   }
 
-  async countEnrollments(userId: string, role: EnrollmentRole, search: string) {
+  async countEnrollments(
+    userId: string,
+    role: EnrollmentRole,
+    search: string,
+    courseVersionId?: string,
+  ) {
     return this._withTransaction(async (session: ClientSession) => {
       const result = await this.enrollmentRepo.countEnrollments(
         userId,
         role,
         search,
+        courseVersionId,
       );
       return result;
     });

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -629,7 +629,7 @@ export class EnrollmentService extends BaseService {
             status: enr.status,
             enrollmentDate: new Date(enr.enrollmentDate),
             course: this.filterCourseVersions(enr.course, enrolledVersionIds),
-            courseVersion: enr.courseVersion,
+            // courseVersion: enr.courseVersion,
             percentCompleted: enr.percentCompleted || 0,
             moduleNumber: enr.moduleNumber,
             sectionNumber: enr.sectionNumber,

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -313,10 +313,17 @@ export class EnrollmentService extends BaseService {
   private filterCourseVersions(course: any, enrolledVersionIds: Set<string>) {
     return {
       ...course,
-      versions:
-        course?.versions?.filter((versionId: string) =>
-          enrolledVersionIds.has(versionId.toString()),
-        ) || [],
+      versions: course?.versions
+        ? course.versions
+            .map((versionId: any) => {
+              // Convert ObjectId to string if needed
+              const versionIdStr = versionId.toString
+                ? versionId.toString()
+                : versionId;
+              return enrolledVersionIds.has(versionIdStr) ? versionIdStr : null;
+            })
+            .filter(Boolean) // Remove null values
+        : [],
     };
   }
 
@@ -481,7 +488,6 @@ export class EnrollmentService extends BaseService {
         }
       });
     }
-
     // Non-student
     return enrollments.map(enr => ({
       _id: enr._id.toString(),
@@ -623,6 +629,7 @@ export class EnrollmentService extends BaseService {
             status: enr.status,
             enrollmentDate: new Date(enr.enrollmentDate),
             course: this.filterCourseVersions(enr.course, enrolledVersionIds),
+            courseVersion: enr.courseVersion,
             percentCompleted: enr.percentCompleted || 0,
             moduleNumber: enr.moduleNumber,
             sectionNumber: enr.sectionNumber,
@@ -653,17 +660,6 @@ export class EnrollmentService extends BaseService {
         }
       });
     }
-
-    // Non-student
-    return enrollments.map(enr => ({
-      _id: enr._id.toString(),
-      courseId: enr.courseId.toString(),
-      courseVersionId: enr.courseVersionId.toString(),
-      role: enr.role,
-      status: enr.status,
-      enrollmentDate: new Date(enr.enrollmentDate),
-      course: this.filterCourseVersions(enr.course, enrolledVersionIds),
-    }));
   }
   async detailedCountEnrollment(
     userId: string,

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -526,31 +526,18 @@ export class EnrollmentService extends BaseService {
 
   public async getDetailedEnrollments(
     userId: string,
-    skip: number,
-    limit: number,
     role: EnrollmentRole,
     search: string,
     courseVersionId?: string,
   ): Promise<EnrollmentDataResponse[]> {
     let enrollments = [];
-    if (role === 'INSTRUCTOR') {
-      enrollments = await this.enrollmentRepo.getBasicInstructorEnrollments(
-        userId,
-        skip,
-        limit,
-        role,
-        search,
-      );
-    } else {
-      enrollments = await this.enrollmentRepo.getDetailedEnrollments(
-        userId,
-        skip,
-        limit,
-        role,
-        search,
-        courseVersionId,
-      );
-    }
+
+    enrollments = await this.enrollmentRepo.getDetailedEnrollments(
+      userId,
+      role,
+      search,
+      courseVersionId,
+    );
 
     if (!enrollments.length) return [];
 

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -460,15 +460,6 @@ export class EnrollmentService extends BaseService {
         }
 
         if (enr.percentCompleted >= 0) {
-          const itemCounts = enr.itemCounts || {};
-
-          // const completedByType = {
-          //   videos: 0,
-          //   quizzes: 0,
-          //   articles: 0,
-          //   projects: 0,
-          // };
-
           return {
             _id: enr._id.toString(),
             courseId: enr.courseId.toString(),
@@ -483,23 +474,6 @@ export class EnrollmentService extends BaseService {
             itemType: enr.itemType,
             contentCounts: {
               totalItems: enr.totalItems ?? 0,
-              videos: itemCounts.VIDEO ?? itemCounts.videos ?? 0,
-              quizzes: itemCounts.QUIZ ?? itemCounts.quizzes ?? 0,
-              articles: itemCounts.BLOG ?? itemCounts.articles ?? 0,
-              project: itemCounts.PROJECT ?? itemCounts.project ?? 0,
-              // totalQuizScore: enrollmentQuizGrades.reduce(
-              //   (sum, grade) => sum + (grade.totalScore || 0),
-              //   0,
-              // ),
-              // totalQuizMaxScore: enrollmentQuizGrades.reduce(
-              //   (sum, grade) => sum + (grade.totalMaxScore || 0),
-              //   0,
-              // ),
-              // Completed counts by type
-              // completedVideos: completedByType.videos,
-              // completedQuizzes: completedByType.quizzes,
-              // completedArticles: completedByType.articles,
-              // completedProjects: completedByType.projects,
             },
 
             completedItems: watchedItemsMap.get(watchedKey) || 0,

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -524,18 +524,16 @@ export class EnrollmentService extends BaseService {
     }));
   }
 
-  public async getDetailedEnrollments(
+  public async getDetailedEnrollment(
     userId: string,
     role: EnrollmentRole,
-    search: string,
     courseVersionId?: string,
   ): Promise<EnrollmentDataResponse[]> {
     let enrollments = [];
 
-    enrollments = await this.enrollmentRepo.getDetailedEnrollments(
+    enrollments = await this.enrollmentRepo.getDetailedEnrollment(
       userId,
       role,
-      search,
       courseVersionId,
     );
 
@@ -646,10 +644,6 @@ export class EnrollmentService extends BaseService {
             articles: 0,
             projects: 0,
           };
-          console.log(
-            'completedByType-----------------------------',
-            completedByType,
-          );
 
           return {
             _id: enr._id.toString(),
@@ -700,6 +694,20 @@ export class EnrollmentService extends BaseService {
       enrollmentDate: new Date(enr.enrollmentDate),
       course: this.filterCourseVersions(enr.course, enrolledVersionIds),
     }));
+  }
+  async detailedCountEnrollment(
+    userId: string,
+    role: EnrollmentRole,
+    courseVersionId?: string,
+  ) {
+    return this._withTransaction(async (session: ClientSession) => {
+      const result = await this.enrollmentRepo.detailedCountEnrollment(
+        userId,
+        role,
+        courseVersionId,
+      );
+      return result;
+    });
   }
 
   async getAllEnrollments(userId: string) {
@@ -962,7 +970,7 @@ export class EnrollmentService extends BaseService {
   async countEnrollments(
     userId: string,
     role: EnrollmentRole,
-    search: string,
+    search?: string,
     courseVersionId?: string,
   ) {
     return this._withTransaction(async (session: ClientSession) => {

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -389,48 +389,53 @@ export class EnrollmentService extends BaseService {
       }));
 
       // Batch all async operations together
-      const [watchedItemsMap, watchedItemsByTypeMap, quizSubmissionGrades]: [
+      const [
+        watchedItemsMap,
+        // watchedItemsByTypeMap,
+        quizSubmissionGrades,
+      ]: [
         Map<string, number>,
-        Map<
-          string,
-          {videos: number; quizzes: number; articles: number; projects: number}
-        >,
+        // Map<
+        //   string,
+        //   {videos: number; quizzes: number; articles: number; projects: number}
+        // >,
         ISubmission[],
       ] = await Promise.all([
         this.enrollmentRepo.getWatchedItemCountsBatch(watchedKeys),
-        this.enrollmentRepo.getWatchedItemCountsByTypeBatch(watchedKeys),
+        // this.enrollmentRepo.getWatchedItemCountsByTypeBatch(watchedKeys),
         allQuizIds.length > 0
           ? this.enrollmentRepo.getQuizSubmissionGrade(userId, allQuizIds)
           : Promise.resolve([]),
       ]);
 
       // Create a map for quick quiz grade lookup
-      const quizGradeMap: Map<string, IGradingResult> = new Map(
-        quizSubmissionGrades.map(grade => [
-          grade.quizId.toString(),
-          grade.gradingResult,
-        ]),
-      );
+      // const quizGradeMap: Map<string, IGradingResult> = new Map(
+      //   quizSubmissionGrades.map(grade => [
+      //     grade.quizId.toString(),
+      //     grade.gradingResult,
+      //   ]),
+      // );
 
       return enrollments.map(enr => {
         const versionIdStr = enr.courseVersionId.toString();
         const watchedKey = `${userId}-${enr.courseId.toString()}-${versionIdStr}`;
-        const versionItemGroups = versionToItemGroups.get(versionIdStr) || [];
-        const versionQuizIds = quizInfo.filter(quiz =>
-          versionItemGroups.includes(quiz._id.toString()),
-        );
+        // const versionItemGroups = versionToItemGroups.get(versionIdStr) || [];
+        // const versionQuizIds = quizInfo.filter(quiz =>
+        //   versionItemGroups.includes(quiz._id.toString()),
+        // );
 
         // Get quiz grades for this enrollment's quizzes
-        const enrollmentQuizGrades = versionQuizIds
-          .map(q =>
-            q.items?._id ? quizGradeMap.get(q.items._id.toString()) : null,
-          )
-          .filter(Boolean) as IGradingResult[];
+        // const enrollmentQuizGrades = versionQuizIds
+        //   .map(q =>
+        //     q.items?._id ? quizGradeMap.get(q.items._id.toString()) : null,
+        //   )
+        //   .filter(Boolean) as IGradingResult[];
 
         // update percentage if contentCountsMap / watchedItemsMap has different value from enrollment.percentCompleted
         // ratio is calculated as (watchedItems / totalItems) * 100
 
         const completedCount = watchedItemsMap.get(watchedKey) || 0;
+        console.log('completedCount==========================', completedCount);
 
         const ratio = completedCount / (enr.totalItems || 1); // avoid division by zero
         // const calculatedPercent = Math.floor(ratio * 100);
@@ -453,16 +458,20 @@ export class EnrollmentService extends BaseService {
 
           enr.percentCompleted = calculatedPercent;
           enr.completedItemsCount = completedCount;
+          console.log('enr=============== 1', enr);
         }
+        console.log('enr=============== 2', enr);
 
         if (enr.percentCompleted >= 0) {
           const itemCounts = enr.itemCounts || {};
-          const completedByType = watchedItemsByTypeMap.get(watchedKey) || {
-            videos: 0,
-            quizzes: 0,
-            articles: 0,
-            projects: 0,
-          };
+          console.log('enr=============== 3', enr);
+
+          // const completedByType = {
+          //   videos: 0,
+          //   quizzes: 0,
+          //   articles: 0,
+          //   projects: 0,
+          // };
 
           return {
             _id: enr._id.toString(),
@@ -482,19 +491,19 @@ export class EnrollmentService extends BaseService {
               quizzes: itemCounts.QUIZ ?? itemCounts.quizzes ?? 0,
               articles: itemCounts.BLOG ?? itemCounts.articles ?? 0,
               project: itemCounts.PROJECT ?? itemCounts.project ?? 0,
-              totalQuizScore: enrollmentQuizGrades.reduce(
-                (sum, grade) => sum + (grade.totalScore || 0),
-                0,
-              ),
-              totalQuizMaxScore: enrollmentQuizGrades.reduce(
-                (sum, grade) => sum + (grade.totalMaxScore || 0),
-                0,
-              ),
+              // totalQuizScore: enrollmentQuizGrades.reduce(
+              //   (sum, grade) => sum + (grade.totalScore || 0),
+              //   0,
+              // ),
+              // totalQuizMaxScore: enrollmentQuizGrades.reduce(
+              //   (sum, grade) => sum + (grade.totalMaxScore || 0),
+              //   0,
+              // ),
               // Completed counts by type
-              completedVideos: completedByType.videos,
-              completedQuizzes: completedByType.quizzes,
-              completedArticles: completedByType.articles,
-              completedProjects: completedByType.projects,
+              // completedVideos: completedByType.videos,
+              // completedQuizzes: completedByType.quizzes,
+              // completedArticles: completedByType.articles,
+              // completedProjects: completedByType.projects,
             },
 
             completedItems: watchedItemsMap.get(watchedKey) || 0,

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -1,36 +1,36 @@
-import { COURSES_TYPES } from '#courses/types.js';
-import { InviteStatus } from '#root/modules/notifications/index.js';
-import { BaseService } from '#root/shared/classes/BaseService.js';
-import { ICourseRepository } from '#root/shared/database/interfaces/ICourseRepository.js';
-import { IItemRepository } from '#root/shared/database/interfaces/IItemRepository.js';
-import { IUserRepository } from '#root/shared/database/interfaces/IUserRepository.js';
-import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {COURSES_TYPES} from '#courses/types.js';
+import {InviteStatus} from '#root/modules/notifications/index.js';
+import {BaseService} from '#root/shared/classes/BaseService.js';
+import {ICourseRepository} from '#root/shared/database/interfaces/ICourseRepository.js';
+import {IItemRepository} from '#root/shared/database/interfaces/IItemRepository.js';
+import {IUserRepository} from '#root/shared/database/interfaces/IUserRepository.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
 import {
   EnrollmentRole,
   EnrollmentStatus,
   ICourseVersion,
   IEnrollment,
 } from '#root/shared/interfaces/models.js';
-import { GLOBAL_TYPES } from '#root/types.js';
-import { EnrollmentRepository } from '#shared/database/providers/mongo/repositories/EnrollmentRepository.js';
-import { Enrollment } from '#users/classes/transformers/Enrollment.js';
-import { EnrollmentStats, USERS_TYPES } from '#users/types.js';
-import { injectable, inject } from 'inversify';
-import { ClientSession, ObjectId, OptionalId } from 'mongodb';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {EnrollmentRepository} from '#shared/database/providers/mongo/repositories/EnrollmentRepository.js';
+import {Enrollment} from '#users/classes/transformers/Enrollment.js';
+import {EnrollmentStats, USERS_TYPES} from '#users/types.js';
+import {injectable, inject} from 'inversify';
+import {ClientSession, ObjectId, OptionalId} from 'mongodb';
 import {
   BadRequestError,
   NotFoundError,
   InternalServerError,
 } from 'routing-controllers';
-import { ProgressService } from './ProgressService.js';
-import { ProgressRepository, InviteRepository } from '#root/shared/index.js';
-import { EnrollmentDataResponse } from '../classes/index.js';
+import {ProgressService} from './ProgressService.js';
+import {ProgressRepository, InviteRepository} from '#root/shared/index.js';
+import {EnrollmentDataResponse} from '../classes/index.js';
 import {
   QuizScoresExportResponseDto,
   StudentQuizScoreDto,
 } from '../dtos/QuizScoresExportDto.js';
-import { COURSE_REGISTRATION_TYPES } from '#root/modules/courseRegistration/types.js';
-import { ICourseRegistrationRepository } from '#root/shared/database/interfaces/ICourseRegistrationRepository.js';
+import {COURSE_REGISTRATION_TYPES} from '#root/modules/courseRegistration/types.js';
+import {ICourseRegistrationRepository} from '#root/shared/database/interfaces/ICourseRegistrationRepository.js';
 import {
   IGradingResult,
   ISubmission,
@@ -98,7 +98,7 @@ export class EnrollmentService extends BaseService {
       // }
 
       if (existingEnrollment && throughInvite) {
-        return { status: 'ALREADY_ENROLLED' as InviteStatus };
+        return {status: 'ALREADY_ENROLLED' as InviteStatus};
       }
 
       if (existingEnrollment && !throughInvite) {
@@ -275,7 +275,7 @@ export class EnrollmentService extends BaseService {
 
     // Process unenrollments in parallel with error handling
     await Promise.allSettled(
-      userIds.map(async (userId) => {
+      userIds.map(async userId => {
         try {
           const enrollment = await this.findActiveEnrollment(
             userId,
@@ -285,9 +285,7 @@ export class EnrollmentService extends BaseService {
 
           if (!enrollment) {
             results.failureCount++;
-            results.errors.push(
-              `User ${userId}: No active enrollment found`,
-            );
+            results.errors.push(`User ${userId}: No active enrollment found`);
             return;
           }
 
@@ -311,7 +309,6 @@ export class EnrollmentService extends BaseService {
 
     return results;
   }
-
 
   private filterCourseVersions(course: any, enrolledVersionIds: Set<string>) {
     return {
@@ -394,7 +391,10 @@ export class EnrollmentService extends BaseService {
       // Batch all async operations together
       const [watchedItemsMap, watchedItemsByTypeMap, quizSubmissionGrades]: [
         Map<string, number>,
-        Map<string, { videos: number; quizzes: number; articles: number; projects: number }>,
+        Map<
+          string,
+          {videos: number; quizzes: number; articles: number; projects: number}
+        >,
         ISubmission[],
       ] = await Promise.all([
         this.enrollmentRepo.getWatchedItemCountsBatch(watchedKeys),
@@ -457,7 +457,190 @@ export class EnrollmentService extends BaseService {
 
         if (enr.percentCompleted >= 0) {
           const itemCounts = enr.itemCounts || {};
-          const completedByType = watchedItemsByTypeMap.get(watchedKey) || { videos: 0, quizzes: 0, articles: 0, projects: 0 };
+          const completedByType = watchedItemsByTypeMap.get(watchedKey) || {
+            videos: 0,
+            quizzes: 0,
+            articles: 0,
+            projects: 0,
+          };
+
+          return {
+            _id: enr._id.toString(),
+            courseId: enr.courseId.toString(),
+            courseVersionId: versionIdStr,
+            role: enr.role,
+            status: enr.status,
+            enrollmentDate: new Date(enr.enrollmentDate),
+            course: this.filterCourseVersions(enr.course, enrolledVersionIds),
+            percentCompleted: enr.percentCompleted || 0,
+            moduleNumber: enr.moduleNumber,
+            sectionNumber: enr.sectionNumber,
+            itemType: enr.itemType,
+            contentCounts: {
+              totalItems: enr.totalItems ?? 0,
+              videos: itemCounts.VIDEO ?? itemCounts.videos ?? 0,
+              quizzes: itemCounts.QUIZ ?? itemCounts.quizzes ?? 0,
+              articles: itemCounts.BLOG ?? itemCounts.articles ?? 0,
+              project: itemCounts.PROJECT ?? itemCounts.project ?? 0,
+              totalQuizScore: enrollmentQuizGrades.reduce(
+                (sum, grade) => sum + (grade.totalScore || 0),
+                0,
+              ),
+              totalQuizMaxScore: enrollmentQuizGrades.reduce(
+                (sum, grade) => sum + (grade.totalMaxScore || 0),
+                0,
+              ),
+              // Completed counts by type
+              completedVideos: completedByType.videos,
+              completedQuizzes: completedByType.quizzes,
+              completedArticles: completedByType.articles,
+              completedProjects: completedByType.projects,
+            },
+
+            completedItems: watchedItemsMap.get(watchedKey) || 0,
+          };
+        }
+      });
+    }
+
+    // Non-student
+    return enrollments.map(enr => ({
+      _id: enr._id.toString(),
+      courseId: enr.courseId.toString(),
+      courseVersionId: enr.courseVersionId.toString(),
+      role: enr.role,
+      status: enr.status,
+      enrollmentDate: new Date(enr.enrollmentDate),
+      course: this.filterCourseVersions(enr.course, enrolledVersionIds),
+    }));
+  }
+
+  public async getDetailedEnrollments(
+    userId: string,
+    skip: number,
+    limit: number,
+    role: EnrollmentRole,
+    search: string,
+  ): Promise<EnrollmentDataResponse[]> {
+    let enrollments = [];
+    if (role === 'INSTRUCTOR') {
+      enrollments = await this.enrollmentRepo.getBasicInstructorEnrollments(
+        userId,
+        skip,
+        limit,
+        role,
+        search,
+      );
+    } else {
+      enrollments = await this.enrollmentRepo.getDetailedEnrollments(
+        userId,
+        skip,
+        limit,
+        role,
+        search,
+      );
+    }
+
+    if (!enrollments.length) return [];
+
+    const enrolledVersionIds: Set<string> = new Set(
+      enrollments.map(e => e.courseVersionId.toString()),
+    );
+
+    if (role === 'STUDENT') {
+      const courseVersions = await this.courseRepo.getActiveVersions(
+        Array.from(enrolledVersionIds),
+      );
+      const versionToItemGroups = new Map<string, string[]>();
+
+      courseVersions.forEach((version: ICourseVersion) => {
+        const itemGroupIds: string[] = [];
+        version.modules.forEach(module => {
+          module.sections.forEach(section => {
+            if (section.itemsGroupId) {
+              itemGroupIds.push(section.itemsGroupId.toString());
+            }
+          });
+        });
+        versionToItemGroups.set(version._id.toString(), itemGroupIds);
+      });
+
+      const allItemGroupIds = Array.from(versionToItemGroups.values()).flat();
+
+      const quizInfo = await this.itemRepo.getQuizInfo(allItemGroupIds);
+      console.log(quizInfo[0]);
+      // Extract actual quiz item IDs from quizInfo
+      const allQuizIds = quizInfo
+        .filter(quiz => quiz.items?._id)
+        .map(quiz => quiz.items._id.toString());
+
+      const watchedKeys = enrollments.map(e => ({
+        userId: new ObjectId(userId),
+        courseId: new ObjectId(e.courseId),
+        courseVersionId: new ObjectId(e.courseVersionId),
+      }));
+
+      // Batch all async operations together
+      const [watchedItemsMap, watchedItemsByTypeMap, quizSubmissionGrades]: [
+        Map<string, number>,
+        Map<
+          string,
+          {videos: number; quizzes: number; articles: number; projects: number}
+        >,
+        ISubmission[],
+      ] = await Promise.all([
+        this.enrollmentRepo.getWatchedItemCountsBatch(watchedKeys),
+        this.enrollmentRepo.getWatchedItemCountsByTypeBatch(watchedKeys),
+        allQuizIds.length > 0
+          ? this.enrollmentRepo.getQuizSubmissionGrade(userId, allQuizIds)
+          : Promise.resolve([]),
+      ]);
+      const quizGradeMap: Map<string, IGradingResult> = new Map(
+        quizSubmissionGrades.map(grade => [
+          grade.quizId.toString(),
+          grade.gradingResult,
+        ]),
+      );
+
+      return enrollments.map(enr => {
+        const versionIdStr = enr.courseVersionId.toString();
+        const watchedKey = `${userId}-${enr.courseId.toString()}-${versionIdStr}`;
+        const versionItemGroups = versionToItemGroups.get(versionIdStr) || [];
+        const versionQuizIds = quizInfo.filter(quiz =>
+          versionItemGroups.includes(quiz._id.toString()),
+        );
+
+        const enrollmentQuizGrades = versionQuizIds
+          .map(q =>
+            q.items?._id ? quizGradeMap.get(q.items._id.toString()) : null,
+          )
+          .filter(Boolean) as IGradingResult[];
+
+        const completedCount = watchedItemsMap.get(watchedKey) || 0;
+
+        const ratio = completedCount / (enr.totalItems || 1);
+        const calculatedPercent = Number((ratio * 100).toFixed(2));
+
+        if (enr.percentCompleted !== calculatedPercent) {
+          void this.enrollmentRepo.updateProgressPercentById(
+            enr._id.toString(),
+            calculatedPercent,
+            undefined,
+            completedCount,
+          );
+
+          enr.percentCompleted = calculatedPercent;
+          enr.completedItemsCount = completedCount;
+        }
+
+        if (enr.percentCompleted >= 0) {
+          const itemCounts = enr.itemCounts || {};
+          const completedByType = watchedItemsByTypeMap.get(watchedKey) || {
+            videos: 0,
+            quizzes: 0,
+            articles: 0,
+            projects: 0,
+          };
 
           return {
             _id: enr._id.toString(),
@@ -578,7 +761,6 @@ export class EnrollmentService extends BaseService {
       // }
 
       if (enrollmentsData.enrollments.length > 0 && filter === 'STUDENT') {
-
         // existing quiz score enrichment
         await this.enrichEnrollmentsWithQuizScores(
           enrollmentsData.enrollments,
@@ -601,10 +783,7 @@ export class EnrollmentService extends BaseService {
         const flattened = allStudentEnrollments.flat();
 
         // build lookup map
-        const contentCountsMap = new Map<
-          string,
-          any
-        >();
+        const contentCountsMap = new Map<string, any>();
 
         flattened.forEach(enr => {
           const key = `${enr.courseVersionId}-${enr._id}`;
@@ -617,7 +796,6 @@ export class EnrollmentService extends BaseService {
           enr.contentCounts = contentCountsMap.get(key);
         });
       }
-
 
       return enrollmentsData;
     });
@@ -774,7 +952,11 @@ export class EnrollmentService extends BaseService {
 
   async countEnrollments(userId: string, role: EnrollmentRole, search: string) {
     return this._withTransaction(async (session: ClientSession) => {
-      const result = await this.enrollmentRepo.countEnrollments(userId, role, search);
+      const result = await this.enrollmentRepo.countEnrollments(
+        userId,
+        role,
+        search,
+      );
       return result;
     });
   }
@@ -898,7 +1080,7 @@ export class EnrollmentService extends BaseService {
   async bulkUpdateAllEnrollments(
     courseId?: string,
     userId?: string,
-  ): Promise<{ totalCount: number; updatedCount: number }> {
+  ): Promise<{totalCount: number; updatedCount: number}> {
     const BATCH_SIZE = 5000;
 
     // 1. Get courses (all or specific one)
@@ -960,7 +1142,7 @@ export class EnrollmentService extends BaseService {
 
             bulkOperations.push({
               updateOne: {
-                filter: { _id: new ObjectId(enrollment._id) },
+                filter: {_id: new ObjectId(enrollment._id)},
                 update: {
                   $set: {
                     percentCompleted,
@@ -978,7 +1160,8 @@ export class EnrollmentService extends BaseService {
                 );
                 updatedCount += bulkOperations.length;
                 console.log(
-                  `✅ Batch ${++batchCount}: Updated ${bulkOperations.length
+                  `✅ Batch ${++batchCount}: Updated ${
+                    bulkOperations.length
                   } enrollments`,
                 );
                 bulkOperations.length = 0;
@@ -1013,7 +1196,7 @@ export class EnrollmentService extends BaseService {
       });
     }
 
-    return { totalCount, updatedCount };
+    return {totalCount, updatedCount};
   }
 
   async getNonStudentEnrollmentsByCourseVersion(
@@ -1026,7 +1209,7 @@ export class EnrollmentService extends BaseService {
     );
   }
   async bulkEnrollUsers(
-    existingEnrolledUsersWithRoles: { userId: string; role: EnrollmentRole }[],
+    existingEnrolledUsersWithRoles: {userId: string; role: EnrollmentRole}[],
     courseId: string,
     courseVersionId: string,
     session?: ClientSession,
@@ -1048,11 +1231,11 @@ export class EnrollmentService extends BaseService {
       const enrollmentsToCreate: OptionalId<IEnrollment>[] = [];
       const results: any[] = [];
 
-      for (const { userId, role } of existingEnrolledUsersWithRoles) {
+      for (const {userId, role} of existingEnrolledUsersWithRoles) {
         const userExists = await this.userRepo.findById(userId, session);
 
         if (!userExists) {
-          results.push({ userId, error: 'User not found' });
+          results.push({userId, error: 'User not found'});
           continue;
         }
         const existingEnrollment =
@@ -1129,7 +1312,7 @@ export class EnrollmentService extends BaseService {
   async bulkUpdateCompletedItemsCountParallelPerCourseVersion(
     courseId?: string,
     userId?: string,
-  ): Promise<{ totalCount: number; updatedCount: number }> {
+  ): Promise<{totalCount: number; updatedCount: number}> {
     const MAX_CONCURRENCY = 4;
 
     // 1. Load courses
@@ -1149,7 +1332,7 @@ export class EnrollmentService extends BaseService {
     let index = 0;
 
     // 🔑 THIS is the Safe Alternative
-    const results: { totalCount: number; updatedCount: number }[] = [];
+    const results: {totalCount: number; updatedCount: number}[] = [];
 
     // 3. Worker
     const worker = async () => {
@@ -1159,7 +1342,7 @@ export class EnrollmentService extends BaseService {
 
         const result =
           await this.enrollmentRepo.bulkUpdateCompletedItemsCountForCourseVersion(
-            { courseVersionId, courseId, userId },
+            {courseVersionId, courseId, userId},
           );
 
         // ✅ push result instead of mutating shared counters
@@ -1168,7 +1351,7 @@ export class EnrollmentService extends BaseService {
     };
 
     // 4. Start workers
-    const workers = Array.from({ length: MAX_CONCURRENCY }, () => worker());
+    const workers = Array.from({length: MAX_CONCURRENCY}, () => worker());
 
     await Promise.all(workers);
 
@@ -1176,6 +1359,6 @@ export class EnrollmentService extends BaseService {
     const totalCount = results.reduce((sum, r) => sum + r.totalCount, 0);
     const updatedCount = results.reduce((sum, r) => sum + r.updatedCount, 0);
 
-    return { totalCount, updatedCount };
+    return {totalCount, updatedCount};
   }
 }

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -506,7 +506,7 @@ export class EnrollmentRepository {
         .aggregate(aggregationPipeline, {session})
         .toArray();
     } catch (error) {
-      console.log(error);
+      console.error(error);
       throw new InternalServerError(`Failed to get enrollments /More ${error}`);
     }
   }
@@ -1186,7 +1186,6 @@ export class EnrollmentRepository {
       const key = `${doc._id.userId.toString()}-${doc._id.courseId.toString()}-${doc._id.courseVersionId.toString()}`;
       map.set(key, doc.count);
     }
-    console.log('MAPPP============getWatchedItemCountsBatch', map);
 
     return map;
   }
@@ -1232,41 +1231,26 @@ export class EnrollmentRepository {
       ])
       .toArray();
 
-    console.log('📊 watchedItems count:', watchedItems.length); // ADD THIS
-    console.log('📊 Sample watchedItem:', watchedItems[0]); // ADD THIS
-
     if (watchedItems.length === 0) {
       return new Map();
     }
 
     const allItemIds = [...new Set(watchedItems.map(w => w._id.itemId))];
-    console.log('📊 allItemIds sample:', allItemIds.slice(0, 3));
 
-    console.log(
-      '📊 allItemIds type check:',
-      allItemIds[0],
-      typeof allItemIds[0],
-    );
-
-    console.log('📊 Unique itemIds to lookup:', allItemIds.length);
     const itemsGroupCollection = await this.db.getCollection('itemsGroup');
 
     // ADD THIS: Check what format items._id is actually stored in
     const sampleDirectQuery = await itemsGroupCollection.findOne({
       'items._id': allItemIds[0],
     });
-    console.log('📊 Direct ObjectId match:', sampleDirectQuery?._id);
+
     const sampleStringQuery = await itemsGroupCollection.findOne({
       'items._id': allItemIds[0].toString(),
     });
-    console.log('📊 Direct String match:', sampleStringQuery?._id);
+
     // Check what the actual structure looks like
     const sampleItem = await itemsGroupCollection.findOne({});
-    console.log('📊 Sample itemsGroup structure:', {
-      _id: sampleItem?._id,
-      firstItem: sampleItem?.items?.[0],
-      itemIdType: typeof sampleItem?.items?.[0]?._id,
-    });
+
     const itemTypeResults = await itemsGroupCollection
       .aggregate([
         {$unwind: '$items'},
@@ -1281,18 +1265,12 @@ export class EnrollmentRepository {
         {$project: {itemId: {$toString: '$items._id'}, type: '$items.type'}},
       ])
       .toArray();
-    console.log('📊 itemTypeResults found:', itemTypeResults.length); // ADD THIS
-    console.log('📊 Sample itemTypeResult:', itemTypeResults[0]); // ADD THIS
 
     const itemTypeMap = new Map<string, string>();
     for (const item of itemTypeResults) {
       itemTypeMap.set(item.itemId, item.type);
     }
-    console.log('📊 itemTypeMap size:', itemTypeMap.size); // ADD THIS
-    console.log(
-      '📊 Sample types:',
-      Array.from(itemTypeMap.entries()).slice(0, 3),
-    );
+
     const map = new Map<
       string,
       {videos: number; quizzes: number; articles: number; projects: number}
@@ -1324,10 +1302,6 @@ export class EnrollmentRepository {
           break;
       }
     }
-    console.log('📊 Final map keys:', Array.from(map.keys())); // ADD THIS
-    console.log('📊 Final map values:', Array.from(map.values())); // ADD THIS
-
-    console.log('MAPPP============getWatchedItemCountsBatch', map);
 
     return map;
   }
@@ -1716,7 +1690,7 @@ export class EnrollmentRepository {
       // await this.enrollmentCollection.createIndex({ courseVersionId: 1 });
       // await this.enrollmentCollection.createIndex({ enrollmentDate: -1 });
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
   }
 
@@ -2994,14 +2968,6 @@ export class EnrollmentRepository {
   ) {
     await this.init();
     const userObjectId = new ObjectId(userId);
-    console.log(
-      '🔍🔍 getDetailedEnrollments called with:;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;',
-      {
-        userId,
-        role,
-        courseVersionId,
-      },
-    );
     const matchStage: any = {
       userId: userObjectId,
       role,

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -1608,17 +1608,24 @@ export class EnrollmentRepository {
     userId: string,
     role: EnrollmentRole,
     search?: string,
+    courseVersionId?: string,
   ) {
     await this.init();
+    const matchStage: any = {
+      userId: new ObjectId(userId),
+      role,
+      isDeleted: {$ne: true},
+      status: {$regex: /^active$/i},
+    };
+
+    // Add courseVersionId filter if provided
+    if (courseVersionId) {
+      matchStage.courseVersionId = new ObjectId(courseVersionId);
+    }
 
     const pipeline: any[] = [
       {
-        $match: {
-          userId: new ObjectId(userId),
-          role,
-          isDeleted: {$ne: true},
-          status: {$regex: /^active$/i},
-        },
+        $match: matchStage,
       },
 
       {
@@ -2986,17 +2993,34 @@ export class EnrollmentRepository {
     limit: number,
     role: EnrollmentRole,
     search: string,
+    courseVersionId?: string,
   ) {
     await this.init();
     const userObjectId = new ObjectId(userId);
+    console.log(
+      '🔍🔍 getDetailedEnrollments called with:;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;',
+      {
+        userId,
+        role,
+        search,
+        courseVersionId,
+      },
+    );
+    const matchStage: any = {
+      userId: userObjectId,
+      role,
+      isDeleted: {$ne: true},
+      status: {$regex: /^active$/i},
+    };
+
+    // ✅ Add courseVersionId filter if provided
+    if (courseVersionId) {
+      matchStage.courseVersionId = new ObjectId(courseVersionId);
+    }
+
     const pipeline: any[] = [
       {
-        $match: {
-          userId: userObjectId,
-          role,
-          isDeleted: {$ne: true},
-          status: {$regex: /^active$/i},
-        },
+        $match: matchStage,
       },
 
       {$sort: {enrollmentDate: -1}},

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -1186,6 +1186,7 @@ export class EnrollmentRepository {
       const key = `${doc._id.userId.toString()}-${doc._id.courseId.toString()}-${doc._id.courseVersionId.toString()}`;
       map.set(key, doc.count);
     }
+    console.log('MAPPP============getWatchedItemCountsBatch', map);
 
     return map;
   }
@@ -1212,7 +1213,7 @@ export class EnrollmentRepository {
       courseVersionId: e.courseVersionId,
       isHidden: {$ne: true},
       isDeleted: {$ne: true},
-      // endTime: {$exists: true, $ne: null},
+      endTime: {$exists: true, $ne: null},
     }));
 
     const watchedItems = await this.watchTimeCollection
@@ -1325,6 +1326,8 @@ export class EnrollmentRepository {
     }
     console.log('📊 Final map keys:', Array.from(map.keys())); // ADD THIS
     console.log('📊 Final map values:', Array.from(map.values())); // ADD THIS
+
+    console.log('MAPPP============getWatchedItemCountsBatch', map);
 
     return map;
   }

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -3037,12 +3037,37 @@ export class EnrollmentRepository {
                 name: 1,
                 description: 1,
                 updatedAt: 1,
+                versions: 1,
               },
             },
           ],
         },
       },
       {$unwind: '$course'},
+      /* ---------------- ADD NEW LOOKUP FOR VERSION DETAILS ---------------- */
+      {
+        $lookup: {
+          from: 'newCourseVersion',
+          let: {versionIds: '$course.versions'},
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $in: ['$_id', '$$versionIds'],
+                },
+              },
+            },
+            {
+              $project: {
+                _id: 1,
+                version: 1,
+                description: 1,
+              },
+            },
+          ],
+          as: 'course.versionDetails',
+        },
+      },
 
       /* ---------------- COURSE VERSION LOOKUP (NEW) ---------------- */
       {

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -2989,8 +2989,6 @@ export class EnrollmentRepository {
 
   async getDetailedEnrollments(
     userId: string,
-    skip: number,
-    limit: number,
     role: EnrollmentRole,
     search: string,
     courseVersionId?: string,
@@ -3105,12 +3103,8 @@ export class EnrollmentRepository {
       },
 
       {$unwind: {path: '$courseVersion', preserveNullAndEmptyArrays: true}},
-      {$skip: skip},
-      {$limit: limit},
+
       /* ---------------- SEARCH ---------------- */
-      ...(search?.trim()
-        ? [{$match: {'course.name': {$regex: search, $options: 'i'}}}]
-        : []),
       //i have converted the id(object form right) to string
       {
         $addFields: {

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -1212,7 +1212,7 @@ export class EnrollmentRepository {
       courseVersionId: e.courseVersionId,
       isHidden: {$ne: true},
       isDeleted: {$ne: true},
-      endTime: {$exists: true, $ne: null},
+      // endTime: {$exists: true, $ne: null},
     }));
 
     const watchedItems = await this.watchTimeCollection
@@ -1231,45 +1231,67 @@ export class EnrollmentRepository {
       ])
       .toArray();
 
+    console.log('📊 watchedItems count:', watchedItems.length); // ADD THIS
+    console.log('📊 Sample watchedItem:', watchedItems[0]); // ADD THIS
+
     if (watchedItems.length === 0) {
       return new Map();
     }
 
     const allItemIds = [...new Set(watchedItems.map(w => w._id.itemId))];
+    console.log('📊 allItemIds sample:', allItemIds.slice(0, 3));
 
+    console.log(
+      '📊 allItemIds type check:',
+      allItemIds[0],
+      typeof allItemIds[0],
+    );
+
+    console.log('📊 Unique itemIds to lookup:', allItemIds.length);
     const itemsGroupCollection = await this.db.getCollection('itemsGroup');
+
+    // ADD THIS: Check what format items._id is actually stored in
+    const sampleDirectQuery = await itemsGroupCollection.findOne({
+      'items._id': allItemIds[0],
+    });
+    console.log('📊 Direct ObjectId match:', sampleDirectQuery?._id);
+    const sampleStringQuery = await itemsGroupCollection.findOne({
+      'items._id': allItemIds[0].toString(),
+    });
+    console.log('📊 Direct String match:', sampleStringQuery?._id);
+    // Check what the actual structure looks like
+    const sampleItem = await itemsGroupCollection.findOne({});
+    console.log('📊 Sample itemsGroup structure:', {
+      _id: sampleItem?._id,
+      firstItem: sampleItem?.items?.[0],
+      itemIdType: typeof sampleItem?.items?.[0]?._id,
+    });
     const itemTypeResults = await itemsGroupCollection
       .aggregate([
         {$unwind: '$items'},
         {
           $match: {
             $or: [
-              {'items._id': {$in: allItemIds}},
-              {
-                'items._id': {
-                  $in: allItemIds
-                    .map(id => {
-                      try {
-                        return new ObjectId(id as string);
-                      } catch {
-                        return null;
-                      }
-                    })
-                    .filter(Boolean),
-                },
-              },
+              {'items._id': {$in: allItemIds}}, // ObjectId match
+              {'items._id': {$in: allItemIds.map(id => id.toString())}}, // String match
             ],
           },
         },
         {$project: {itemId: {$toString: '$items._id'}, type: '$items.type'}},
       ])
       .toArray();
+    console.log('📊 itemTypeResults found:', itemTypeResults.length); // ADD THIS
+    console.log('📊 Sample itemTypeResult:', itemTypeResults[0]); // ADD THIS
 
     const itemTypeMap = new Map<string, string>();
     for (const item of itemTypeResults) {
       itemTypeMap.set(item.itemId, item.type);
     }
-
+    console.log('📊 itemTypeMap size:', itemTypeMap.size); // ADD THIS
+    console.log(
+      '📊 Sample types:',
+      Array.from(itemTypeMap.entries()).slice(0, 3),
+    );
     const map = new Map<
       string,
       {videos: number; quizzes: number; articles: number; projects: number}
@@ -1301,6 +1323,8 @@ export class EnrollmentRepository {
           break;
       }
     }
+    console.log('📊 Final map keys:', Array.from(map.keys())); // ADD THIS
+    console.log('📊 Final map values:', Array.from(map.values())); // ADD THIS
 
     return map;
   }

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -3233,7 +3233,7 @@ export class EnrollmentRepository {
           sectionNumber: '$sectionNumber',
           itemType: '$currentItemObj.type',
 
-          // 🔥 pulled from courseVersion
+          // pulled from courseVersion
           totalItems: {$ifNull: ['$courseVersion.totalItems', 0]},
           itemCounts: {$ifNull: ['$courseVersion.itemCounts', {}]},
 

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -8,12 +8,12 @@ import {
   IUser,
   ID,
 } from '#shared/interfaces/models.js';
-import { injectable, inject } from 'inversify';
-import { ClientSession, Collection, ObjectId, OptionalId } from 'mongodb';
-import { InternalServerError, NotFoundError } from 'routing-controllers';
-import { MongoDatabase } from '../MongoDatabase.js';
-import { GLOBAL_TYPES } from '#root/types.js';
-import { EnrollmentStats } from '#root/modules/users/types.js';
+import {injectable, inject} from 'inversify';
+import {ClientSession, Collection, ObjectId, OptionalId} from 'mongodb';
+import {InternalServerError, NotFoundError} from 'routing-controllers';
+import {MongoDatabase} from '../MongoDatabase.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {EnrollmentStats} from '#root/modules/users/types.js';
 import {
   StudentQuizScoreDto,
   QuizScoresExportResponseDto,
@@ -22,10 +22,10 @@ import {
   IAttempt,
   ISubmission,
 } from '#root/modules/quizzes/interfaces/grading.js';
-import { ItemsGroup, QuizItem } from '#root/modules/courses/classes/index.js';
-import { AttemptRepository } from '#root/modules/quizzes/repositories/index.js';
-import { QUIZZES_TYPES } from '#root/modules/quizzes/types.js';
-import { IQuestionBank } from '#root/shared/interfaces/quiz.js';
+import {ItemsGroup, QuizItem} from '#root/modules/courses/classes/index.js';
+import {AttemptRepository} from '#root/modules/quizzes/repositories/index.js';
+import {QUIZZES_TYPES} from '#root/modules/quizzes/types.js';
+import {IQuestionBank} from '#root/shared/interfaces/quiz.js';
 
 @injectable()
 export class EnrollmentRepository {
@@ -43,7 +43,7 @@ export class EnrollmentRepository {
     @inject(QUIZZES_TYPES.AttemptRepo)
     private attemptRepository: AttemptRepository,
     @inject(GLOBAL_TYPES.Database) private db: MongoDatabase,
-  ) { }
+  ) {}
 
   private async init() {
     this.enrollmentCollection =
@@ -72,7 +72,7 @@ export class EnrollmentRepository {
   async findById(id: string): Promise<IEnrollment | null> {
     await this.init();
     try {
-      return await this.enrollmentCollection.findOne({ _id: new ObjectId(id) });
+      return await this.enrollmentCollection.findOne({_id: new ObjectId(id)});
     } catch (error) {
       console.error('Error finding enrollment by ID:', error);
       throw error;
@@ -97,9 +97,9 @@ export class EnrollmentRepository {
         userId: userObjectid,
         courseId: courseObjectId,
         courseVersionId: courseVersionObjectId,
-        isDeleted: { $ne: true },
+        isDeleted: {$ne: true},
       },
-      { session },
+      {session},
     );
   }
 
@@ -121,9 +121,9 @@ export class EnrollmentRepository {
         courseId: courseObjectId,
         courseVersionId: courseVersionObjectId,
         status: 'ACTIVE',
-        isDeleted: { $ne: true },
+        isDeleted: {$ne: true},
       },
-      { session },
+      {session},
     );
   }
 
@@ -142,7 +142,7 @@ export class EnrollmentRepository {
           role: 'INSTRUCTOR',
           status: 'ACTIVE',
         },
-        { projection: { userId: 1, _id: 0 }, session }, // only return userId
+        {projection: {userId: 1, _id: 0}, session}, // only return userId
       )
       .toArray();
     return enrollments.map(enrollment => enrollment.userId);
@@ -156,15 +156,15 @@ export class EnrollmentRepository {
   ): Promise<void> {
     try {
       await this.init();
-      const update: any = { percentCompleted };
+      const update: any = {percentCompleted};
       if (typeof completedItemsCount === 'number') {
         update.completedItemsCount = completedItemsCount;
       }
 
       await this.enrollmentCollection.findOneAndUpdate(
-        { _id: new ObjectId(enrollmentId) },
-        { $set: update },
-        { session },
+        {_id: new ObjectId(enrollmentId)},
+        {$set: update},
+        {session},
       );
     } catch (error) {
       throw new InternalServerError(
@@ -181,9 +181,9 @@ export class EnrollmentRepository {
     try {
       await this.init();
       await this.enrollmentCollection.findOneAndUpdate(
-        { _id: new ObjectId(enrollmentId) },
-        { $set: { completedItemsCount, updatedAt: new Date() } },
-        { session },
+        {_id: new ObjectId(enrollmentId)},
+        {$set: {completedItemsCount, updatedAt: new Date()}},
+        {session},
       );
     } catch (error) {
       throw new InternalServerError(
@@ -211,7 +211,7 @@ export class EnrollmentRepository {
         {
           _id: result.insertedId,
         },
-        { session },
+        {session},
       );
 
       if (!newEnrollment) {
@@ -246,7 +246,7 @@ export class EnrollmentRepository {
     const result = await this.enrollmentCollection.updateOne(
       {
         _id: enrollmentObjectId,
-        userId: { $in: userFilter },
+        userId: {$in: userFilter},
         courseId: courseObjectId,
         courseVersionId: courseVersionObjectId,
       },
@@ -258,7 +258,7 @@ export class EnrollmentRepository {
           unenrolledAt: new Date(),
         },
       },
-      { session },
+      {session},
     );
     if (result.modifiedCount === 0) {
       throw new NotFoundError('Enrollment not found to delete');
@@ -285,7 +285,7 @@ export class EnrollmentRepository {
         {
           _id: result.insertedId,
         },
-        { session },
+        {session},
       );
 
       if (!newProgress) {
@@ -313,8 +313,8 @@ export class EnrollmentRepository {
         courseId: new ObjectId(courseId),
         courseVersionId: new ObjectId(courseVersionId),
       },
-      { $set: { isDeleted: true, deletedAt: new Date() } },
-      { session },
+      {$set: {isDeleted: true, deletedAt: new Date()}},
+      {session},
     );
   }
 
@@ -335,30 +335,30 @@ export class EnrollmentRepository {
           $match: {
             userId: userObjectId,
             role,
-            isDeleted: { $ne: true },
+            isDeleted: {$ne: true},
             status: 'ACTIVE',
           },
         },
-        { $sort: { enrollmentDate: -1 } },
-        { $skip: skip },
-        { $limit: limit },
+        {$sort: {enrollmentDate: -1}},
+        {$skip: skip},
+        {$limit: limit},
         {
           $lookup: {
             from: 'newCourse',
             localField: 'courseId',
             foreignField: '_id',
             as: 'course',
-            pipeline: [{ $project: { name: 1, versions: 1 } }],
+            pipeline: [{$project: {name: 1, versions: 1}}],
           },
         },
-        { $unwind: { path: '$course', preserveNullAndEmptyArrays: true } },
+        {$unwind: {path: '$course', preserveNullAndEmptyArrays: true}},
         // Lookup content counts (optimized)
         {
           $lookup: {
             from: 'newCourseVersion',
-            let: { versionId: '$courseVersionId' },
+            let: {versionId: '$courseVersionId'},
             pipeline: [
-              { $match: { $expr: { $eq: ['$_id', '$$versionId'] } } },
+              {$match: {$expr: {$eq: ['$_id', '$$versionId']}}},
               {
                 $project: {
                   itemGroupIds: {
@@ -377,15 +377,15 @@ export class EnrollmentRepository {
                         },
                       },
                       initialValue: [],
-                      in: { $concatArrays: ['$$value', '$$this'] },
+                      in: {$concatArrays: ['$$value', '$$this']},
                     },
                   },
                 },
               },
-              { $unwind: '$itemGroupIds' },
+              {$unwind: '$itemGroupIds'},
               {
                 $addFields: {
-                  itemGroupObjId: { $toObjectId: '$itemGroupIds' },
+                  itemGroupObjId: {$toObjectId: '$itemGroupIds'},
                 },
               },
               {
@@ -396,26 +396,26 @@ export class EnrollmentRepository {
                   as: 'itemsGroup',
                 },
               },
-              { $unwind: '$itemsGroup' },
-              { $unwind: '$itemsGroup.items' },
+              {$unwind: '$itemsGroup'},
+              {$unwind: '$itemsGroup.items'},
               {
                 $group: {
                   _id: '$_id',
-                  totalItems: { $sum: 1 },
+                  totalItems: {$sum: 1},
                   videos: {
                     $sum: {
-                      $cond: [{ $eq: ['$itemsGroup.items.type', 'VIDEO'] }, 1, 0],
+                      $cond: [{$eq: ['$itemsGroup.items.type', 'VIDEO']}, 1, 0],
                     },
                   },
                   quizzes: {
                     $sum: {
-                      $cond: [{ $eq: ['$itemsGroup.items.type', 'QUIZ'] }, 1, 0],
+                      $cond: [{$eq: ['$itemsGroup.items.type', 'QUIZ']}, 1, 0],
                     },
                   },
                   articles: {
                     $sum: {
                       $cond: [
-                        { $eq: ['$itemsGroup.items.type', 'ARTICLE'] },
+                        {$eq: ['$itemsGroup.items.type', 'ARTICLE']},
                         1,
                         0,
                       ],
@@ -431,8 +431,8 @@ export class EnrollmentRepository {
           $set: {
             contentCounts: {
               $ifNull: [
-                { $arrayElemAt: ['$contentCounts', 0] },
-                { totalItems: 0, videos: 0, quizzes: 0, articles: 0 },
+                {$arrayElemAt: ['$contentCounts', 0]},
+                {totalItems: 0, videos: 0, quizzes: 0, articles: 0},
               ],
             },
           },
@@ -451,9 +451,9 @@ export class EnrollmentRepository {
                 $match: {
                   $expr: {
                     $and: [
-                      { $eq: ['$userId', '$$userId'] },
-                      { $eq: ['$courseId', '$$courseId'] },
-                      { $eq: ['$courseVersionId', '$$courseVersionId'] },
+                      {$eq: ['$userId', '$$userId']},
+                      {$eq: ['$courseId', '$$courseId']},
+                      {$eq: ['$courseVersionId', '$$courseVersionId']},
                     ],
                   },
                 },
@@ -461,7 +461,7 @@ export class EnrollmentRepository {
               {
                 $group: {
                   _id: null,
-                  distinctItemIds: { $addToSet: '$itemId' },
+                  distinctItemIds: {$addToSet: '$itemId'},
                 },
               },
             ],
@@ -473,29 +473,29 @@ export class EnrollmentRepository {
             watchedItemCount: {
               $size: {
                 $ifNull: [
-                  { $arrayElemAt: ['$watchedItems.distinctItemIds', 0] },
+                  {$arrayElemAt: ['$watchedItems.distinctItemIds', 0]},
                   [],
                 ],
               },
             },
           },
         },
-        { $unset: 'watchedItems' },
+        {$unset: 'watchedItems'},
         // Only add search filter if search is provided
         ...(search && search.trim()
-          ? [{ $match: { 'course.name': { $regex: search, $options: 'i' } } }]
+          ? [{$match: {'course.name': {$regex: search, $options: 'i'}}}]
           : []),
         // Project only required fields
         {
           $project: {
-            _id: { $toString: '$_id' },
-            courseId: { $toString: '$courseId' },
-            courseVersionId: { $toString: '$courseVersionId' },
+            _id: {$toString: '$_id'},
+            courseId: {$toString: '$courseId'},
+            courseVersionId: {$toString: '$courseVersionId'},
             role: 1,
             status: 1,
             enrollmentDate: 1,
             course: 1,
-            percentCompleted: { $ifNull: ['$percentCompleted', 0] },
+            percentCompleted: {$ifNull: ['$percentCompleted', 0]},
             contentCounts: 1,
             watchedItemCount: 1,
           },
@@ -503,7 +503,7 @@ export class EnrollmentRepository {
       ];
 
       return await this.enrollmentCollection
-        .aggregate(aggregationPipeline, { session })
+        .aggregate(aggregationPipeline, {session})
         .toArray();
     } catch (error) {
       console.log(error);
@@ -525,51 +525,49 @@ export class EnrollmentRepository {
         $match: {
           userId: userObjectId,
           role,
-          isDeleted: { $ne: true },
-          status: { $regex: /^active$/i },
+          isDeleted: {$ne: true},
+          status: {$regex: /^active$/i},
         },
       },
 
-      { $sort: { enrollmentDate: -1 } },
+      {$sort: {enrollmentDate: -1}},
       //from progress
       {
         $lookup: {
           from: 'progress',
           let: {
-            userId: "$userId",
-            courseId: "$courseId",
-            courseVersionId: "$courseVersionId",
-
+            userId: '$userId',
+            courseId: '$courseId',
+            courseVersionId: '$courseVersionId',
           },
           pipeline: [
             {
               $match: {
                 $expr: {
                   $and: [
-                    { $eq: ["$userId", "$$userId"] },
-                    { $eq: ["$courseId", "$$courseId"] },
-                    { $eq: ["$courseVersionId", "$$courseVersionId"] },
-                    { $eq: ["$status", "active"] }
-                  ]
-                }
-              }
+                    {$eq: ['$userId', '$$userId']},
+                    {$eq: ['$courseId', '$$courseId']},
+                    {$eq: ['$courseVersionId', '$$courseVersionId']},
+                    {$eq: ['$status', 'active']},
+                  ],
+                },
+              },
             },
             {
               $project: {
                 currentModule: 1,
                 currentSection: 1,
-                currentItem: 1
-              }
-            }
+                currentItem: 1,
+              },
+            },
           ],
-          as: "progress",
-        }
+          as: 'progress',
+        },
       },
       // {$unwind: '$progress'},
       {
-        $unwind: { path: "$progress", preserveNullAndEmptyArrays: true },
+        $unwind: {path: '$progress', preserveNullAndEmptyArrays: true},
       },
-
 
       /* ---------------- COURSE LOOKUP ---------------- */
       {
@@ -589,7 +587,7 @@ export class EnrollmentRepository {
           ],
         },
       },
-      { $unwind: '$course' },
+      {$unwind: '$course'},
 
       /* ---------------- COURSE VERSION LOOKUP (NEW) ---------------- */
       {
@@ -602,7 +600,7 @@ export class EnrollmentRepository {
             {
               $project: {
                 totalItems: 1,
-                itemCounts: 1,
+                // itemCounts: 1,
                 supportLink: 1,
                 version: 1,
                 description: 1,
@@ -613,41 +611,40 @@ export class EnrollmentRepository {
         },
       },
 
-      { $unwind: { path: '$courseVersion', preserveNullAndEmptyArrays: true } },
-      { $skip: skip },
-      { $limit: limit },
+      {$unwind: {path: '$courseVersion', preserveNullAndEmptyArrays: true}},
+      {$skip: skip},
+      {$limit: limit},
       /* ---------------- SEARCH ---------------- */
       ...(search?.trim()
-        ? [{ $match: { 'course.name': { $regex: search, $options: 'i' } } }]
+        ? [{$match: {'course.name': {$regex: search, $options: 'i'}}}]
         : []),
       //i have converted the id(object form right) to string
       {
         $addFields: {
-          currentModuleStr: { $toString: "$progress.currentModule" },
-          currentSectionStr: { $toString: "$progress.currentSection" },
-          currentItemStr: { $toString: "$progress.currentItem" }
-        }
+          currentModuleStr: {$toString: '$progress.currentModule'},
+          currentSectionStr: {$toString: '$progress.currentSection'},
+          currentItemStr: {$toString: '$progress.currentItem'},
+        },
       },
       //getting items group for current section id
       {
-
         $lookup: {
-          from: "itemsGroup",
+          from: 'itemsGroup',
           let: {
-            sectionId: "$progress.currentSection"
+            sectionId: '$progress.currentSection',
           },
           pipeline: [
             {
               $match: {
-                $expr: { $eq: ["$sectionId", "$$sectionId"] }
-              }
+                $expr: {$eq: ['$sectionId', '$$sectionId']},
+              },
             },
             {
-              $project: { items: 1 }
-            }
+              $project: {items: 1},
+            },
           ],
-          as: "itemsGroup"
-        }
+          as: 'itemsGroup',
+        },
       },
       //getting item object from items group to get type.
       {
@@ -657,17 +654,17 @@ export class EnrollmentRepository {
               $filter: {
                 input: {
                   $reduce: {
-                    input: "$itemsGroup",
+                    input: '$itemsGroup',
                     initialValue: [],
-                    in: { $concatArrays: ["$$value", "$$this.items"] }
-                  }
+                    in: {$concatArrays: ['$$value', '$$this.items']},
+                  },
                 },
-                as: "i",
-                cond: { $eq: [{ $toString: "$$i._id" }, "$currentItemStr"] }
-              }
-            }
-          }
-        }
+                as: 'i',
+                cond: {$eq: [{$toString: '$$i._id'}, '$currentItemStr']},
+              },
+            },
+          },
+        },
       },
       //accessing current module
 
@@ -676,13 +673,13 @@ export class EnrollmentRepository {
           currentModuleObj: {
             $first: {
               $filter: {
-                input: "$courseVersion.modules",
-                as: "m",
-                cond: { $eq: [{ $toString: "$$m.moduleId" }, "$currentModuleStr"] }
-              }
-            }
-          }
-        }
+                input: '$courseVersion.modules',
+                as: 'm',
+                cond: {$eq: [{$toString: '$$m.moduleId'}, '$currentModuleStr']},
+              },
+            },
+          },
+        },
       },
       {
         $addFields: {
@@ -692,18 +689,18 @@ export class EnrollmentRepository {
                 $indexOfArray: [
                   {
                     $map: {
-                      input: "$courseVersion.modules",
-                      as: "m",
-                      in: { $toString: "$$m.moduleId" }
-                    }
+                      input: '$courseVersion.modules',
+                      as: 'm',
+                      in: {$toString: '$$m.moduleId'},
+                    },
                   },
-                  "$currentModuleStr"
-                ]
+                  '$currentModuleStr',
+                ],
               },
-              1
-            ]
-          }
-        }
+              1,
+            ],
+          },
+        },
       },
 
       //accessing current section
@@ -712,13 +709,15 @@ export class EnrollmentRepository {
           currentSectionObj: {
             $first: {
               $filter: {
-                input: "$currentModuleObj.sections",
-                as: "s",
-                cond: { $eq: [{ $toString: "$$s.sectionId" }, "$currentSectionStr"] }
-              }
-            }
-          }
-        }
+                input: '$currentModuleObj.sections',
+                as: 's',
+                cond: {
+                  $eq: [{$toString: '$$s.sectionId'}, '$currentSectionStr'],
+                },
+              },
+            },
+          },
+        },
       },
       {
         $addFields: {
@@ -728,21 +727,19 @@ export class EnrollmentRepository {
                 $indexOfArray: [
                   {
                     $map: {
-                      input: "$currentModuleObj.sections",
-                      as: "s",
-                      in: { $toString: "$$s.sectionId" }
-                    }
+                      input: '$currentModuleObj.sections',
+                      as: 's',
+                      in: {$toString: '$$s.sectionId'},
+                    },
                   },
-                  "$currentSectionStr"
-                ]
-              }, 1
-            ]
-          }
-        }
+                  '$currentSectionStr',
+                ],
+              },
+              1,
+            ],
+          },
+        },
       },
-
-
-
 
       /* ---------------- FINAL SHAPE ---------------- */
       {
@@ -756,19 +753,18 @@ export class EnrollmentRepository {
           course: 1,
           courseVersion: 1,
           //getting current course completion details(not actual details)
-          moduleNumber: "$moduleNumber",
-          sectionNumber: "$sectionNumber",
-          itemType: "$currentItemObj.type",
+          moduleNumber: '$moduleNumber',
+          sectionNumber: '$sectionNumber',
+          itemType: '$currentItemObj.type',
 
           // 🔥 pulled from courseVersion
-          totalItems: { $ifNull: ['$courseVersion.totalItems', 0] },
-          itemCounts: { $ifNull: ['$courseVersion.itemCounts', {}] },
+          totalItems: {$ifNull: ['$courseVersion.totalItems', 0]},
+          // itemCounts: { $ifNull: ['$courseVersion.itemCounts', {}] },
 
-          percentCompleted: { $ifNull: ['$percentCompleted', 0] },
+          percentCompleted: {$ifNull: ['$percentCompleted', 0]},
         },
       },
     ];
-
 
     const enrollments = await this.enrollmentCollection
       .aggregate(pipeline)
@@ -792,12 +788,12 @@ export class EnrollmentRepository {
         $match: {
           userId: new ObjectId(userId),
           role,
-          isDeleted: { $ne: true },
-          status: { $regex: /^active$/i },
+          isDeleted: {$ne: true},
+          status: {$regex: /^active$/i},
         },
       },
 
-      { $sort: { enrollmentDate: -1 } },
+      {$sort: {enrollmentDate: -1}},
       // { $skip: skip },
       // { $limit: limit },
 
@@ -805,13 +801,13 @@ export class EnrollmentRepository {
       {
         $lookup: {
           from: 'newCourse',
-          let: { courseId: '$courseId' },
+          let: {courseId: '$courseId'},
           pipeline: [
             {
               $match: {
-                $expr: { $eq: ['$_id', '$$courseId'] },
+                $expr: {$eq: ['$_id', '$$courseId']},
                 ...(search?.trim()
-                  ? { name: { $regex: search, $options: 'i' } }
+                  ? {name: {$regex: search, $options: 'i'}}
                   : {}),
               },
             },
@@ -834,8 +830,8 @@ export class EnrollmentRepository {
                 foreignField: '_id',
                 as: 'versions',
                 pipeline: [
-                  { $match: { isDeleted: { $ne: true } } },
-                  { $project: { _id: 1 } },
+                  {$match: {isDeleted: {$ne: true}}},
+                  {$project: {_id: 1}},
                 ],
               },
             },
@@ -849,7 +845,7 @@ export class EnrollmentRepository {
                   $map: {
                     input: '$versions',
                     as: 'v',
-                    in: { $toString: '$$v._id' },
+                    in: {$toString: '$$v._id'},
                   },
                 },
               },
@@ -860,9 +856,9 @@ export class EnrollmentRepository {
       },
 
       /* ---------- REMOVE NON-MATCHED COURSES ---------- */
-      { $unwind: '$course' },
-      { $skip: skip },
-      { $limit: limit },
+      {$unwind: '$course'},
+      {$skip: skip},
+      {$limit: limit},
 
       /* ---------- FINAL SHAPE ---------- */
       {
@@ -886,7 +882,7 @@ export class EnrollmentRepository {
   ): Promise<Map<string, any>> {
     const results = await this.courseVersionCollection
       .aggregate([
-        { $match: { _id: { $in: versionIds } } },
+        {$match: {_id: {$in: versionIds}}},
         {
           $project: {
             _id: 1,
@@ -906,15 +902,15 @@ export class EnrollmentRepository {
                   },
                 },
                 initialValue: [],
-                in: { $concatArrays: ['$$value', '$$this'] },
+                in: {$concatArrays: ['$$value', '$$this']},
               },
             },
           },
         },
-        { $unwind: '$itemGroupIds' },
+        {$unwind: '$itemGroupIds'},
         {
           $addFields: {
-            itemGroupObjId: { $toObjectId: '$itemGroupIds' },
+            itemGroupObjId: {$toObjectId: '$itemGroupIds'},
           },
         },
         {
@@ -925,31 +921,31 @@ export class EnrollmentRepository {
             as: 'itemsGroup',
           },
         },
-        { $unwind: '$itemsGroup' },
-        { $match: { 'itemsGroup.isHidden': { $ne: true } } },
+        {$unwind: '$itemsGroup'},
+        {$match: {'itemsGroup.isHidden': {$ne: true}}},
 
-        { $unwind: '$itemsGroup.items' },
+        {$unwind: '$itemsGroup.items'},
         {
           $addFields: {
-            itemObjId: { $toObjectId: '$itemsGroup.items._id' },
+            itemObjId: {$toObjectId: '$itemsGroup.items._id'},
           },
         },
         {
           $lookup: {
             from: 'videos',
-            let: { itemId: '$itemObjId', itemType: '$itemsGroup.items.type' },
+            let: {itemId: '$itemObjId', itemType: '$itemsGroup.items.type'},
             pipeline: [
               {
                 $match: {
                   $expr: {
                     $and: [
-                      { $eq: ['$_id', '$$itemId'] },
-                      { $eq: ['$$itemType', 'VIDEO'] },
+                      {$eq: ['$_id', '$$itemId']},
+                      {$eq: ['$$itemType', 'VIDEO']},
                     ],
                   },
                 },
               },
-              { $project: { isDeleted: 1, isHidden: 1 } },
+              {$project: {isDeleted: 1, isHidden: 1}},
             ],
             as: 'videoDoc',
           },
@@ -957,19 +953,19 @@ export class EnrollmentRepository {
         {
           $lookup: {
             from: 'blogs',
-            let: { itemId: '$itemObjId', itemType: '$itemsGroup.items.type' },
+            let: {itemId: '$itemObjId', itemType: '$itemsGroup.items.type'},
             pipeline: [
               {
                 $match: {
                   $expr: {
                     $and: [
-                      { $eq: ['$_id', '$$itemId'] },
-                      { $eq: ['$$itemType', 'BLOG'] },
+                      {$eq: ['$_id', '$$itemId']},
+                      {$eq: ['$$itemType', 'BLOG']},
                     ],
                   },
                 },
               },
-              { $project: { isDeleted: 1, isHidden: 1 } },
+              {$project: {isDeleted: 1, isHidden: 1}},
             ],
             as: 'blogDoc',
           },
@@ -977,19 +973,19 @@ export class EnrollmentRepository {
         {
           $lookup: {
             from: 'quizzes',
-            let: { itemId: '$itemObjId', itemType: '$itemsGroup.items.type' },
+            let: {itemId: '$itemObjId', itemType: '$itemsGroup.items.type'},
             pipeline: [
               {
                 $match: {
                   $expr: {
                     $and: [
-                      { $eq: ['$_id', '$$itemId'] },
-                      { $eq: ['$$itemType', 'QUIZ'] },
+                      {$eq: ['$_id', '$$itemId']},
+                      {$eq: ['$$itemType', 'QUIZ']},
                     ],
                   },
                 },
               },
-              { $project: { isDeleted: 1, isHidden: 1 } },
+              {$project: {isDeleted: 1, isHidden: 1}},
             ],
             as: 'quizDoc',
           },
@@ -997,19 +993,19 @@ export class EnrollmentRepository {
         {
           $lookup: {
             from: 'projects',
-            let: { itemId: '$itemObjId', itemType: '$itemsGroup.items.type' },
+            let: {itemId: '$itemObjId', itemType: '$itemsGroup.items.type'},
             pipeline: [
               {
                 $match: {
                   $expr: {
                     $and: [
-                      { $eq: ['$_id', '$$itemId'] },
-                      { $eq: ['$$itemType', 'PROJECT'] },
+                      {$eq: ['$_id', '$$itemId']},
+                      {$eq: ['$$itemType', 'PROJECT']},
                     ],
                   },
                 },
               },
-              { $project: { isDeleted: 1, isHidden: 1 } },
+              {$project: {isDeleted: 1, isHidden: 1}},
             ],
             as: 'projectDoc',
           },
@@ -1020,37 +1016,37 @@ export class EnrollmentRepository {
               $switch: {
                 branches: [
                   {
-                    case: { $eq: ['$itemsGroup.items.type', 'VIDEO'] },
+                    case: {$eq: ['$itemsGroup.items.type', 'VIDEO']},
                     then: {
                       $ifNull: [
-                        { $arrayElemAt: ['$videoDoc.isDeleted', 0] },
+                        {$arrayElemAt: ['$videoDoc.isDeleted', 0]},
                         false,
                       ],
                     },
                   },
                   {
-                    case: { $eq: ['$itemsGroup.items.type', 'BLOG'] },
+                    case: {$eq: ['$itemsGroup.items.type', 'BLOG']},
                     then: {
                       $ifNull: [
-                        { $arrayElemAt: ['$blogDoc.isDeleted', 0] },
+                        {$arrayElemAt: ['$blogDoc.isDeleted', 0]},
                         false,
                       ],
                     },
                   },
                   {
-                    case: { $eq: ['$itemsGroup.items.type', 'QUIZ'] },
+                    case: {$eq: ['$itemsGroup.items.type', 'QUIZ']},
                     then: {
                       $ifNull: [
-                        { $arrayElemAt: ['$quizDoc.isDeleted', 0] },
+                        {$arrayElemAt: ['$quizDoc.isDeleted', 0]},
                         false,
                       ],
                     },
                   },
                   {
-                    case: { $eq: ['$itemsGroup.items.type', 'PROJECT'] },
+                    case: {$eq: ['$itemsGroup.items.type', 'PROJECT']},
                     then: {
                       $ifNull: [
-                        { $arrayElemAt: ['$projectDoc.isDeleted', 0] },
+                        {$arrayElemAt: ['$projectDoc.isDeleted', 0]},
                         false,
                       ],
                     },
@@ -1063,37 +1059,37 @@ export class EnrollmentRepository {
               $switch: {
                 branches: [
                   {
-                    case: { $eq: ['$itemsGroup.items.type', 'VIDEO'] },
+                    case: {$eq: ['$itemsGroup.items.type', 'VIDEO']},
                     then: {
                       $ifNull: [
-                        { $arrayElemAt: ['$videoDoc.isHidden', 0] },
+                        {$arrayElemAt: ['$videoDoc.isHidden', 0]},
                         false,
                       ],
                     },
                   },
                   {
-                    case: { $eq: ['$itemsGroup.items.type', 'BLOG'] },
+                    case: {$eq: ['$itemsGroup.items.type', 'BLOG']},
                     then: {
                       $ifNull: [
-                        { $arrayElemAt: ['$blogDoc.isHidden', 0] },
+                        {$arrayElemAt: ['$blogDoc.isHidden', 0]},
                         false,
                       ],
                     },
                   },
                   {
-                    case: { $eq: ['$itemsGroup.items.type', 'QUIZ'] },
+                    case: {$eq: ['$itemsGroup.items.type', 'QUIZ']},
                     then: {
                       $ifNull: [
-                        { $arrayElemAt: ['$quizDoc.isHidden', 0] },
+                        {$arrayElemAt: ['$quizDoc.isHidden', 0]},
                         false,
                       ],
                     },
                   },
                   {
-                    case: { $eq: ['$itemsGroup.items.type', 'PROJECT'] },
+                    case: {$eq: ['$itemsGroup.items.type', 'PROJECT']},
                     then: {
                       $ifNull: [
-                        { $arrayElemAt: ['$projectDoc.isHidden', 0] },
+                        {$arrayElemAt: ['$projectDoc.isHidden', 0]},
                         false,
                       ],
                     },
@@ -1104,30 +1100,30 @@ export class EnrollmentRepository {
             },
           },
         },
-        { $match: { isItemDeleted: { $ne: true } } },
-        { $match: { isItemHidden: { $ne: true } } },
+        {$match: {isItemDeleted: {$ne: true}}},
+        {$match: {isItemHidden: {$ne: true}}},
         {
           $group: {
             _id: '$_id',
-            totalItems: { $sum: 1 },
+            totalItems: {$sum: 1},
             videos: {
               $sum: {
-                $cond: [{ $eq: ['$itemsGroup.items.type', 'VIDEO'] }, 1, 0],
+                $cond: [{$eq: ['$itemsGroup.items.type', 'VIDEO']}, 1, 0],
               },
             },
             quizzes: {
               $sum: {
-                $cond: [{ $eq: ['$itemsGroup.items.type', 'QUIZ'] }, 1, 0],
+                $cond: [{$eq: ['$itemsGroup.items.type', 'QUIZ']}, 1, 0],
               },
             },
             articles: {
               $sum: {
-                $cond: [{ $eq: ['$itemsGroup.items.type', 'BLOG'] }, 1, 0],
+                $cond: [{$eq: ['$itemsGroup.items.type', 'BLOG']}, 1, 0],
               },
             },
             project: {
               $sum: {
-                $cond: [{ $eq: ['$itemsGroup.items.type', 'PROJECT'] }, 1, 0],
+                $cond: [{$eq: ['$itemsGroup.items.type', 'PROJECT']}, 1, 0],
               },
             },
           },
@@ -1159,13 +1155,13 @@ export class EnrollmentRepository {
       userId: e.userId,
       courseId: e.courseId,
       courseVersionId: e.courseVersionId,
-      isHidden: { $ne: true },
-      isDeleted: { $ne: true },
+      isHidden: {$ne: true},
+      isDeleted: {$ne: true},
     }));
 
     const results = await this.watchTimeCollection
       .aggregate([
-        { $match: { $or: matchConditions } },
+        {$match: {$or: matchConditions}},
         {
           $group: {
             _id: {
@@ -1173,13 +1169,13 @@ export class EnrollmentRepository {
               courseId: '$courseId',
               courseVersionId: '$courseVersionId',
             },
-            itemIds: { $addToSet: '$itemId' },
+            itemIds: {$addToSet: '$itemId'},
           },
         },
         {
           $project: {
             _id: 1,
-            count: { $size: '$itemIds' },
+            count: {$size: '$itemIds'},
           },
         },
       ])
@@ -1200,7 +1196,12 @@ export class EnrollmentRepository {
       courseId: ObjectId;
       courseVersionId: ObjectId;
     }[],
-  ): Promise<Map<string, { videos: number; quizzes: number; articles: number; projects: number }>> {
+  ): Promise<
+    Map<
+      string,
+      {videos: number; quizzes: number; articles: number; projects: number}
+    >
+  > {
     if (entries.length === 0) {
       return new Map();
     }
@@ -1209,14 +1210,14 @@ export class EnrollmentRepository {
       userId: e.userId,
       courseId: e.courseId,
       courseVersionId: e.courseVersionId,
-      isHidden: { $ne: true },
-      isDeleted: { $ne: true },
-      endTime: { $exists: true, $ne: null },
+      isHidden: {$ne: true},
+      isDeleted: {$ne: true},
+      endTime: {$exists: true, $ne: null},
     }));
 
     const watchedItems = await this.watchTimeCollection
       .aggregate([
-        { $match: { $or: matchConditions } },
+        {$match: {$or: matchConditions}},
         {
           $group: {
             _id: {
@@ -1239,22 +1240,28 @@ export class EnrollmentRepository {
     const itemsGroupCollection = await this.db.getCollection('itemsGroup');
     const itemTypeResults = await itemsGroupCollection
       .aggregate([
-        { $unwind: '$items' },
+        {$unwind: '$items'},
         {
           $match: {
             $or: [
-              { 'items._id': { $in: allItemIds } },
+              {'items._id': {$in: allItemIds}},
               {
                 'items._id': {
-                  $in: allItemIds.map(id => {
-                    try { return new ObjectId(id as string); } catch { return null; }
-                  }).filter(Boolean)
-                }
-              }
-            ]
-          }
+                  $in: allItemIds
+                    .map(id => {
+                      try {
+                        return new ObjectId(id as string);
+                      } catch {
+                        return null;
+                      }
+                    })
+                    .filter(Boolean),
+                },
+              },
+            ],
+          },
         },
-        { $project: { itemId: { $toString: '$items._id' }, type: '$items.type' } }
+        {$project: {itemId: {$toString: '$items._id'}, type: '$items.type'}},
       ])
       .toArray();
 
@@ -1263,13 +1270,16 @@ export class EnrollmentRepository {
       itemTypeMap.set(item.itemId, item.type);
     }
 
-    const map = new Map<string, { videos: number; quizzes: number; articles: number; projects: number }>();
+    const map = new Map<
+      string,
+      {videos: number; quizzes: number; articles: number; projects: number}
+    >();
 
     for (const watched of watchedItems) {
       const key = `${watched._id.userId.toString()}-${watched._id.courseId.toString()}-${watched._id.courseVersionId.toString()}`;
 
       if (!map.has(key)) {
-        map.set(key, { videos: 0, quizzes: 0, articles: 0, projects: 0 });
+        map.set(key, {videos: 0, quizzes: 0, articles: 0, projects: 0});
       }
 
       const counts = map.get(key)!;
@@ -1307,14 +1317,14 @@ export class EnrollmentRepository {
     // const userObjectid = new ObjectId(userId)
 
     return await this.enrollmentCollection
-      .find({ userId: { $in: userFilter }, isDeleted: { $ne: true } }, { session })
-      .sort({ enrollmentDate: -1 })
+      .find({userId: {$in: userFilter}, isDeleted: {$ne: true}}, {session})
+      .sort({enrollmentDate: -1})
       .toArray();
   }
 
   async getAllExisitingEnrollments(session?: ClientSession) {
     await this.init();
-    return await this.enrollmentCollection.find({}, { session }).toArray();
+    return await this.enrollmentCollection.find({}, {session}).toArray();
   }
 
   async getCourseVersionEnrollments(
@@ -1336,14 +1346,14 @@ export class EnrollmentRepository {
       courseVersionId: new ObjectId(courseVersionId),
     };
 
-    let matchStage: any = { ...baseMatch };
+    let matchStage: any = {...baseMatch};
 
     //  ACTIVE tab
     if (statusTab === 'ACTIVE') {
       matchStage = {
         ...baseMatch,
-        status: { $regex: /^active$/i },
-        isDeleted: { $ne: true },
+        status: {$regex: /^active$/i},
+        isDeleted: {$ne: true},
       };
     }
 
@@ -1351,7 +1361,7 @@ export class EnrollmentRepository {
     if (statusTab === 'INACTIVE') {
       matchStage = {
         ...baseMatch,
-        $or: [{ status: { $regex: /^inactive$/i } }, { isDeleted: true }],
+        $or: [{status: {$regex: /^inactive$/i}}, {isDeleted: true}],
       };
     }
 
@@ -1384,7 +1394,7 @@ export class EnrollmentRepository {
       if (filter === 'STUDENT') {
         matchStage.role = 'STUDENT';
       } else if (filter === 'OTHER') {
-        matchStage.role = { $ne: 'STUDENT' };
+        matchStage.role = {$ne: 'STUDENT'};
       }
     }
 
@@ -1397,18 +1407,18 @@ export class EnrollmentRepository {
         lastName: sortOrder === 'asc' ? 1 : -1,
       };
     } else if (sortBy === 'enrollmentDate') {
-      sortField = { enrollmentDate: sortOrder === 'asc' ? 1 : -1 };
+      sortField = {enrollmentDate: sortOrder === 'asc' ? 1 : -1};
     } else if (sortBy === 'progress') {
-      sortField = { percentCompleted: sortOrder === 'asc' ? 1 : -1 };
+      sortField = {percentCompleted: sortOrder === 'asc' ? 1 : -1};
     } else if (sortBy === 'unenrolledAt') {
-      sortField = { unenrolledAt: sortOrder === 'asc' ? 1 : -1 };
+      sortField = {unenrolledAt: sortOrder === 'asc' ? 1 : -1};
     }
 
     const aggregationPipeline: any[] = [
-      { $match: matchStage },
+      {$match: matchStage},
       {
         $addFields: {
-          userId: { $toObjectId: '$userId' },
+          userId: {$toObjectId: '$userId'},
         },
       },
       {
@@ -1419,17 +1429,17 @@ export class EnrollmentRepository {
           as: 'userInfo',
         },
       },
-      { $unwind: { path: '$userInfo', preserveNullAndEmptyArrays: true } },
+      {$unwind: {path: '$userInfo', preserveNullAndEmptyArrays: true}},
       {
         $addFields: {
-          userId: { $toString: '$userInfo._id' },
-          _id: { $toString: '$_id' },
-          courseId: { $toString: '$courseId' },
-          courseVersionId: { $toString: '$courseVersionId' },
+          userId: {$toString: '$userInfo._id'},
+          _id: {$toString: '$_id'},
+          courseId: {$toString: '$courseId'},
+          courseVersionId: {$toString: '$courseVersionId'},
           firstName: '$userInfo.firstName',
           lastName: '$userInfo.lastName',
           email: '$userInfo.email',
-          completedItemsCount: { $ifNull: ['$completedItemsCount', 0] },
+          completedItemsCount: {$ifNull: ['$completedItemsCount', 0]},
         },
       },
     ];
@@ -1440,28 +1450,28 @@ export class EnrollmentRepository {
       aggregationPipeline.push({
         $match: {
           $or: [
-            { 'userInfo.firstName': { $regex: search, $options: 'i' } },
-            { 'userInfo.email': { $regex: search, $options: 'i' } },
-            { firstName: { $regex: searchTerm, $options: 'i' } },
-            { lastName: { $regex: searchTerm, $options: 'i' } },
-            { email: { $regex: searchTerm, $options: 'i' } },
+            {'userInfo.firstName': {$regex: search, $options: 'i'}},
+            {'userInfo.email': {$regex: search, $options: 'i'}},
+            {firstName: {$regex: searchTerm, $options: 'i'}},
+            {lastName: {$regex: searchTerm, $options: 'i'}},
+            {email: {$regex: searchTerm, $options: 'i'}},
           ],
         },
       });
     }
 
     // Get the total count with search applied
-    const countPipeline = [...aggregationPipeline, { $count: 'total' }];
+    const countPipeline = [...aggregationPipeline, {$count: 'total'}];
     const countResult = await this.enrollmentCollection
-      .aggregate<{ total: number }>(countPipeline, { session })
+      .aggregate<{total: number}>(countPipeline, {session})
       .next();
     const totalDocuments = countResult?.total || 0;
 
     // sorting
-    aggregationPipeline.push({ $sort: sortField });
+    aggregationPipeline.push({$sort: sortField});
 
     // pagination
-    aggregationPipeline.push({ $skip: skip }, { $limit: limit });
+    aggregationPipeline.push({$skip: skip}, {$limit: limit});
 
     // count separately
     // const totalDocuments = await this.enrollmentCollection.countDocuments(
@@ -1469,7 +1479,7 @@ export class EnrollmentRepository {
     // );
 
     const enrollments = await this.enrollmentCollection
-      .aggregate(aggregationPipeline, { session })
+      .aggregate(aggregationPipeline, {session})
       .toArray();
 
     const totalPages = limit > 0 ? Math.ceil(totalDocuments / limit) : 1;
@@ -1499,22 +1509,22 @@ export class EnrollmentRepository {
               courseId: new ObjectId(courseId),
               courseVersionId: new ObjectId(courseVersionId),
               role: 'STUDENT',
-              status: { $regex: /^active$/i },
-              isDeleted: { $ne: true }, // Exclude soft-deleted enrollments
+              status: {$regex: /^active$/i},
+              isDeleted: {$ne: true}, // Exclude soft-deleted enrollments
             },
           },
           {
             $group: {
               _id: null,
-              totalEnrollments: { $sum: 1 },
+              totalEnrollments: {$sum: 1},
               completedCount: {
                 $sum: {
-                  $cond: [{ $gte: ['$percentCompleted', 100] }, 1, 0],
+                  $cond: [{$gte: ['$percentCompleted', 100]}, 1, 0],
                 },
               },
               totalProgress: {
                 $sum: {
-                  $multiply: [{ $ifNull: ['$percentCompleted', 0] }, 1],
+                  $multiply: [{$ifNull: ['$percentCompleted', 0]}, 1],
                 },
               },
             },
@@ -1526,10 +1536,10 @@ export class EnrollmentRepository {
               completedCount: 1,
               averageProgressPercent: {
                 $cond: [
-                  { $gt: ['$totalEnrollments', 0] },
+                  {$gt: ['$totalEnrollments', 0]},
                   {
                     $round: [
-                      { $divide: ['$totalProgress', '$totalEnrollments'] },
+                      {$divide: ['$totalProgress', '$totalEnrollments']},
                       2,
                     ],
                   },
@@ -1539,7 +1549,7 @@ export class EnrollmentRepository {
             },
           },
         ],
-        { session },
+        {session},
       )
       .toArray();
 
@@ -1567,7 +1577,11 @@ export class EnrollmentRepository {
   //     status: { $regex: /^active$/i },
   //   });
   // }
-  async countEnrollments(userId: string,role: EnrollmentRole,search?: string,) {
+  async countEnrollments(
+    userId: string,
+    role: EnrollmentRole,
+    search?: string,
+  ) {
     await this.init();
 
     const pipeline: any[] = [
@@ -1575,21 +1589,21 @@ export class EnrollmentRepository {
         $match: {
           userId: new ObjectId(userId),
           role,
-          isDeleted: { $ne: true },
-          status: { $regex: /^active$/i },
+          isDeleted: {$ne: true},
+          status: {$regex: /^active$/i},
         },
       },
 
       {
         $lookup: {
           from: 'newCourse',
-          let: { courseId: '$courseId' },
+          let: {courseId: '$courseId'},
           pipeline: [
             {
               $match: {
-                $expr: { $eq: ['$_id', '$$courseId'] },
+                $expr: {$eq: ['$_id', '$$courseId']},
                 ...(search?.trim()
-                  ? { name: { $regex: search, $options: 'i' } }
+                  ? {name: {$regex: search, $options: 'i'}}
                   : {}),
               },
             },
@@ -1599,9 +1613,9 @@ export class EnrollmentRepository {
       },
 
       // remove enrollments whose course did not match search
-      { $unwind: '$course' },
+      {$unwind: '$course'},
 
-      { $count: 'total' },
+      {$count: 'total'},
     ];
 
     const result = await this.enrollmentCollection
@@ -1637,10 +1651,10 @@ export class EnrollmentRepository {
     await this.init();
 
     const query: any = {
-      isDeleted: { $ne: true },
-      status: { $regex: /^active$/i },
+      isDeleted: {$ne: true},
+      status: {$regex: /^active$/i},
       role: 'STUDENT',
-      percentCompleted: { $exists: true, $gte: 99, $lt: 100 },
+      percentCompleted: {$exists: true, $gte: 99, $lt: 100},
     };
 
     if (filters.courseId) query.courseId = new ObjectId(filters.courseId);
@@ -1660,8 +1674,8 @@ export class EnrollmentRepository {
       await this.enrollmentCollection.dropIndex('enrollmentDate_-1');
 
       await this.enrollmentCollection.createIndex(
-        { courseId: 1, courseVersionId: 1 },
-        { name: 'courseId_1_courseVersionId_1' },
+        {courseId: 1, courseVersionId: 1},
+        {name: 'courseId_1_courseVersionId_1'},
       );
       // await this.enrollmentCollection.createIndex({ userId: 1, role: 1 });
       // await this.enrollmentCollection.createIndex({ courseId: 1 });
@@ -1695,26 +1709,26 @@ export class EnrollmentRepository {
           courseId: new ObjectId(courseId),
           courseVersionId: new ObjectId(courseVersionId),
         },
-        { session },
+        {session},
       )
       .toArray();
   }
 
   /* Update progress percentage for array of users */
   async bulkUpdateProgressPercents(
-    updates: { enrollmentId: string; percentCompleted: number }[],
+    updates: {enrollmentId: string; percentCompleted: number}[],
     session?: ClientSession,
   ): Promise<void> {
     if (!updates.length) return;
 
     const operations = updates.map(update => ({
       updateOne: {
-        filter: { _id: new ObjectId(update.enrollmentId) },
-        update: { $set: { progressPercent: update.percentCompleted } },
+        filter: {_id: new ObjectId(update.enrollmentId)},
+        update: {$set: {progressPercent: update.percentCompleted}},
       },
     }));
 
-    await this.enrollmentCollection.bulkWrite(operations, { session });
+    await this.enrollmentCollection.bulkWrite(operations, {session});
   }
 
   private async processCompletedItemsBatch(
@@ -1738,7 +1752,7 @@ export class EnrollmentRepository {
         [
           {
             $match: {
-              isDeleted: { $ne: true },
+              isDeleted: {$ne: true},
               $or: enrollments.map(e => ({
                 userId: e.userId,
                 courseId: e.courseId,
@@ -1753,16 +1767,16 @@ export class EnrollmentRepository {
                 courseId: '$courseId',
                 courseVersionId: '$courseVersionId',
               },
-              completedItemsCount: { $addToSet: '$itemId' },
+              completedItemsCount: {$addToSet: '$itemId'},
             },
           },
           {
             $project: {
-              completedItemsCount: { $size: '$completedItemsCount' },
+              completedItemsCount: {$size: '$completedItemsCount'},
             },
           },
         ],
-        { session },
+        {session},
       )
       .toArray();
 
@@ -1772,7 +1786,7 @@ export class EnrollmentRepository {
 
       return {
         updateOne: {
-          filter: { _id: enrollmentId },
+          filter: {_id: enrollmentId},
           update: {
             $set: {
               completedItemsCount: c.completedItemsCount,
@@ -1800,7 +1814,7 @@ export class EnrollmentRepository {
       userId?: string;
     },
     session?: ClientSession,
-  ): Promise<{ totalCount: number; updatedCount: number }> {
+  ): Promise<{totalCount: number; updatedCount: number}> {
     await this.init();
 
     const BATCH_SIZE = 500;
@@ -1808,7 +1822,7 @@ export class EnrollmentRepository {
     let updatedCount = 0;
 
     const match: any = {
-      isDeleted: { $ne: true },
+      isDeleted: {$ne: true},
       courseVersionId: new ObjectId(filters.courseVersionId),
     };
 
@@ -1822,7 +1836,7 @@ export class EnrollmentRepository {
 
     const cursor = this.enrollmentCollection
       .find(match)
-      .project({ userId: 1, courseId: 1, courseVersionId: 1 })
+      .project({userId: 1, courseId: 1, courseVersionId: 1})
       .batchSize(BATCH_SIZE);
 
     let batch: any[] = [];
@@ -1845,7 +1859,7 @@ export class EnrollmentRepository {
       `✅ CourseVersion ${filters.courseVersionId} → scanned=${totalCount}, updated=${updatedCount}`,
     );
 
-    return { totalCount, updatedCount };
+    return {totalCount, updatedCount};
   }
 
   /**
@@ -1858,10 +1872,10 @@ export class EnrollmentRepository {
    */
   private async getQuizDetails(
     quizIds: ObjectId[],
-  ): Promise<Map<string, { name: string }>> {
+  ): Promise<Map<string, {name: string}>> {
     const quizzes = await this.quizCollection
       .find({
-        _id: { $in: quizIds },
+        _id: {$in: quizIds},
       })
       .project({
         _id: 1,
@@ -1869,7 +1883,7 @@ export class EnrollmentRepository {
       })
       .toArray();
 
-    const quizDetails = new Map<string, { name: string }>();
+    const quizDetails = new Map<string, {name: string}>();
     quizzes.forEach(quiz => {
       quizDetails.set(quiz._id.toString(), {
         name: quiz.name,
@@ -1932,18 +1946,18 @@ export class EnrollmentRepository {
               $and: [
                 {
                   $or: [
-                    { userId: { $in: ObjuserIds } },
-                    { userId: { $in: stringUserIds } },
+                    {userId: {$in: ObjuserIds}},
+                    {userId: {$in: stringUserIds}},
                   ],
                 },
                 {
                   $or: [
-                    { quizId: { $in: ObjquizIds } },
-                    { quizId: { $in: stringQuizIds } },
+                    {quizId: {$in: ObjquizIds}},
+                    {quizId: {$in: stringQuizIds}},
                   ],
                 },
-                { 'gradingResult.totalMaxScore': { $exists: true } },
-                { 'gradingResult.totalScore': { $exists: true } },
+                {'gradingResult.totalMaxScore': {$exists: true}},
+                {'gradingResult.totalScore': {$exists: true}},
               ],
             },
           },
@@ -1951,8 +1965,8 @@ export class EnrollmentRepository {
             $project: {
               userId: 1,
               quizId: 1,
-              score: { $ifNull: ['$gradingResult.totalScore', 0] },
-              maxPossibleScore: { $ifNull: ['$gradingResult.totalMaxScore', 0] },
+              score: {$ifNull: ['$gradingResult.totalScore', 0]},
+              maxPossibleScore: {$ifNull: ['$gradingResult.totalMaxScore', 0]},
             },
           },
           {
@@ -1961,15 +1975,15 @@ export class EnrollmentRepository {
                 userId: '$userId',
                 quizId: '$quizId',
               },
-              bestScore: { $max: '$score' },
-              maxPossibleScore: { $first: '$maxPossibleScore' },
+              bestScore: {$max: '$score'},
+              maxPossibleScore: {$first: '$maxPossibleScore'},
             },
           },
           {
             $project: {
               _id: 0,
-              userId: { $toString: '$_id.userId' },
-              quizId: { $toString: '$_id.quizId' },
+              userId: {$toString: '$_id.userId'},
+              quizId: {$toString: '$_id.quizId'},
               bestScore: 1,
               maxPossibleScore: 1,
               scorePercentage: {
@@ -1977,11 +1991,11 @@ export class EnrollmentRepository {
                   vars: {
                     percentage: {
                       $cond: [
-                        { $eq: ['$maxPossibleScore', 0] },
+                        {$eq: ['$maxPossibleScore', 0]},
                         0,
                         {
                           $multiply: [
-                            { $divide: ['$bestScore', '$maxPossibleScore'] },
+                            {$divide: ['$bestScore', '$maxPossibleScore']},
                             100,
                           ],
                         },
@@ -1990,9 +2004,9 @@ export class EnrollmentRepository {
                   },
                   in: {
                     $cond: [
-                      { $eq: [{ $mod: ['$$percentage', 1] }, 0] },
+                      {$eq: [{$mod: ['$$percentage', 1]}, 0]},
                       '$$percentage',
-                      { $round: ['$$percentage', 2] },
+                      {$round: ['$$percentage', 2]},
                     ],
                   },
                 },
@@ -2008,17 +2022,17 @@ export class EnrollmentRepository {
           $and: [
             {
               $or: [
-                { userId: { $in: ObjuserIds } },
-                { userId: { $in: stringUserIds } },
+                {userId: {$in: ObjuserIds}},
+                {userId: {$in: stringUserIds}},
               ],
             },
             {
               $or: [
-                { quizId: { $in: ObjquizIds } },
-                { quizId: { $in: stringQuizIds } },
+                {quizId: {$in: ObjquizIds}},
+                {quizId: {$in: stringQuizIds}},
               ],
             },
-            { 'gradingResult.overallFeedback': { $exists: true, $ne: [] } },
+            {'gradingResult.overallFeedback': {$exists: true, $ne: []}},
           ],
         })
         .project({
@@ -2037,7 +2051,7 @@ export class EnrollmentRepository {
 
       // Process max scores (now as percentages)
       maxScoreResults.forEach(result => {
-        const { userId, quizId, maxScorePercentage } = result;
+        const {userId, quizId, maxScorePercentage} = result;
         if (!maxScores.has(userId)) {
           maxScores.set(userId, new Map<string, number>());
         }
@@ -2079,7 +2093,7 @@ export class EnrollmentRepository {
         }
       });
 
-      return { maxScores, questionScores };
+      return {maxScores, questionScores};
     } catch (error) {
       console.error('Error in getMaxScoresForQuizzes:', error);
       return {
@@ -2109,21 +2123,21 @@ export class EnrollmentRepository {
         .aggregate([
           {
             $match: {
-              userId: { $in: ObjUserIds },
-              quizId: { $in: ObjQuizIds },
+              userId: {$in: ObjUserIds},
+              quizId: {$in: ObjQuizIds},
             },
           },
           {
             $group: {
-              _id: { userId: '$userId', quizId: '$quizId' },
-              attemptCount: { $sum: 1 },
+              _id: {userId: '$userId', quizId: '$quizId'},
+              attemptCount: {$sum: 1},
             },
           },
           {
             $project: {
               _id: 0,
-              userId: { $toString: '$_id.userId' },
-              quizId: { $toString: '$_id.quizId' },
+              userId: {$toString: '$_id.userId'},
+              quizId: {$toString: '$_id.quizId'},
               attemptCount: 1,
             },
           },
@@ -2131,7 +2145,7 @@ export class EnrollmentRepository {
         .toArray();
 
       const attemptMap = new Map<string, Map<string, number>>();
-      for (const { userId, quizId, attemptCount } of results) {
+      for (const {userId, quizId, attemptCount} of results) {
         if (!attemptMap.has(userId)) {
           attemptMap.set(userId, new Map());
         }
@@ -2174,8 +2188,8 @@ export class EnrollmentRepository {
        * ------------------------------------ */
       const quizzes = await this.quizCollection
         .find({
-          _id: { $in: quizIds.map(id => new ObjectId(id)) },
-          'details.questionBankRefs': { $exists: true, $ne: [] },
+          _id: {$in: quizIds.map(id => new ObjectId(id))},
+          'details.questionBankRefs': {$exists: true, $ne: []},
         })
         .project({
           _id: 1,
@@ -2205,9 +2219,9 @@ export class EnrollmentRepository {
        * ------------------------------------ */
       const questionBanks = await this.questionBankCollection
         .find({
-          _id: { $in: [...bankIds].map(id => new ObjectId(id)) },
+          _id: {$in: [...bankIds].map(id => new ObjectId(id))},
         })
-        .project({ _id: 1, questions: 1 })
+        .project({_id: 1, questions: 1})
         .toArray();
 
       /** ------------------------------------
@@ -2265,7 +2279,7 @@ export class EnrollmentRepository {
   private async getQuizQuestionIds(quizId: string): Promise<string[]> {
     await this.init();
 
-    const quiz = await this.quizCollection.findOne({ _id: new ObjectId(quizId) });
+    const quiz = await this.quizCollection.findOne({_id: new ObjectId(quizId)});
     if (!quiz || !quiz.details?.questionBankRefs?.length) {
       return [];
     }
@@ -2281,7 +2295,7 @@ export class EnrollmentRepository {
 
     // Get all questions from the question banks
     const questionBanks = await this.questionBankCollection
-      .find({ _id: { $in: bankIds } })
+      .find({_id: {$in: bankIds}})
       .toArray();
 
     // Extract all question IDs
@@ -2316,13 +2330,13 @@ export class EnrollmentRepository {
     }>
   > {
     // Define types for the data we're working with
-    type QuizDocument = { _id: ObjectId; itemsGroupId: string };
+    type QuizDocument = {_id: ObjectId; itemsGroupId: string};
     type ModuleSection = {
       sectionId: string;
       name: string;
       itemsGroupId: string;
     };
-    type Module = { moduleId: string; name: string; sections: ModuleSection[] };
+    type Module = {moduleId: string; name: string; sections: ModuleSection[]};
     await this.init();
 
     if (!ObjectId.isValid(versionId)) {
@@ -2332,7 +2346,7 @@ export class EnrollmentRepository {
     try {
       // 1. Get the course version with modules and sections
       const courseVersion = await this.courseVersionCollection.findOne(
-        { _id: new ObjectId(versionId) },
+        {_id: new ObjectId(versionId)},
         {
           projection: {
             'modules.moduleId': 1,
@@ -2367,7 +2381,7 @@ export class EnrollmentRepository {
       // 3. Get all items groups that contain quizzes
       const itemsGroups = await this.itemsGroupCollection
         .find({
-          _id: { $in: sectionItemsGroupIds.map(id => new ObjectId(id)) },
+          _id: {$in: sectionItemsGroupIds.map(id => new ObjectId(id))},
         })
         .toArray();
 
@@ -2425,7 +2439,7 @@ export class EnrollmentRepository {
         .map(module => {
           const moduleSections = (module.sections || [])
             .filter(
-              (section): section is ModuleSection & { itemsGroupId: string } => {
+              (section): section is ModuleSection & {itemsGroupId: string} => {
                 if (!section || !section.itemsGroupId) {
                   return false;
                 }
@@ -2492,12 +2506,12 @@ export class EnrollmentRepository {
 
     // Add status-specific filters
     if (statusTab === 'ACTIVE') {
-      studentFilter.status = { $regex: /^active$/i };
-      studentFilter.isDeleted = { $ne: true };
+      studentFilter.status = {$regex: /^active$/i};
+      studentFilter.isDeleted = {$ne: true};
     } else if (statusTab === 'INACTIVE') {
       studentFilter.$or = [
-        { status: { $regex: /^inactive$/i } },
-        { isDeleted: true },
+        {status: {$regex: /^inactive$/i}},
+        {isDeleted: true},
       ];
     }
 
@@ -2506,7 +2520,7 @@ export class EnrollmentRepository {
      * ----------------------------------------------------- */
     const enrollments = await this.enrollmentCollection
       .aggregate([
-        { $match: studentFilter },
+        {$match: studentFilter},
         {
           $lookup: {
             from: 'users',
@@ -2515,7 +2529,7 @@ export class EnrollmentRepository {
             as: 'user',
           },
         },
-        { $unwind: '$user' },
+        {$unwind: '$user'},
         {
           $project: {
             userId: 1,
@@ -2585,8 +2599,8 @@ export class EnrollmentRepository {
       .aggregate([
         {
           $match: {
-            userId: { $in: userIds },
-            quizId: { $in: quizIdsObj },
+            userId: {$in: userIds},
+            quizId: {$in: quizIdsObj},
           },
         },
         {
@@ -2605,7 +2619,7 @@ export class EnrollmentRepository {
             maxScore: {
               $max: '$gradingResult.totalScore',
             },
-            attempts: { $sum: 1 },
+            attempts: {$sum: 1},
           },
         },
       ])
@@ -2678,8 +2692,9 @@ export class EnrollmentRepository {
       return {
         studentId: userId,
         name:
-          `${enrollment.user.firstName ?? ''} ${enrollment.user.lastName ?? ''
-            }`.trim() || 'Unknown',
+          `${enrollment.user.firstName ?? ''} ${
+            enrollment.user.lastName ?? ''
+          }`.trim() || 'Unknown',
         email: enrollment.user.email ?? '',
         quizScores,
       };
@@ -2711,7 +2726,7 @@ export class EnrollmentRepository {
         .find({
           courseId: courseObjectId,
           courseVersionId: versionObjectId,
-          role: { $ne: 'STUDENT' },
+          role: {$ne: 'STUDENT'},
         })
         .toArray();
 
@@ -2738,9 +2753,9 @@ export class EnrollmentRepository {
             courseId: courseObjectId,
             courseVersionId: versionObjectId,
             role: 'STUDENT',
-            status: { $regex: /^active$/i },
+            status: {$regex: /^active$/i},
           },
-          { session },
+          {session},
         )
         .toArray();
 
@@ -2764,8 +2779,8 @@ export class EnrollmentRepository {
         {
           courseVersionId: versionObjectId,
         },
-        { $set: { isDeleted: true, deletedAt: new Date() } },
-        { session },
+        {$set: {isDeleted: true, deletedAt: new Date()}},
+        {session},
       );
 
       return result.modifiedCount;
@@ -2794,9 +2809,9 @@ export class EnrollmentRepository {
 
     const result = await this.enrollmentCollection.deleteMany(
       {
-        courseVersionId: { $in: versionIds },
+        courseVersionId: {$in: versionIds},
       },
-      { session },
+      {session},
     );
     return result.acknowledged && result.deletedCount > 0;
   }
@@ -2815,7 +2830,7 @@ export class EnrollmentRepository {
           courseId: new ObjectId(courseId),
           courseVersionId: new ObjectId(courseVersionId),
         },
-        { session },
+        {session},
       )
       .next();
   }
@@ -2830,9 +2845,9 @@ export class EnrollmentRepository {
     const itemObjIds = itemIds.map(id => new ObjectId(id));
 
     const result = await this.watchTimeCollection.updateMany(
-      { itemId: { $in: itemObjIds } },
-      { $set: { isHidden: isHidden } },
-      { session },
+      {itemId: {$in: itemObjIds}},
+      {$set: {isHidden: isHidden}},
+      {session},
     );
 
     if (!result.acknowledged) {
@@ -2869,14 +2884,14 @@ export class EnrollmentRepository {
         [
           {
             $match: {
-              userId: { $in: userObjectIds },
-              quizId: { $in: quizObjectIds },
-              'gradingResult.totalScore': { $exists: true },
+              userId: {$in: userObjectIds},
+              quizId: {$in: quizObjectIds},
+              'gradingResult.totalScore': {$exists: true},
             },
           },
           // Sort by score descending to get best score first
           {
-            $sort: { 'gradingResult.totalScore': -1 },
+            $sort: {'gradingResult.totalScore': -1},
           },
           // Group by user and quiz, take the first (best) submission
           {
@@ -2885,12 +2900,12 @@ export class EnrollmentRepository {
                 userId: '$userId',
                 quizId: '$quizId',
               },
-              submission: { $first: '$$ROOT' },
+              submission: {$first: '$$ROOT'},
             },
           },
           // Replace root to get back the submission document
           {
-            $replaceRoot: { newRoot: '$submission' },
+            $replaceRoot: {newRoot: '$submission'},
           },
           // Project only needed fields
           {
@@ -2902,7 +2917,7 @@ export class EnrollmentRepository {
             },
           },
         ],
-        { session },
+        {session},
       )
       .toArray();
   }
@@ -2921,7 +2936,7 @@ export class EnrollmentRepository {
       .find(
         {
           userId: userObjectId,
-          quizId: { $in: quizObjectIds },
+          quizId: {$in: quizObjectIds},
         },
         {
           session,
@@ -2936,5 +2951,266 @@ export class EnrollmentRepository {
       .toArray();
 
     return submission;
+  }
+
+  async getDetailedEnrollments(
+    userId: string,
+    skip: number,
+    limit: number,
+    role: EnrollmentRole,
+    search: string,
+  ) {
+    await this.init();
+    const userObjectId = new ObjectId(userId);
+    const pipeline: any[] = [
+      {
+        $match: {
+          userId: userObjectId,
+          role,
+          isDeleted: {$ne: true},
+          status: {$regex: /^active$/i},
+        },
+      },
+
+      {$sort: {enrollmentDate: -1}},
+      //from progress
+      {
+        $lookup: {
+          from: 'progress',
+          let: {
+            userId: '$userId',
+            courseId: '$courseId',
+            courseVersionId: '$courseVersionId',
+          },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $and: [
+                    {$eq: ['$userId', '$$userId']},
+                    {$eq: ['$courseId', '$$courseId']},
+                    {$eq: ['$courseVersionId', '$$courseVersionId']},
+                    {$eq: ['$status', 'active']},
+                  ],
+                },
+              },
+            },
+            {
+              $project: {
+                currentModule: 1,
+                currentSection: 1,
+                currentItem: 1,
+              },
+            },
+          ],
+          as: 'progress',
+        },
+      },
+      // {$unwind: '$progress'},
+      {
+        $unwind: {path: '$progress', preserveNullAndEmptyArrays: true},
+      },
+
+      /* ---------------- COURSE LOOKUP ---------------- */
+      {
+        $lookup: {
+          from: 'newCourse',
+          localField: 'courseId',
+          foreignField: '_id',
+          as: 'course',
+          pipeline: [
+            {
+              $project: {
+                name: 1,
+                description: 1,
+                updatedAt: 1,
+              },
+            },
+          ],
+        },
+      },
+      {$unwind: '$course'},
+
+      /* ---------------- COURSE VERSION LOOKUP (NEW) ---------------- */
+      {
+        $lookup: {
+          from: 'newCourseVersion',
+          localField: 'courseVersionId',
+          foreignField: '_id',
+          as: 'courseVersion',
+          pipeline: [
+            {
+              $project: {
+                totalItems: 1,
+                itemCounts: 1,
+                supportLink: 1,
+                version: 1,
+                description: 1,
+                modules: 1,
+              },
+            },
+          ],
+        },
+      },
+
+      {$unwind: {path: '$courseVersion', preserveNullAndEmptyArrays: true}},
+      {$skip: skip},
+      {$limit: limit},
+      /* ---------------- SEARCH ---------------- */
+      ...(search?.trim()
+        ? [{$match: {'course.name': {$regex: search, $options: 'i'}}}]
+        : []),
+      //i have converted the id(object form right) to string
+      {
+        $addFields: {
+          currentModuleStr: {$toString: '$progress.currentModule'},
+          currentSectionStr: {$toString: '$progress.currentSection'},
+          currentItemStr: {$toString: '$progress.currentItem'},
+        },
+      },
+      //getting items group for current section id
+      {
+        $lookup: {
+          from: 'itemsGroup',
+          let: {
+            sectionId: '$progress.currentSection',
+          },
+          pipeline: [
+            {
+              $match: {
+                $expr: {$eq: ['$sectionId', '$$sectionId']},
+              },
+            },
+            {
+              $project: {items: 1},
+            },
+          ],
+          as: 'itemsGroup',
+        },
+      },
+      //getting item object from items group to get type.
+      {
+        $addFields: {
+          currentItemObj: {
+            $first: {
+              $filter: {
+                input: {
+                  $reduce: {
+                    input: '$itemsGroup',
+                    initialValue: [],
+                    in: {$concatArrays: ['$$value', '$$this.items']},
+                  },
+                },
+                as: 'i',
+                cond: {$eq: [{$toString: '$$i._id'}, '$currentItemStr']},
+              },
+            },
+          },
+        },
+      },
+      //accessing current module
+
+      {
+        $addFields: {
+          currentModuleObj: {
+            $first: {
+              $filter: {
+                input: '$courseVersion.modules',
+                as: 'm',
+                cond: {$eq: [{$toString: '$$m.moduleId'}, '$currentModuleStr']},
+              },
+            },
+          },
+        },
+      },
+      {
+        $addFields: {
+          moduleNumber: {
+            $add: [
+              {
+                $indexOfArray: [
+                  {
+                    $map: {
+                      input: '$courseVersion.modules',
+                      as: 'm',
+                      in: {$toString: '$$m.moduleId'},
+                    },
+                  },
+                  '$currentModuleStr',
+                ],
+              },
+              1,
+            ],
+          },
+        },
+      },
+
+      //accessing current section
+      {
+        $addFields: {
+          currentSectionObj: {
+            $first: {
+              $filter: {
+                input: '$currentModuleObj.sections',
+                as: 's',
+                cond: {
+                  $eq: [{$toString: '$$s.sectionId'}, '$currentSectionStr'],
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        $addFields: {
+          sectionNumber: {
+            $add: [
+              {
+                $indexOfArray: [
+                  {
+                    $map: {
+                      input: '$currentModuleObj.sections',
+                      as: 's',
+                      in: {$toString: '$$s.sectionId'},
+                    },
+                  },
+                  '$currentSectionStr',
+                ],
+              },
+              1,
+            ],
+          },
+        },
+      },
+
+      /* ---------------- FINAL SHAPE ---------------- */
+      {
+        $project: {
+          _id: 1,
+          courseId: 1,
+          courseVersionId: 1,
+          role: 1,
+          status: 1,
+          enrollmentDate: 1,
+          course: 1,
+          courseVersion: 1,
+          //getting current course completion details(not actual details)
+          moduleNumber: '$moduleNumber',
+          sectionNumber: '$sectionNumber',
+          itemType: '$currentItemObj.type',
+
+          // 🔥 pulled from courseVersion
+          totalItems: {$ifNull: ['$courseVersion.totalItems', 0]},
+          itemCounts: {$ifNull: ['$courseVersion.itemCounts', {}]},
+
+          percentCompleted: {$ifNull: ['$percentCompleted', 0]},
+        },
+      },
+    ];
+    const enrollments = await this.enrollmentCollection
+      .aggregate(pipeline)
+      .toArray();
+
+    return enrollments;
   }
 }

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -2987,10 +2987,9 @@ export class EnrollmentRepository {
     return submission;
   }
 
-  async getDetailedEnrollments(
+  async getDetailedEnrollment(
     userId: string,
     role: EnrollmentRole,
-    search: string,
     courseVersionId?: string,
   ) {
     await this.init();
@@ -3000,7 +2999,6 @@ export class EnrollmentRepository {
       {
         userId,
         role,
-        search,
         courseVersionId,
       },
     );
@@ -3257,5 +3255,55 @@ export class EnrollmentRepository {
       .toArray();
 
     return enrollments;
+  }
+  async detailedCountEnrollment(
+    userId: string,
+    role: EnrollmentRole,
+    courseVersionId?: string,
+  ) {
+    await this.init();
+    const matchStage: any = {
+      userId: new ObjectId(userId),
+      role,
+      isDeleted: {$ne: true},
+      status: {$regex: /^active$/i},
+    };
+
+    // Add courseVersionId filter if provided
+    if (courseVersionId) {
+      matchStage.courseVersionId = new ObjectId(courseVersionId);
+    }
+
+    const pipeline: any[] = [
+      {
+        $match: matchStage,
+      },
+
+      {
+        $lookup: {
+          from: 'newCourse',
+          let: {courseId: '$courseId'},
+          pipeline: [
+            {
+              $match: {
+                $expr: {$eq: ['$_id', '$$courseId']},
+              },
+            },
+          ],
+          as: 'course',
+        },
+      },
+
+      // remove enrollments whose course did not match search
+      {$unwind: '$course'},
+
+      {$count: 'total'},
+    ];
+
+    const result = await this.enrollmentCollection
+      .aggregate(pipeline)
+      .toArray();
+
+    return result[0]?.total || 0;
   }
 }

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -1,6 +1,6 @@
-import { ObjectId } from 'mongodb';
-import { ProctoringComponent } from '../database/index.js';
-import { Type } from 'class-transformer';
+import {ObjectId} from 'mongodb';
+import {ProctoringComponent} from '../database/index.js';
+import {Type} from 'class-transformer';
 import {
   IsOptional,
   IsInt,
@@ -10,7 +10,7 @@ import {
   isString,
   IsEnum,
 } from 'class-validator';
-import { Priority } from './quiz.js';
+import {Priority} from './quiz.js';
 
 export interface IUser {
   _id?: string | ObjectId | null;
@@ -411,9 +411,9 @@ export interface IProgress {
 }
 
 export interface ICurrentProgressPath {
-  module: { id: string; name: string } | null;
-  section: { id: string; name: string } | null;
-  item: { id: string; name: string; type: string } | null;
+  module: {id: string; name: string} | null;
+  section: {id: string; name: string} | null;
+  item: {id: string; name: string; type: string} | null;
   message?: string;
 }
 
@@ -479,14 +479,14 @@ export interface IRegistrationSettings {
   _id?: ID;
   label: string;
   type:
-  | 'TEXT'
-  | 'TEXTAREA'
-  | 'EMAIL'
-  | 'TEL'
-  | 'DATE'
-  | 'NUMBER'
-  | 'URL'
-  | 'SELECT';
+    | 'TEXT'
+    | 'TEXTAREA'
+    | 'EMAIL'
+    | 'TEL'
+    | 'DATE'
+    | 'NUMBER'
+    | 'URL'
+    | 'SELECT';
   isDefault: boolean;
   required: boolean;
   options?: string[];
@@ -574,6 +574,10 @@ export class EnrollmentFilterQuery {
   @IsString()
   @IsIn(['STUDENT', 'INSTRUCTOR', 'MANAGER', 'TA', 'STAFF'])
   role: EnrollmentRole;
+
+  @IsOptional()
+  @IsString()
+  courseVersionId?: string;
 }
 
 export class EnrollmentsQuery {
@@ -595,7 +599,8 @@ export class EnrollmentsQuery {
 
   @IsOptional()
   @IsIn(['name', 'enrollmentDate', 'progress', 'unenrolledAt'])
-  sortBy: 'name' | 'enrollmentDate' | 'progress' | 'unenrolledAt' = 'enrollmentDate';
+  sortBy: 'name' | 'enrollmentDate' | 'progress' | 'unenrolledAt' =
+    'enrollmentDate';
 
   @IsOptional()
   @IsIn(['asc', 'desc'])
@@ -608,7 +613,6 @@ export class EnrollmentsQuery {
   @IsOptional()
   @IsIn(['ACTIVE', 'INACTIVE'])
   statusTab: 'ACTIVE' | 'INACTIVE' = 'ACTIVE';
-
 }
 
 export class BulkEnrollmentsQuery {

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -1,5 +1,4 @@
 import { Clock, FileText, CheckCircle2, Trophy, Medal, Award, Crown, Info, ExternalLink, Copy, MessageCircle, Users, Check, Sparkles, LifeBuoy, Mail, Headphones, Play } from "lucide-react";
-import { } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -19,6 +18,13 @@ import { cn } from "@/utils/utils";
 import type { CourseCardProps } from '@/types/course.types';
 import { Pagination } from "../ui/Pagination";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { lazy, Suspense } from "react";
+
+const EnrollmentDetailsDialog = lazy(() => 
+  import("./EnrollmentDetailsDialog").then(mod => ({ 
+    default: mod.EnrollmentDetailsDialog 
+  }))
+);
 
 export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard', className, completion, setCompletion }: CourseCardProps) => {
   // Add null checks to prevent errors when enrollment data is incomplete
@@ -58,19 +64,19 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
   const totalLessons = contentCounts.totalItems || 0;
   const completedLessons = enrollment.completedItems as number || 0;
   const isCompleted = (typeof enrollment.percentCompleted === 'number' && enrollment.percentCompleted >= 100) || false;
-  const totalQuizScore = contentCounts.totalQuizScore as number || 0;
-  const totalQuizMaxScore = contentCounts.totalQuizMaxScore as number || 0;
+  // const totalQuizScore = contentCounts.totalQuizScore as number || 0;
+  // const totalQuizMaxScore = contentCounts.totalQuizMaxScore as number || 0;
 
-  const videoCount: number = contentCounts.videos || 0;
-  const quizCount: number = contentCounts.quizzes || 0;
-  const articleCount: number = contentCounts.articles || 0;
-  const projectCount: number = contentCounts.project || 0;
+  // const videoCount: number = contentCounts.videos || 0;
+  // const quizCount: number = contentCounts.quizzes || 0;
+  // const articleCount: number = contentCounts.articles || 0;
+  // const projectCount: number = contentCounts.project || 0;
 
 
-  const completedVideos: number = contentCounts.completedVideos || 0;
-  const completedQuizzes: number = contentCounts.completedQuizzes || 0;
-  const completedArticles: number = contentCounts.completedArticles || 0;
-  const completedProjects: number = contentCounts.completedProjects || 0;
+  // const completedVideos: number = contentCounts.completedVideos || 0;
+  // const completedQuizzes: number = contentCounts.completedQuizzes || 0;
+  // const completedArticles: number = contentCounts.completedArticles || 0;
+  // const completedProjects: number = contentCounts.completedProjects || 0;
 
 
   // Find if this courseVersionId is already in completion
@@ -246,7 +252,19 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
               </DialogTrigger>
               <LeaderboardDialog courseId={courseId} versionId={versionId} courseName={enrollment?.course?.name} isOpen={isLeaderboardOpen} />
             </Dialog>}
-           {enrollment.courseVersionId!=="6981df886e100cfe04f9c4ae"&& <Dialog open={isDetailsOpen} onOpenChange={setIsDetailsOpen}>
+            {
+              enrollment.courseVersionId!=="6981df886e100cfe04f9c4ae" && isDetailsOpen && (
+        <Suspense fallback={null}>
+          <EnrollmentDetailsDialog
+            isOpen={isDetailsOpen}
+            onOpenChange={setIsDetailsOpen}
+            enrollment={enrollment}
+          />
+        </Suspense>
+      )
+            }
+            {enrollment.courseVersionId!=="6981df886e100cfe04f9c4ae"&& <Button onClick={()=>setIsDetailsOpen(true)} variant="outline" className="w-full sm:w-auto">View Details</Button> }
+           {/* {enrollment.courseVersionId!=="6981df886e100cfe04f9c4ae"&& <Dialog open={isDetailsOpen} onOpenChange={setIsDetailsOpen}>
               <DialogTrigger asChild>
                 <Button variant="outline" className="w-full sm:w-auto">View Details</Button>
               </DialogTrigger>
@@ -369,7 +387,7 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
                   </div>
                 </ScrollArea>
               </DialogContent>
-            </Dialog>}
+            </Dialog>} */}
 
             {supportLink && (() => {
               const isEmail = supportLink.startsWith('mailto:') || (!supportLink.startsWith('http://') && !supportLink.startsWith('https://') && !supportLink.startsWith('//') && supportLink.includes('@'));

--- a/frontend/src/components/course/EnrollmentDetailsDialog.tsx
+++ b/frontend/src/components/course/EnrollmentDetailsDialog.tsx
@@ -41,7 +41,7 @@ export function EnrollmentDetailsDialog({
     data: enrollmentDetails, 
     isLoading, 
     error 
-  } = useUserEnrollmentsDetails(1, 100, true, "", "STUDENT",courseVersionId);
+  } = useUserEnrollmentsDetails( true, "", "STUDENT",courseVersionId);
 
   console.log('----------------------------enrollmentDetails', enrollmentDetails);
 

--- a/frontend/src/components/course/EnrollmentDetailsDialog.tsx
+++ b/frontend/src/components/course/EnrollmentDetailsDialog.tsx
@@ -1,0 +1,186 @@
+// Create a new component: EnrollmentDetailsDialog.tsx
+import { useState } from "react";
+import { useUserEnrollmentsDetails } from "@/hooks/hooks";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "../ui/button";
+import { Separator } from "@/components/ui/separator";
+import { CheckCircle2, Clock } from "lucide-react";
+import { formatDateTime } from "@/utils/utils";
+
+
+interface EnrollmentDetailsDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  enrollment: any; // Use your proper type
+}
+
+export function EnrollmentDetailsDialog({ 
+  isOpen, 
+  onOpenChange, 
+  enrollment 
+}: EnrollmentDetailsDialogProps) {
+  // Hook is only called when this component is mounted
+  const { 
+    data: enrollmentDetails, 
+    isLoading, 
+    error 
+  } = useUserEnrollmentsDetails(1, 100, true, "", "STUDENT");
+
+  // Extract data from enrollment prop (same as your CourseCard)
+  const contentCounts = enrollment.contentCounts as { 
+    totalItems?: number; 
+    videos?: number; 
+    quizzes?: number; 
+    articles?: number; 
+    project?: number; 
+    totalQuizScore?: number; 
+    totalQuizMaxScore?: number; 
+    completedVideos?: number; 
+    completedQuizzes?: number; 
+    completedArticles?: number; 
+    completedProjects?: number;
+  } || {};
+  
+  const totalLessons = contentCounts.totalItems || 0;
+  const completedLessons = enrollment.completedItems as number || 0;
+  const isCompleted = (typeof enrollment.percentCompleted === 'number' && enrollment.percentCompleted >= 100) || false;
+  const totalQuizScore = contentCounts.totalQuizScore as number || 0;
+  const totalQuizMaxScore = contentCounts.totalQuizMaxScore as number || 0;
+  const videoCount: number = contentCounts.videos || 0;
+  const quizCount: number = contentCounts.quizzes || 0;
+  const articleCount: number = contentCounts.articles || 0;
+  const projectCount: number = contentCounts.project || 0;
+  const completedVideos: number = contentCounts.completedVideos || 0;
+  const completedQuizzes: number = contentCounts.completedQuizzes || 0;
+  const completedArticles: number = contentCounts.completedArticles || 0;
+  const completedProjects: number = contentCounts.completedProjects || 0;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+              <DialogTrigger asChild>
+                <Button variant="outline" className="w-full sm:w-auto">View Details</Button>
+              </DialogTrigger>
+              <DialogContent className="w-full max-[425px]:w-[95vw] max-w-sm sm:max-w-md md:max-w-2xl lg:max-w-3xl mx-auto px-4 max-h-full flex flex-col">
+                <DialogHeader className="mb-3 text-left">
+                  <DialogTitle>Course Details</DialogTitle>
+                </DialogHeader>
+                <ScrollArea className="flex-1 pr-4 -mr-4 max-h-[700px] overflow-y-auto">
+                  <div className="space-y-6 py-2">
+                    <div>
+                      <div className="grid grid-cols-2 gap-4 mt-2">
+                        <div className="space-y-1">
+                          <p className="text-sm font-medium text-muted-foreground">Course Name</p>
+                          <p>{enrollment?.course?.name || 'N/A'}</p>
+                        </div>
+                        <div className="space-y-1">
+                          <p className="text-sm font-medium text-muted-foreground">Version</p>
+                          <p>{enrollment?.courseVersion?.name || 'N/A'}</p>
+                        </div>
+                        <div className="space-y-1 col-span-2">
+                          <p className="text-sm font-medium text-muted-foreground">Description</p>
+                          <p className="text-sm">{enrollment?.course?.description || 'No description available'}</p>
+                        </div>
+                        <div className="space-y-1 col-span-2">
+                          <p className="text-sm font-medium text-muted-foreground">Version Description</p>
+                          <p className="text-sm">{enrollment?.courseVersion?.description || 'No version description available'}</p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <Separator />
+
+                    <div>
+                      <h3 className="text-lg font-semibold">Content Summary</h3>
+                      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-2">
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Contents</p>
+                          <p className="text-xl font-semibold">{totalLessons}</p>
+                        </div>
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Videos</p>
+                          <p className="text-xl font-semibold">{videoCount}</p>
+                        </div>
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Quizzes</p>
+                          <p className="text-xl font-semibold">{quizCount}</p>
+                        </div>
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Articles</p>
+                          <p className="text-xl font-semibold">{articleCount}</p>
+                        </div>
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Project</p>
+                          <p className="text-xl font-semibold">{projectCount}</p>
+                        </div>
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Quiz Scores</p>
+                          <p className="text-xl font-semibold">{totalQuizScore} / {totalQuizMaxScore}</p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <Separator />
+
+                    <div>
+                      <h3 className="text-lg font-semibold">Completion Details</h3>
+                      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-2">
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Total Completed</p>
+                          <p className="text-xl font-semibold">{completedLessons} / {totalLessons}</p>
+                        </div>
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Videos Watched</p>
+                          <p className="text-xl font-semibold">{completedVideos} / {videoCount}</p>
+                        </div>
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Quizzes Completed</p>
+                          <p className="text-xl font-semibold">{completedQuizzes} / {quizCount}</p>
+                        </div>
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Articles Read</p>
+                          <p className="text-xl font-semibold">{completedArticles} / {articleCount}</p>
+                        </div>
+                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                          <p className="text-sm font-medium text-muted-foreground">Projects Done</p>
+                          <p className="text-xl font-semibold">{completedProjects} / {projectCount}</p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <Separator />
+
+                    <div>
+                      <h3 className="text-lg font-semibold">Enrollment Details</h3>
+                      <div className="grid grid-cols-2 gap-4 mt-2">
+                        <div className="space-y-1">
+                          <p className="text-sm font-medium text-muted-foreground">Enrolled On</p>
+                          <p>{enrollment?.enrollmentDate ? formatDateTime(enrollment.enrollmentDate as string) : 'N/A'}</p>
+                        </div>
+                        <div className="space-y-1">
+                          <p className="text-sm font-medium text-muted-foreground">Status</p>
+                          <div className="flex items-center gap-1">
+                            {isCompleted ? (
+                              <>
+                                <CheckCircle2 className="h-4 w-4 text-green-500" />
+                                <span>Completed</span>
+                              </>
+                            ) : (
+                              <>
+                                <Clock className="h-4 w-4 text-yellow-500" />
+                                <span>In Progress</span>
+                              </>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+
+                  </div>
+                </ScrollArea>
+              </DialogContent>
+            </Dialog>
+  );
+}

--- a/frontend/src/components/course/EnrollmentDetailsDialog.tsx
+++ b/frontend/src/components/course/EnrollmentDetailsDialog.tsx
@@ -35,17 +35,17 @@ export function EnrollmentDetailsDialog({
   enrollment 
 }: EnrollmentDetailsDialogProps) {
   console.log('----------------------------enrollment', enrollment);
-
+    const courseVersionId = enrollment.courseVersionId;
   // Hook is only called when this component is mounted
   const { 
     data: enrollmentDetails, 
     isLoading, 
     error 
-  } = useUserEnrollmentsDetails(1, 100, true, "", "STUDENT");
+  } = useUserEnrollmentsDetails(1, 100, true, "", "STUDENT",courseVersionId);
 
   console.log('----------------------------enrollmentDetails', enrollmentDetails);
 
-  const enroll1=enrollmentDetails?.enrollments?.[1];
+  const enroll1=enrollmentDetails?.enrollments?.[0];
 
   
   // Extract data from enrollment prop

--- a/frontend/src/components/course/EnrollmentDetailsDialog.tsx
+++ b/frontend/src/components/course/EnrollmentDetailsDialog.tsx
@@ -8,6 +8,7 @@ import { Button } from "../ui/button";
 import { Separator } from "@/components/ui/separator";
 import { CheckCircle2, Clock } from "lucide-react";
 
+
 const formatDate = (dateString: string) => {
   try {
     return new Date(dateString).toLocaleDateString('en-GB', {
@@ -26,7 +27,7 @@ const formatDate = (dateString: string) => {
 interface EnrollmentDetailsDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  enrollment: any; // Use your proper type
+  enrollment: any; 
 }
 
 export function EnrollmentDetailsDialog({ 
@@ -34,7 +35,7 @@ export function EnrollmentDetailsDialog({
   onOpenChange, 
   enrollment 
 }: EnrollmentDetailsDialogProps) {
-  console.log('----------------------------enrollment', enrollment);
+  
     const courseVersionId = enrollment.courseVersionId;
   // Hook is only called when this component is mounted
   const { 
@@ -43,7 +44,7 @@ export function EnrollmentDetailsDialog({
     error 
   } = useUserEnrollmentsDetails( true, "", "STUDENT",courseVersionId);
 
-  console.log('----------------------------enrollmentDetails', enrollmentDetails);
+ 
 
   const enroll1=enrollmentDetails?.enrollments?.[0];
 
@@ -70,11 +71,10 @@ export function EnrollmentDetailsDialog({
   const completedProjects = contentCounts.completedProjects || 0;
 
   // Debug: Check if contentCounts is empty
-  console.log('contentCounts:', contentCounts);
-  console.log('Is contentCounts empty?', Object.keys(contentCounts).length === 0);
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
+        {isLoading ?<Skeleton/>:<>
       <DialogTrigger asChild>
         <Button variant="outline" className="w-full sm:w-auto">View Details</Button>
       </DialogTrigger>
@@ -215,6 +215,7 @@ export function EnrollmentDetailsDialog({
           </div>
         </ScrollArea>
       </DialogContent>
+      </> }
     </Dialog>
   );
 }

--- a/frontend/src/components/course/EnrollmentDetailsDialog.tsx
+++ b/frontend/src/components/course/EnrollmentDetailsDialog.tsx
@@ -7,7 +7,20 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "../ui/button";
 import { Separator } from "@/components/ui/separator";
 import { CheckCircle2, Clock } from "lucide-react";
-import { formatDateTime } from "@/utils/utils";
+
+const formatDate = (dateString: string) => {
+  try {
+    return new Date(dateString).toLocaleDateString('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  } catch (error) {
+    return 'N/A';
+  }
+};
 
 
 interface EnrollmentDetailsDialogProps {
@@ -21,6 +34,8 @@ export function EnrollmentDetailsDialog({
   onOpenChange, 
   enrollment 
 }: EnrollmentDetailsDialogProps) {
+  console.log('----------------------------enrollment', enrollment);
+
   // Hook is only called when this component is mounted
   const { 
     data: enrollmentDetails, 
@@ -28,159 +43,178 @@ export function EnrollmentDetailsDialog({
     error 
   } = useUserEnrollmentsDetails(1, 100, true, "", "STUDENT");
 
-  // Extract data from enrollment prop (same as your CourseCard)
-  const contentCounts = enrollment.contentCounts as { 
-    totalItems?: number; 
-    videos?: number; 
-    quizzes?: number; 
-    articles?: number; 
-    project?: number; 
-    totalQuizScore?: number; 
-    totalQuizMaxScore?: number; 
-    completedVideos?: number; 
-    completedQuizzes?: number; 
-    completedArticles?: number; 
-    completedProjects?: number;
-  } || {};
+  console.log('----------------------------enrollmentDetails', enrollmentDetails);
+
+  const enroll1=enrollmentDetails?.enrollments?.[1];
+
   
+  // Extract data from enrollment prop
+  const contentCounts = enroll1?.contentCounts || {};
+  
+  // Get values with fallbacks
   const totalLessons = contentCounts.totalItems || 0;
-  const completedLessons = enrollment.completedItems as number || 0;
-  const isCompleted = (typeof enrollment.percentCompleted === 'number' && enrollment.percentCompleted >= 100) || false;
-  const totalQuizScore = contentCounts.totalQuizScore as number || 0;
-  const totalQuizMaxScore = contentCounts.totalQuizMaxScore as number || 0;
-  const videoCount: number = contentCounts.videos || 0;
-  const quizCount: number = contentCounts.quizzes || 0;
-  const articleCount: number = contentCounts.articles || 0;
-  const projectCount: number = contentCounts.project || 0;
-  const completedVideos: number = contentCounts.completedVideos || 0;
-  const completedQuizzes: number = contentCounts.completedQuizzes || 0;
-  const completedArticles: number = contentCounts.completedArticles || 0;
-  const completedProjects: number = contentCounts.completedProjects || 0;
+  const completedLessons = enroll1?.completedItems || 0;
+  const isCompleted = (enroll1?.percentCompleted >= 100) || false;
+  
+  const totalQuizScore = contentCounts.totalQuizScore || 0;
+  const totalQuizMaxScore = contentCounts.totalQuizMaxScore || 0;
+  
+  const videoCount = contentCounts.videos || 0;
+  const quizCount = contentCounts.quizzes || 0;
+  const articleCount = contentCounts.articles || 0;
+  const projectCount = contentCounts.project || 0;
+  
+  const completedVideos = contentCounts.completedVideos || 0;
+  const completedQuizzes = contentCounts.completedQuizzes || 0;
+  const completedArticles = contentCounts.completedArticles || 0;
+  const completedProjects = contentCounts.completedProjects || 0;
+
+  // Debug: Check if contentCounts is empty
+  console.log('contentCounts:', contentCounts);
+  console.log('Is contentCounts empty?', Object.keys(contentCounts).length === 0);
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-              <DialogTrigger asChild>
-                <Button variant="outline" className="w-full sm:w-auto">View Details</Button>
-              </DialogTrigger>
-              <DialogContent className="w-full max-[425px]:w-[95vw] max-w-sm sm:max-w-md md:max-w-2xl lg:max-w-3xl mx-auto px-4 max-h-full flex flex-col">
-                <DialogHeader className="mb-3 text-left">
-                  <DialogTitle>Course Details</DialogTitle>
-                </DialogHeader>
-                <ScrollArea className="flex-1 pr-4 -mr-4 max-h-[700px] overflow-y-auto">
-                  <div className="space-y-6 py-2">
-                    <div>
-                      <div className="grid grid-cols-2 gap-4 mt-2">
-                        <div className="space-y-1">
-                          <p className="text-sm font-medium text-muted-foreground">Course Name</p>
-                          <p>{enrollment?.course?.name || 'N/A'}</p>
-                        </div>
-                        <div className="space-y-1">
-                          <p className="text-sm font-medium text-muted-foreground">Version</p>
-                          <p>{enrollment?.courseVersion?.name || 'N/A'}</p>
-                        </div>
-                        <div className="space-y-1 col-span-2">
-                          <p className="text-sm font-medium text-muted-foreground">Description</p>
-                          <p className="text-sm">{enrollment?.course?.description || 'No description available'}</p>
-                        </div>
-                        <div className="space-y-1 col-span-2">
-                          <p className="text-sm font-medium text-muted-foreground">Version Description</p>
-                          <p className="text-sm">{enrollment?.courseVersion?.description || 'No version description available'}</p>
-                        </div>
-                      </div>
-                    </div>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="w-full sm:w-auto">View Details</Button>
+      </DialogTrigger>
+      
+      <DialogContent className="w-full max-[425px]:w-[95vw] max-w-sm sm:max-w-md md:max-w-2xl lg:max-w-3xl mx-auto px-4 max-h-full flex flex-col">
+        <DialogHeader className="mb-3 text-left">
+          <DialogTitle>Course Details</DialogTitle>
+        </DialogHeader>
+        
+        <ScrollArea className="flex-1 pr-4 -mr-4 max-h-[700px] overflow-y-auto">
+          <div className="space-y-6 py-2">
+            {/* Course Information */}
+            <div>
+              <div className="grid grid-cols-2 gap-4 mt-2">
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-muted-foreground">Course Name</p>
+                  <p>{enroll1?.course?.name || 'N/A'}</p>
+                </div>
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-muted-foreground">Version</p>
+                  <p>{enroll1?.courseVersion?.name || 'N/A'}</p>
+                </div>
+                <div className="space-y-1 col-span-2">
+                  <p className="text-sm font-medium text-muted-foreground">Description</p>
+                  <p className="text-sm">{enroll1?.course?.description || 'No description available'}</p>
+                </div>
+                <div className="space-y-1 col-span-2">
+                  <p className="text-sm font-medium text-muted-foreground">Version Description</p>
+                  <p className="text-sm">{enroll1?.courseVersion?.description || 'No version description available'}</p>
+                </div>
+              </div>
+            </div>
 
-                    <Separator />
+            <Separator />
 
-                    <div>
-                      <h3 className="text-lg font-semibold">Content Summary</h3>
-                      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-2">
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Contents</p>
-                          <p className="text-xl font-semibold">{totalLessons}</p>
-                        </div>
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Videos</p>
-                          <p className="text-xl font-semibold">{videoCount}</p>
-                        </div>
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Quizzes</p>
-                          <p className="text-xl font-semibold">{quizCount}</p>
-                        </div>
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Articles</p>
-                          <p className="text-xl font-semibold">{articleCount}</p>
-                        </div>
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Project</p>
-                          <p className="text-xl font-semibold">{projectCount}</p>
-                        </div>
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Quiz Scores</p>
-                          <p className="text-xl font-semibold">{totalQuizScore} / {totalQuizMaxScore}</p>
-                        </div>
-                      </div>
-                    </div>
+            {/* Content Summary */}
+            <div>
+              <h3 className="text-lg font-semibold">Content Summary</h3>
+              
+              {/* Show warning if contentCounts is empty */}
+              {Object.keys(contentCounts).length === 0 && (
+                <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg mb-3">
+                  <p className="text-sm text-yellow-800">
+                    Content details are not available for this enrollment.
+                  </p>
+                </div>
+              )}
+              
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-2">
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Total Items</p>
+                  <p className="text-xl font-semibold">{totalLessons}</p>
+                </div>
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Videos</p>
+                  <p className="text-xl font-semibold">{videoCount}</p>
+                </div>
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Quizzes</p>
+                  <p className="text-xl font-semibold">{quizCount}</p>
+                </div>
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Articles</p>
+                  <p className="text-xl font-semibold">{articleCount}</p>
+                </div>
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Projects</p>
+                  <p className="text-xl font-semibold">{projectCount}</p>
+                </div>
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Quiz Scores</p>
+                  <p className="text-xl font-semibold">{totalQuizScore} / {totalQuizMaxScore}</p>
+                </div>
+              </div>
+            </div>
 
-                    <Separator />
+            <Separator />
 
-                    <div>
-                      <h3 className="text-lg font-semibold">Completion Details</h3>
-                      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-2">
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Total Completed</p>
-                          <p className="text-xl font-semibold">{completedLessons} / {totalLessons}</p>
-                        </div>
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Videos Watched</p>
-                          <p className="text-xl font-semibold">{completedVideos} / {videoCount}</p>
-                        </div>
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Quizzes Completed</p>
-                          <p className="text-xl font-semibold">{completedQuizzes} / {quizCount}</p>
-                        </div>
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Articles Read</p>
-                          <p className="text-xl font-semibold">{completedArticles} / {articleCount}</p>
-                        </div>
-                        <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                          <p className="text-sm font-medium text-muted-foreground">Projects Done</p>
-                          <p className="text-xl font-semibold">{completedProjects} / {projectCount}</p>
-                        </div>
-                      </div>
-                    </div>
+            {/* Completion Details */}
+            <div>
+              <h3 className="text-lg font-semibold">Completion Details</h3>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-2">
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Total Completed</p>
+                  <p className="text-xl font-semibold">{completedLessons} / {totalLessons}</p>
+                </div>
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Videos Watched</p>
+                  <p className="text-xl font-semibold">{completedVideos} / {videoCount}</p>
+                </div>
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Quizzes Completed</p>
+                  <p className="text-xl font-semibold">{completedQuizzes} / {quizCount}</p>
+                </div>
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Articles Read</p>
+                  <p className="text-xl font-semibold">{completedArticles} / {articleCount}</p>
+                </div>
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Projects Done</p>
+                  <p className="text-xl font-semibold">{completedProjects} / {projectCount}</p>
+                </div>
+                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                  <p className="text-sm font-medium text-muted-foreground">Progress</p>
+                  <p className="text-xl font-semibold">{enroll1?.percentCompleted?.toFixed(2) || 0}%</p>
+                </div>
+              </div>
+            </div>
 
-                    <Separator />
+            <Separator />
 
-                    <div>
-                      <h3 className="text-lg font-semibold">Enrollment Details</h3>
-                      <div className="grid grid-cols-2 gap-4 mt-2">
-                        <div className="space-y-1">
-                          <p className="text-sm font-medium text-muted-foreground">Enrolled On</p>
-                          <p>{enrollment?.enrollmentDate ? formatDateTime(enrollment.enrollmentDate as string) : 'N/A'}</p>
-                        </div>
-                        <div className="space-y-1">
-                          <p className="text-sm font-medium text-muted-foreground">Status</p>
-                          <div className="flex items-center gap-1">
-                            {isCompleted ? (
-                              <>
-                                <CheckCircle2 className="h-4 w-4 text-green-500" />
-                                <span>Completed</span>
-                              </>
-                            ) : (
-                              <>
-                                <Clock className="h-4 w-4 text-yellow-500" />
-                                <span>In Progress</span>
-                              </>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-
+            {/* Enrollment Details */}
+            <div>
+              <h3 className="text-lg font-semibold">Enrollment Details</h3>
+              <div className="grid grid-cols-2 gap-4 mt-2">
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-muted-foreground">Enrolled On</p>
+                  <p>{enroll1?.enrollmentDate ? formatDate(enroll1.enrollmentDate) : 'N/A'}</p>
+                </div>
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-muted-foreground">Status</p>
+                  <div className="flex items-center gap-1">
+                    {isCompleted ? (
+                      <>
+                        <CheckCircle2 className="h-4 w-4 text-green-500" />
+                        <span>Completed</span>
+                      </>
+                    ) : (
+                      <>
+                        <Clock className="h-4 w-4 text-yellow-500" />
+                        <span>In Progress</span>
+                      </>
+                    )}
                   </div>
-                </ScrollArea>
-              </DialogContent>
-            </Dialog>
+                </div>
+              </div>
+            </div>
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/components/course/EnrollmentDetailsDialog.tsx
+++ b/frontend/src/components/course/EnrollmentDetailsDialog.tsx
@@ -95,7 +95,7 @@ export function EnrollmentDetailsDialog({
                 </div>
                 <div className="space-y-1">
                   <p className="text-sm font-medium text-muted-foreground">Version</p>
-                  <p>{enroll1?.courseVersion?.name || 'N/A'}</p>
+                  <p>{enroll1?.course?.versionDetails?.[0]?.version || 'N/A'}</p>
                 </div>
                 <div className="space-y-1 col-span-2">
                   <p className="text-sm font-medium text-muted-foreground">Description</p>
@@ -103,7 +103,7 @@ export function EnrollmentDetailsDialog({
                 </div>
                 <div className="space-y-1 col-span-2">
                   <p className="text-sm font-medium text-muted-foreground">Version Description</p>
-                  <p className="text-sm">{enroll1?.courseVersion?.description || 'No version description available'}</p>
+                  <p className="text-sm">{enroll1?.course?.versionDetails?.[0]?.description || 'No version description available'}</p>
                 </div>
               </div>
             </div>

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -4086,3 +4086,25 @@ export function useMarkNotificationAsRead(): {
 export const useBulkUnenrollUsers = () => {
   return api.useMutation('post', '/users/enrollments/courses/{courseId}/versions/{versionId}/bulk-unenroll');
 };
+
+// GET /users/enrollments
+export function useUserEnrollmentsDetails(page?: number, limit?: number, enabled: boolean = true, search?: string, role = "STUDENT"): {
+  data: components['schemas']['EnrollmentResponse'] | undefined,
+  isLoading: boolean,
+  error: string | null,
+  refetch: () => void
+} {
+  const result = api.useQuery("get", "/users/enrollments/details", {
+    params: {
+      query: { page, limit, search, role }
+    },
+    enabled: enabled
+  });
+
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+    error: result.error ? (result.error.message || 'Failed to fetch user enrollments') : null,
+    refetch: result.refetch
+  };
+}

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -4088,7 +4088,7 @@ export const useBulkUnenrollUsers = () => {
 };
 
 // GET /users/enrollments
-export function useUserEnrollmentsDetails(page?: number, limit?: number, enabled: boolean = true, search?: string, role = "STUDENT", courseVersionId?: string, ): {
+export function useUserEnrollmentsDetails( enabled: boolean = true, search?: string, role = "STUDENT", courseVersionId?: string, ): {
   data: components['schemas']['EnrollmentResponse'] | undefined,
   isLoading: boolean,
   error: string | null,
@@ -4096,7 +4096,7 @@ export function useUserEnrollmentsDetails(page?: number, limit?: number, enabled
 } {
   const result = api.useQuery("get", "/users/enrollments/details", {
     params: {
-      query: { page, limit, search, role, courseVersionId  }
+      query: {  search, role, courseVersionId  }
     },
     enabled: enabled
   });

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -4088,7 +4088,7 @@ export const useBulkUnenrollUsers = () => {
 };
 
 // GET /users/enrollments
-export function useUserEnrollmentsDetails(page?: number, limit?: number, enabled: boolean = true, search?: string, role = "STUDENT"): {
+export function useUserEnrollmentsDetails(page?: number, limit?: number, enabled: boolean = true, search?: string, role = "STUDENT", courseVersionId?: string, ): {
   data: components['schemas']['EnrollmentResponse'] | undefined,
   isLoading: boolean,
   error: string | null,
@@ -4096,7 +4096,7 @@ export function useUserEnrollmentsDetails(page?: number, limit?: number, enabled
 } {
   const result = api.useQuery("get", "/users/enrollments/details", {
     params: {
-      query: { page, limit, search, role }
+      query: { page, limit, search, role, courseVersionId  }
     },
     enabled: enabled
   });


### PR DESCRIPTION
### Issue
on the student side, the Enrollments API returned the complete course details along with the enrollment information. This behavior needed to be modified. The API should initially return only the basic course information required for listing. Detailed course data should be fetched separately and only when the user clicks on “View Details.” This change would ensure optimized data loading and improved performance by avoiding unnecessary payloads during the initial page load.

## What was done

### Backend
- Created a new api Controller `getUserEnrollmentsDetails` at `/enrollments/details` which received `courseVersionId` as parameter in order to get the corresponding details related to that course version.
- Corresponding to that, created `enrollmentService.getDetailedEnrollment` and `enrollmentService.detailedCountEnrollment` to get detailed information and count based on the course version.
- Older controller's(`getUserEnrollments`) service logic optimised in `enrollmentService.getEnrollments` and `enrollmentService.countEnrollments` based on only the payload that is needed.
- Created a stage for pipeline for versionDetails, which was missing in the original repo method.

### Frontend
- Created a separate component for View Details `EnrollmentDetailsDialog`
- Created a new hook called `useUserEnrollmentsDetails` and called it inside the component `EnrollmentDetailsDialog`
- Applied `lazy loading` to `EnrollmentDetailsDialog` to ensure that the hook is only called when View Details is clicked and `EnrollmentDetailsDialog` is mounted in `CourseCard`.