### PR TITLE
Fix Course Details Modal & Hide View Details for Available Courses

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -278,7 +278,7 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
                 </Suspense>
               )
             }
-            {enrollment.courseVersionId !== "6981df886e100cfe04f9c4ae" && <Button onClick={() => setIsDetailsOpen(true)} variant="outline" className="w-full sm:w-auto">View Details</Button>}
+            {variant !== 'available' && enrollment.courseVersionId !== "6981df886e100cfe04f9c4ae" && <Button onClick={() => setIsDetailsOpen(true)} variant="outline" className="w-full sm:w-auto">View Details</Button>}
             {/* {enrollment.courseVersionId!=="6981df886e100cfe04f9c4ae"&& <Dialog open={isDetailsOpen} onOpenChange={setIsDetailsOpen}>
               <DialogTrigger asChild>
                 <Button variant="outline" className="w-full sm:w-auto">View Details</Button>
@@ -937,7 +937,7 @@ const LeaderboardDialog = ({ courseId, versionId, courseName, isOpen }: { course
             <div className="w-px h-6 bg-border" />
             <div className="flex items-center gap-2">
               <span className="text-xs text-muted-foreground uppercase tracking-wider">Progress</span>
-              <span className="font-semibold text-foreground">{Math.round(myStats.completionPercentage*1000)/1000}%</span>
+              <span className="font-semibold text-foreground">{Math.round(myStats.completionPercentage * 1000) / 1000}%</span>
             </div>
           </div>
         ) : (

--- a/frontend/src/components/course/EnrollmentDetailsDialog.tsx
+++ b/frontend/src/components/course/EnrollmentDetailsDialog.tsx
@@ -1,6 +1,6 @@
 // Create a new component: EnrollmentDetailsDialog.tsx
-import { useState } from "react";
-import { useUserEnrollmentsDetails } from "@/hooks/hooks";
+import { useUserEnrollmentsDetails, useCourseVersionById } from "@/hooks/hooks";
+import { bufferToHex } from '@/utils/helpers';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -27,44 +27,48 @@ const formatDate = (dateString: string) => {
 interface EnrollmentDetailsDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  enrollment: any; 
+  enrollment: any;
 }
 
-export function EnrollmentDetailsDialog({ 
-  isOpen, 
-  onOpenChange, 
-  enrollment 
+export function EnrollmentDetailsDialog({
+  isOpen,
+  onOpenChange,
+  enrollment
 }: EnrollmentDetailsDialogProps) {
-  
-    const courseVersionId = enrollment.courseVersionId;
+
+  const courseVersionId = bufferToHex(enrollment.courseVersionId);
   // Hook is only called when this component is mounted
-  const { 
-    data: enrollmentDetails, 
-    isLoading, 
-    error 
-  } = useUserEnrollmentsDetails( true, "", "STUDENT",courseVersionId);
+  const {
+    data: enrollmentDetails,
+    isLoading
+  } = useUserEnrollmentsDetails(true, "", "STUDENT", courseVersionId);
 
- 
+  const { data: versionDetails } = useCourseVersionById(courseVersionId);
 
-  const enroll1=enrollmentDetails?.enrollments?.[0];
 
-  
+
+
+
+  // Use the fetched enrollment details if available, otherwise fall back to the passed enrollment prop
+  const enroll1 = enrollmentDetails?.enrollments?.[0] || enrollment;
+
+
   // Extract data from enrollment prop
   const contentCounts = enroll1?.contentCounts || {};
-  
+
   // Get values with fallbacks
   const totalLessons = contentCounts.totalItems || 0;
   const completedLessons = enroll1?.completedItems || 0;
   const isCompleted = (enroll1?.percentCompleted >= 100) || false;
-  
+
   const totalQuizScore = contentCounts.totalQuizScore || 0;
   const totalQuizMaxScore = contentCounts.totalQuizMaxScore || 0;
-  
+
   const videoCount = contentCounts.videos || 0;
   const quizCount = contentCounts.quizzes || 0;
   const articleCount = contentCounts.articles || 0;
   const projectCount = contentCounts.project || 0;
-  
+
   const completedVideos = contentCounts.completedVideos || 0;
   const completedQuizzes = contentCounts.completedQuizzes || 0;
   const completedArticles = contentCounts.completedArticles || 0;
@@ -74,148 +78,148 @@ export function EnrollmentDetailsDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        {isLoading ?<Skeleton/>:<>
-      <DialogTrigger asChild>
-        <Button variant="outline" className="w-full sm:w-auto">View Details</Button>
-      </DialogTrigger>
-      
-      <DialogContent className="w-full max-[425px]:w-[95vw] max-w-sm sm:max-w-md md:max-w-2xl lg:max-w-3xl mx-auto px-4 max-h-full flex flex-col">
-        <DialogHeader className="mb-3 text-left">
-          <DialogTitle>Course Details</DialogTitle>
-        </DialogHeader>
-        
-        <ScrollArea className="flex-1 pr-4 -mr-4 max-h-[700px] overflow-y-auto">
-          <div className="space-y-6 py-2">
-            {/* Course Information */}
-            <div>
-              <div className="grid grid-cols-2 gap-4 mt-2">
-                <div className="space-y-1">
-                  <p className="text-sm font-medium text-muted-foreground">Course Name</p>
-                  <p>{enroll1?.course?.name || 'N/A'}</p>
-                </div>
-                <div className="space-y-1">
-                  <p className="text-sm font-medium text-muted-foreground">Version</p>
-                  <p>{enroll1?.course?.versionDetails?.[0]?.version || 'N/A'}</p>
-                </div>
-                <div className="space-y-1 col-span-2">
-                  <p className="text-sm font-medium text-muted-foreground">Description</p>
-                  <p className="text-sm">{enroll1?.course?.description || 'No description available'}</p>
-                </div>
-                <div className="space-y-1 col-span-2">
-                  <p className="text-sm font-medium text-muted-foreground">Version Description</p>
-                  <p className="text-sm">{enroll1?.course?.versionDetails?.[0]?.description || 'No version description available'}</p>
+      {isLoading ? <Skeleton /> : <>
+        <DialogTrigger asChild>
+          <Button variant="outline" className="w-full sm:w-auto">View Details</Button>
+        </DialogTrigger>
+
+        <DialogContent className="w-full max-[425px]:w-[95vw] max-w-sm sm:max-w-md md:max-w-2xl lg:max-w-3xl mx-auto px-4 max-h-full flex flex-col">
+          <DialogHeader className="mb-3 text-left">
+            <DialogTitle>Course Details</DialogTitle>
+          </DialogHeader>
+
+          <ScrollArea className="flex-1 pr-4 -mr-4 max-h-[700px] overflow-y-auto">
+            <div className="space-y-6 py-2">
+              {/* Course Information */}
+              <div>
+                <div className="grid grid-cols-2 gap-4 mt-2">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">Course Name</p>
+                    <p>{enroll1?.course?.name || 'N/A'}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">Version</p>
+                    <p>{enroll1?.course?.versionDetails?.[0]?.version || versionDetails?.version || 'N/A'}</p>
+                  </div>
+                  <div className="space-y-1 col-span-2">
+                    <p className="text-sm font-medium text-muted-foreground">Description</p>
+                    <p className="text-sm">{enroll1?.course?.description || 'No description available'}</p>
+                  </div>
+                  <div className="space-y-1 col-span-2">
+                    <p className="text-sm font-medium text-muted-foreground">Version Description</p>
+                    <p className="text-sm">{enroll1?.course?.versionDetails?.[0]?.description || versionDetails?.description || 'No version description available'}</p>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <Separator />
+              <Separator />
 
-            {/* Content Summary */}
-            <div>
-              <h3 className="text-lg font-semibold">Content Summary</h3>
-              
-              {/* Show warning if contentCounts is empty */}
-              {Object.keys(contentCounts).length === 0 && (
-                <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg mb-3">
-                  <p className="text-sm text-yellow-800">
-                    Content details are not available for this enrollment.
-                  </p>
-                </div>
-              )}
-              
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-2">
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Total Items</p>
-                  <p className="text-xl font-semibold">{totalLessons}</p>
-                </div>
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Videos</p>
-                  <p className="text-xl font-semibold">{videoCount}</p>
-                </div>
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Quizzes</p>
-                  <p className="text-xl font-semibold">{quizCount}</p>
-                </div>
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Articles</p>
-                  <p className="text-xl font-semibold">{articleCount}</p>
-                </div>
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Projects</p>
-                  <p className="text-xl font-semibold">{projectCount}</p>
-                </div>
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Quiz Scores</p>
-                  <p className="text-xl font-semibold">{totalQuizScore} / {totalQuizMaxScore}</p>
+              {/* Content Summary */}
+              <div>
+                <h3 className="text-lg font-semibold">Content Summary</h3>
+
+                {/* Show warning if contentCounts is empty */}
+                {Object.keys(contentCounts).length === 0 && (
+                  <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg mb-3">
+                    <p className="text-sm text-blue-800">
+                      Course content details will be available after enrollment.
+                    </p>
+                  </div>
+                )}
+
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-2">
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Total Items</p>
+                    <p className="text-xl font-semibold">{totalLessons}</p>
+                  </div>
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Videos</p>
+                    <p className="text-xl font-semibold">{videoCount}</p>
+                  </div>
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Quizzes</p>
+                    <p className="text-xl font-semibold">{quizCount}</p>
+                  </div>
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Articles</p>
+                    <p className="text-xl font-semibold">{articleCount}</p>
+                  </div>
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Projects</p>
+                    <p className="text-xl font-semibold">{projectCount}</p>
+                  </div>
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Quiz Scores</p>
+                    <p className="text-xl font-semibold">{totalQuizScore} / {totalQuizMaxScore}</p>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <Separator />
+              <Separator />
 
-            {/* Completion Details */}
-            <div>
-              <h3 className="text-lg font-semibold">Completion Details</h3>
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-2">
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Total Completed</p>
-                  <p className="text-xl font-semibold">{completedLessons} / {totalLessons}</p>
-                </div>
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Videos Watched</p>
-                  <p className="text-xl font-semibold">{completedVideos} / {videoCount}</p>
-                </div>
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Quizzes Completed</p>
-                  <p className="text-xl font-semibold">{completedQuizzes} / {quizCount}</p>
-                </div>
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Articles Read</p>
-                  <p className="text-xl font-semibold">{completedArticles} / {articleCount}</p>
-                </div>
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Projects Done</p>
-                  <p className="text-xl font-semibold">{completedProjects} / {projectCount}</p>
-                </div>
-                <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
-                  <p className="text-sm font-medium text-muted-foreground">Progress</p>
-                  <p className="text-xl font-semibold">{enroll1?.percentCompleted?.toFixed(2) || 0}%</p>
+              {/* Completion Details */}
+              <div>
+                <h3 className="text-lg font-semibold">Completion Details</h3>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-2">
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Total Completed</p>
+                    <p className="text-xl font-semibold">{completedLessons} / {totalLessons}</p>
+                  </div>
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Videos Watched</p>
+                    <p className="text-xl font-semibold">{completedVideos} / {videoCount}</p>
+                  </div>
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Quizzes Completed</p>
+                    <p className="text-xl font-semibold">{completedQuizzes} / {quizCount}</p>
+                  </div>
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Articles Read</p>
+                    <p className="text-xl font-semibold">{completedArticles} / {articleCount}</p>
+                  </div>
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Projects Done</p>
+                    <p className="text-xl font-semibold">{completedProjects} / {projectCount}</p>
+                  </div>
+                  <div className="space-y-1 p-3 bg-muted/20 rounded-lg">
+                    <p className="text-sm font-medium text-muted-foreground">Progress</p>
+                    <p className="text-xl font-semibold">{enroll1?.percentCompleted?.toFixed(2) || 0}%</p>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <Separator />
+              <Separator />
 
-            {/* Enrollment Details */}
-            <div>
-              <h3 className="text-lg font-semibold">Enrollment Details</h3>
-              <div className="grid grid-cols-2 gap-4 mt-2">
-                <div className="space-y-1">
-                  <p className="text-sm font-medium text-muted-foreground">Enrolled On</p>
-                  <p>{enroll1?.enrollmentDate ? formatDate(enroll1.enrollmentDate) : 'N/A'}</p>
-                </div>
-                <div className="space-y-1">
-                  <p className="text-sm font-medium text-muted-foreground">Status</p>
-                  <div className="flex items-center gap-1">
-                    {isCompleted ? (
-                      <>
-                        <CheckCircle2 className="h-4 w-4 text-green-500" />
-                        <span>Completed</span>
-                      </>
-                    ) : (
-                      <>
-                        <Clock className="h-4 w-4 text-yellow-500" />
-                        <span>In Progress</span>
-                      </>
-                    )}
+              {/* Enrollment Details */}
+              <div>
+                <h3 className="text-lg font-semibold">Enrollment Details</h3>
+                <div className="grid grid-cols-2 gap-4 mt-2">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">Enrolled On</p>
+                    <p>{enroll1?.enrollmentDate ? formatDate(enroll1.enrollmentDate) : 'N/A'}</p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">Status</p>
+                    <div className="flex items-center gap-1">
+                      {isCompleted ? (
+                        <>
+                          <CheckCircle2 className="h-4 w-4 text-green-500" />
+                          <span>Completed</span>
+                        </>
+                      ) : (
+                        <>
+                          <Clock className="h-4 w-4 text-yellow-500" />
+                          <span>In Progress</span>
+                        </>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </ScrollArea>
-      </DialogContent>
-      </> }
+          </ScrollArea>
+        </DialogContent>
+      </>}
     </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
This PR addresses issues with the course details modal in the Student Dashboard.
## Changes
`EnrollmentDetailsDialog.tsx`:
- Added bufferToHex to correctly parse courseVersionId from the enrollment object.
- Added useCourseVersionById hook as a fallback for version name/description.
`CourseCard.tsx`:
- Hidden the "View Details" button for courses in the Available tab, since the backend returns 403 Forbidden for unenrolled students fetching course version details
## Root Cause
`GET /courses/versions/{id}` returns 403 Forbidden for unenrolled students, so the modal always showed "NA" for Version/Version Description. The button is now hidden for available courses until backend permissions are updated.