### PR TITLE
Added toggle button for reordering

### DIFF
--- a/frontend/src/app/pages/teacher/teacher-course-page.tsx
+++ b/frontend/src/app/pages/teacher/teacher-course-page.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo, ChangeEvent, use } from "react";
 import * as Papa from 'papaparse';
 import { useAddQuestionBankToQuiz, useAddQuestionToBank, useCreateQuestion, useCreateQuestionBank, useOverallVideoAnalytics, userParseCSVtoItems, useUpdateItemOptional, useVideoUserAnalytics } from '@/hooks/hooks';
-import { BarChart3, Download, LogOut, Upload, UserRoundCheck, Video, Clock, PlayCircle, Users, Search } from 'lucide-react';
+import { BarChart3, Download, LogOut, Upload, UserRoundCheck, Video, Clock, PlayCircle, Users, Search, LockOpen, Lock } from 'lucide-react';
 import { useHideItem } from '@/hooks/hooks';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 
@@ -137,7 +137,7 @@ function TeacherCourseContent() {
   const [pendingInvites, setPendingInvites] = useState<any[]>([]);
   const invitesRef = useRef<HTMLDivElement | null>(null);
   const [videoTab, setVideoTab] = useState("video");
-
+  const [isReorderEnabled,setIsReorderEnabled]=useState(false);
 
 
 
@@ -1585,12 +1585,32 @@ function TeacherCourseContent() {
           <div className="h-full overflow-hidden border-r border-border/40 bg-sidebar/50">
             <Sidebar variant="sidebar" collapsible="none" className="h-screen w-full">
               <SidebarHeader>
-                <div className="flex items-center gap-3 px-3 py-2">
-                  <BookOpen className="text-primary" />
-                  <div>
-                    <h1 className="text-base font-bold">Vibe (Teacher)</h1>
-                    <p className="text-xs text-muted-foreground">Course Editor</p>
+                <div className="flex justify-between items-center">
+                  <div className="flex items-center gap-3 px-3 py-2">
+                    <BookOpen className="text-primary" />
+                    <div>
+                      <h1 className="text-base font-bold">Vibe (Teacher)</h1>
+                      <p className="text-xs text-muted-foreground">Course Editor</p>
+                    </div>
                   </div>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          size="icon"
+                          variant={isReorderEnabled ? "default" : "ghost"}
+                          className={`h-7 w-7 transition-all duration-200 ${isReorderEnabled ? "bg-primary text-primary-foreground" : "text-muted-foreground"}`}
+                          onClick={() => setIsReorderEnabled((prev) => !prev)}
+                        >
+                          {isReorderEnabled?<LockOpen className="h-4 w-4" />:<Lock className="h-4 w-4" />}
+                          <span className="sr-only">Toggle Reorder</span>
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        {isReorderEnabled ? "Disable Reordering" : "Enable Reordering"}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
                 <Separator className="opacity-50" />
               </SidebarHeader>
@@ -1617,7 +1637,7 @@ function TeacherCourseContent() {
                               key={module.moduleId}
                               value={module}
                               as="div"
-                              drag
+                              drag={isReorderEnabled}
                               className={module.isHidden ? "focus:outline-none opacity-60" : "focus:outline-none"}
                               whileDrag={{ scale: 1.02 }}
                               onDragEnd={() => {
@@ -1667,7 +1687,7 @@ function TeacherCourseContent() {
                                     <Reorder.Item
                                       key={section.sectionId}
                                       value={section}
-                                      drag
+                                      drag={isReorderEnabled}
                                       className={section.isHidden || module.isHidden ? "focus:outline-none opacity-60" : "focus:outline-none"}
                                       whileDrag={{ scale: 1.02 }}
                                       onDragEnd={() => {
@@ -1741,7 +1761,7 @@ function TeacherCourseContent() {
                                                   <Reorder.Item
                                                     key={item._id}
                                                     value={item}
-                                                    drag
+                                                    drag={isReorderEnabled}
                                                     className={section.isHidden || module.isHidden || item.isHidden ? "focus:outline-none opacity-60" : "focus:outline-none"}
                                                     whileDrag={{ scale: 1.02 }}
                                                     onDragEnd={() => {


### PR DESCRIPTION
# Added toggle button for reordering items.

<img width="377" height="228" alt="image" src="https://github.com/user-attachments/assets/34ccdf42-2cb9-42ac-83f1-19ada474e05c" />

## Initially Re-ordering is disabled.

<img width="377" height="228" alt="image" src="https://github.com/user-attachments/assets/39621c63-bec3-41f6-98b1-254bffb196bd" />

## Now we can re-order the items.


# This can prevent accidental re-ordering of items.