### PR TITLE
Fix/save and fetch as objectid for ids in mongodb

### DIFF
--- a/backend/src/modules/courseRegistration/services/CourseRegistrationService.ts
+++ b/backend/src/modules/courseRegistration/services/CourseRegistrationService.ts
@@ -536,8 +536,8 @@ export class CourseRegistrationService extends BaseService {
           if (!item) continue;
           const existingEnrollment = await this.enrollmentRepo.findEnrollment(
             item.userId.toString(),
-            item.versionId.toString(),
             item.courseId.toString(),
+            item.versionId.toString(),
             session,
           );
           if (existingEnrollment) continue;

--- a/backend/src/modules/courses/classes/validators/ItemValidators.ts
+++ b/backend/src/modules/courses/classes/validators/ItemValidators.ts
@@ -649,6 +649,16 @@ class DeleteItemParams {
   @IsMongoId()
   @IsString()
   itemId: string;
+
+  @JSONSchema({
+    title: 'courseId ID',
+    description: 'ID of the courseId to delete',
+    example: '60d5ec49b3f1c8e4a8f8b8f8',
+    type: 'string',
+  })
+  @IsMongoId()
+  @IsString()
+  courseId: string;
 }
 
 class GetItemParams {

--- a/backend/src/modules/courses/classes/validators/ItemValidators.ts
+++ b/backend/src/modules/courses/classes/validators/ItemValidators.ts
@@ -618,6 +618,15 @@ class VersionItemParams {
   @IsMongoId()
   @IsString()
   itemId: string;
+
+  @JSONSchema({
+    title: 'courseId ID',
+    description: 'courseId of the item',
+    type: 'string',
+  })
+  @IsMongoId()
+  @IsString()
+  courseId: string;
 }
 
 class DeleteItemParams {

--- a/backend/src/modules/courses/controllers/ItemController.ts
+++ b/backend/src/modules/courses/controllers/ItemController.ts
@@ -330,7 +330,7 @@ export class ItemController {
   - Instructors or managers of the course.`,
   })
   @Authorized()
-  @Delete('/itemGroups/:itemsGroupId/items/:itemId')
+  @Delete('/:courseId/itemGroups/:itemsGroupId/items/:itemId')
   @UseInterceptor(AuditTrailsHandler)
   @ResponseSchema(DeletedItemResponse, {
     description: 'Item deleted successfully',
@@ -348,7 +348,7 @@ export class ItemController {
     @Ability(getItemAbility) { ability, user },
     @Req() req: Request,
   ) {
-    const { itemsGroupId, itemId } = params;
+    const { itemsGroupId, itemId , courseId} = params;
     const version = await this.itemService.findVersion(itemsGroupId);
     // Create an item resource object for permission checking
     const itemResource = subject('Item', { versionId: version._id.toString() });
@@ -359,7 +359,7 @@ export class ItemController {
       );
     }
 
-    const getItemBeforeDelete = await this.itemService.readItem(user._id.toString(), version._id.toString(), itemId);
+    const getItemBeforeDelete = await this.itemService.readItem(user._id.toString(), version._id.toString(), itemId, courseId);
 
     setAuditTrail(req, {
       category: AuditCategory.ITEM,
@@ -614,7 +614,7 @@ Access control logic:
   ) {
     const { versionId, itemId, courseId, moduleId, sectionId } = params;
     const { _id: userId } = user;
-    console.log("---params----", params);
+
     // Check time slot access for this specific course
     try {
       const timeSlotAccess = await this.timeSlotService.canStudentAccessCourse(

--- a/backend/src/modules/courses/controllers/ItemController.ts
+++ b/backend/src/modules/courses/controllers/ItemController.ts
@@ -251,7 +251,7 @@ export class ItemController {
   - Instructors, managers, and teaching assistants of the course.`,
   })
   @Authorized()
-  @Put('/versions/:versionId/items/:itemId')
+  @Put('/:courseId/versions/:versionId/items/:itemId')
   @UseInterceptor(AuditTrailsHandler)
   @ResponseSchema(ItemDataResponse, {
     description: 'Item updated successfully',
@@ -270,7 +270,7 @@ export class ItemController {
     @Ability(getItemAbility) { ability, user },
     @Req() req: Request,
   ) {
-    const { versionId, itemId } = params;
+    const {courseId, versionId, itemId } = params;
 
     // Create an item resource object for permission checking
     const itemResource = subject('Item', { versionId });
@@ -282,7 +282,7 @@ export class ItemController {
       );
     }
 
-    const getItemBeforeUpdate = await this.itemService.readItem(user._id.toString(), versionId, itemId);
+    const getItemBeforeUpdate = await this.itemService.readItem(user._id.toString(), versionId, itemId, courseId);
 
     const itemData = await this.itemService.updateItem(versionId, itemId, body)
 
@@ -614,7 +614,7 @@ Access control logic:
   ) {
     const { versionId, itemId, courseId, moduleId, sectionId } = params;
     const { _id: userId } = user;
-
+    console.log("---params----", params);
     // Check time slot access for this specific course
     try {
       const timeSlotAccess = await this.timeSlotService.canStudentAccessCourse(
@@ -760,7 +760,7 @@ Accessible to:
     }
 
     const getItemBeforeUpdate = await this.itemService.readItem(user._id.toString(), versionId, itemId);
-
+    console.log("getItemBeforeUpdate----",getItemBeforeUpdate);
     setAuditTrail(req, {
       category: AuditCategory.ITEM,
       action: AuditAction.ITEM_MAKE_OPTIONAL,

--- a/backend/src/modules/courses/services/CourseVersionService.ts
+++ b/backend/src/modules/courses/services/CourseVersionService.ts
@@ -92,7 +92,7 @@ export class CourseVersionService extends BaseService {
       newVersion.courseId = new ObjectId(courseId);
 
       const createdVersion = await this.courseRepo.createVersion(
-        newVersion,
+        {...newVersion, courseId: new ObjectId(newVersion.courseId)},
         txnSession,
       );
       if (!createdVersion) {

--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -277,7 +277,18 @@ export class ItemService extends BaseService {
 
       // Step 6: Update hierarchy timestamps
       const updatedVersion = await this._updateHierarchyAndVersion(
-        version,
+        {...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         module,
         section,
         session,

--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -157,19 +157,7 @@ export class ItemService extends BaseService {
 
     return (await this.courseRepo.updateVersion(
       version._id.toString(),
-      {
-        ...version,
-        courseId: new ObjectId(version.courseId),
-        modules: (version.modules || []).map(module => ({
-          ...module,
-          moduleId: new ObjectId(module.moduleId),
-          sections: (module.sections || []).map(section => ({
-            ...section,
-            sectionId: new ObjectId(section.sectionId),
-            itemsGroupId: new ObjectId(section.itemsGroupId),
-          })),
-        })),
-      },
+      version,
       session,
     )) as CourseVersion; // Assuming version has _id
   }

--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -789,19 +789,7 @@ export class ItemService extends BaseService {
         // Step 5: Update version
         const updatedVersion = await this.courseRepo.updateVersion(
           versionId,
-          {
-            ...version,
-            courseId: new ObjectId(version.courseId),
-            modules: (version.modules || []).map(module => ({
-              ...module,
-              moduleId: new ObjectId(module.moduleId),
-              sections: (module.sections || []).map(section => ({
-                ...section,
-                sectionId: new ObjectId(section.sectionId),
-                itemsGroupId: new ObjectId(section.itemsGroupId),
-              })),
-            })),
-          },
+          version,
           session,
         );
         if (!updatedVersion) {
@@ -883,19 +871,7 @@ export class ItemService extends BaseService {
       );
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        }
+        version,
       );
 
       return { itemsGroup: updatedItemsGroup, version: updatedVersion };
@@ -1063,19 +1039,7 @@ export class ItemService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         courseVersionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
 

--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -157,7 +157,19 @@ export class ItemService extends BaseService {
 
     return (await this.courseRepo.updateVersion(
       version._id.toString(),
-      version,
+      {
+        ...version,
+        courseId: new ObjectId(version.courseId),
+        modules: (version.modules || []).map(module => ({
+          ...module,
+          moduleId: new ObjectId(module.moduleId),
+          sections: (module.sections || []).map(section => ({
+            ...section,
+            sectionId: new ObjectId(section.sectionId),
+            itemsGroupId: new ObjectId(section.itemsGroupId),
+          })),
+        })),
+      },
       session,
     )) as CourseVersion; // Assuming version has _id
   }
@@ -777,7 +789,19 @@ export class ItemService extends BaseService {
         // Step 5: Update version
         const updatedVersion = await this.courseRepo.updateVersion(
           versionId,
-          version,
+          {
+            ...version,
+            courseId: new ObjectId(version.courseId),
+            modules: (version.modules || []).map(module => ({
+              ...module,
+              moduleId: new ObjectId(module.moduleId),
+              sections: (module.sections || []).map(section => ({
+                ...section,
+                sectionId: new ObjectId(section.sectionId),
+                itemsGroupId: new ObjectId(section.itemsGroupId),
+              })),
+            })),
+          },
           session,
         );
         if (!updatedVersion) {
@@ -859,7 +883,19 @@ export class ItemService extends BaseService {
       );
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        }
       );
 
       return { itemsGroup: updatedItemsGroup, version: updatedVersion };
@@ -1027,7 +1063,19 @@ export class ItemService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         courseVersionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
 

--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -465,8 +465,8 @@ export class ItemService extends BaseService {
     // Fetch enrollment early
     const enrollment = await this.enrollmentRepo.findEnrollment(
       userId,
+      courseId,
       versionId,
-      courseId
     );
 
     if (!enrollment) {

--- a/backend/src/modules/courses/services/ModuleService.ts
+++ b/backend/src/modules/courses/services/ModuleService.ts
@@ -107,19 +107,7 @@ export class ModuleService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
 
@@ -151,19 +139,7 @@ export class ModuleService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
 
@@ -208,19 +184,7 @@ export class ModuleService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
       return updatedVersion;
@@ -263,19 +227,7 @@ export class ModuleService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
 
@@ -345,19 +297,7 @@ export class ModuleService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
 
@@ -388,19 +328,7 @@ export class ModuleService extends BaseService {
 
       const updatedVersionWithCounts = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
 

--- a/backend/src/modules/courses/services/ModuleService.ts
+++ b/backend/src/modules/courses/services/ModuleService.ts
@@ -107,7 +107,19 @@ export class ModuleService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
 
@@ -139,7 +151,19 @@ export class ModuleService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
 
@@ -184,7 +208,19 @@ export class ModuleService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
       return updatedVersion;
@@ -227,7 +263,19 @@ export class ModuleService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
 
@@ -297,7 +345,19 @@ export class ModuleService extends BaseService {
 
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
 
@@ -328,7 +388,19 @@ export class ModuleService extends BaseService {
 
       const updatedVersionWithCounts = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
 

--- a/backend/src/modules/courses/services/SectionService.ts
+++ b/backend/src/modules/courses/services/SectionService.ts
@@ -162,7 +162,19 @@ export class SectionService extends BaseService {
       //Update Version
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
       if (!updatedVersion) {
@@ -226,7 +238,19 @@ export class SectionService extends BaseService {
       //Update Version
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
 
@@ -296,7 +320,19 @@ export class SectionService extends BaseService {
 
       await this.courseRepo.updateVersion(
         updatedVersion._id.toString(),
-        updatedVersion,
+        {
+          ...updatedVersion,
+          courseId: new ObjectId(updatedVersion.courseId),
+          modules: (updatedVersion.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
 
@@ -409,7 +445,19 @@ export class SectionService extends BaseService {
       // Update Version
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
       if (!updatedVersion) {

--- a/backend/src/modules/courses/services/SectionService.ts
+++ b/backend/src/modules/courses/services/SectionService.ts
@@ -96,19 +96,7 @@ export class SectionService extends BaseService {
       //Update Version
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
       if (!updatedVersion) {
@@ -162,19 +150,7 @@ export class SectionService extends BaseService {
       //Update Version
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
       if (!updatedVersion) {
@@ -238,19 +214,7 @@ export class SectionService extends BaseService {
       //Update Version
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
 
@@ -320,19 +284,7 @@ export class SectionService extends BaseService {
 
       await this.courseRepo.updateVersion(
         updatedVersion._id.toString(),
-        {
-          ...updatedVersion,
-          courseId: new ObjectId(updatedVersion.courseId),
-          modules: (updatedVersion.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        updatedVersion,
         session,
       );
 
@@ -445,19 +397,7 @@ export class SectionService extends BaseService {
       // Update Version
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        {
-          ...version,
-          courseId: new ObjectId(version.courseId),
-          modules: (version.modules || []).map(module => ({
-            ...module,
-            moduleId: new ObjectId(module.moduleId),
-            sections: (module.sections || []).map(section => ({
-              ...section,
-              sectionId: new ObjectId(section.sectionId),
-              itemsGroupId: new ObjectId(section.itemsGroupId),
-            })),
-          })),
-        },
+        version,
         session,
       );
       if (!updatedVersion) {

--- a/backend/src/modules/courses/services/SectionService.ts
+++ b/backend/src/modules/courses/services/SectionService.ts
@@ -96,7 +96,19 @@ export class SectionService extends BaseService {
       //Update Version
       const updatedVersion = await this.courseRepo.updateVersion(
         versionId,
-        version,
+        {
+          ...version,
+          courseId: new ObjectId(version.courseId),
+          modules: (version.modules || []).map(module => ({
+            ...module,
+            moduleId: new ObjectId(module.moduleId),
+            sections: (module.sections || []).map(section => ({
+              ...section,
+              sectionId: new ObjectId(section.sectionId),
+              itemsGroupId: new ObjectId(section.itemsGroupId),
+            })),
+          })),
+        },
         session,
       );
       if (!updatedVersion) {

--- a/backend/src/modules/quizzes/classes/transformers/Question.ts
+++ b/backend/src/modules/quizzes/classes/transformers/Question.ts
@@ -16,7 +16,7 @@ import {QuestionBody} from '../validators/QuestionValidator.js';
 
 abstract class BaseQuestion implements IQuestion {
   _id?: string | ObjectId;
-  createdBy?: string;
+  createdBy?: string | ObjectId;
   text: string;
   type: QuestionType;
   isParameterized: boolean;
@@ -30,7 +30,7 @@ abstract class BaseQuestion implements IQuestion {
 
   constructor(question: IQuestion, userId: string) {
     this._id = question._id;
-    this.createdBy = userId;
+    this.createdBy = new ObjectId(userId);
     this.text = question.text;
     this.type = question.type;
     this.isParameterized = question.isParameterized;

--- a/backend/src/modules/quizzes/interfaces/grading.ts
+++ b/backend/src/modules/quizzes/interfaces/grading.ts
@@ -3,16 +3,16 @@ import {ILotItem, IQuestion, IUser} from '#root/shared/index.js';
 import {ObjectId} from 'mongodb';
 
 interface ISOLAnswer {
-  lotItemId: string;
+  lotItemId: string | ObjectId;
 }
 
 interface ISMLAnswer {
-  lotItemIds: string[];
+  lotItemIds: string[] | ObjectId[];
 }
 
 interface IOrder {
   order: number;
-  lotItemId: string;
+  lotItemId: string | ObjectId;
 }
 
 interface IOTLAnswer {
@@ -35,7 +35,7 @@ export type Answer =
   | IDESAnswer;
 
 interface IQuestionAnswer {
-  questionId: string;
+  questionId: string | ObjectId;
   questionType: string;
   answer: Answer;
 }

--- a/backend/src/modules/quizzes/question-processing/graders/SMLQuestionGrader.ts
+++ b/backend/src/modules/quizzes/question-processing/graders/SMLQuestionGrader.ts
@@ -33,10 +33,10 @@ class SMLQuestionGrader implements IGrader {
     if (quiz.details.allowPartialGrading) {
       // Partial grading logic
       const correctAnswers = answer.lotItemIds.filter(id =>
-        correctLotItemIds.includes(id),
+        correctLotItemIds.includes(id.toString()),
       );
       const incorrectAnswers = answer.lotItemIds.filter(
-        id => !correctLotItemIds.includes(id),
+        id => !correctLotItemIds.includes(id.toString()),
       );
 
       const score =
@@ -62,7 +62,7 @@ class SMLQuestionGrader implements IGrader {
       // Full grading logic
       const isCorrect =
         answer.lotItemIds.length === correctLotItemIds.length &&
-        answer.lotItemIds.every(id => correctLotItemIds.includes(id));
+        answer.lotItemIds.every(id => correctLotItemIds.includes(id.toString()));
 
       let feedbackText = isCorrect
         ? 'Correct answer!'

--- a/backend/src/modules/quizzes/repositories/providers/mongodb/AttemptRepository.ts
+++ b/backend/src/modules/quizzes/repositories/providers/mongodb/AttemptRepository.ts
@@ -123,7 +123,7 @@ class AttemptRepository {
   }
 
   async countByQuestionId(
-    questionId: string,
+    questionId: string | ObjectId,
     session?: ClientSession,
   ): Promise<number> {
     await this.init();
@@ -139,7 +139,7 @@ class AttemptRepository {
   }
 
   async countDistinctUsersByQuestionId(
-    questionId: string,
+    questionId: string | ObjectId,
     session?: ClientSession,
   ): Promise<number> {
     await this.init();

--- a/backend/src/modules/quizzes/repositories/providers/mongodb/QuestionBankRepository.ts
+++ b/backend/src/modules/quizzes/repositories/providers/mongodb/QuestionBankRepository.ts
@@ -147,7 +147,7 @@ class QuestionBankRepository {
   }
 
   async getQuestionBanksByQuestionId(
-    questionId: string,
+    questionId: string | ObjectId,
     session?: ClientSession,
   ): Promise<IQuestionBank[]> {
     await this.init();

--- a/backend/src/modules/quizzes/repositories/providers/mongodb/QuestionRepository.ts
+++ b/backend/src/modules/quizzes/repositories/providers/mongodb/QuestionRepository.ts
@@ -36,7 +36,7 @@ class QuestionRepository {
     }
   }
   public async getById(
-    questionId: string,
+    questionId: string | ObjectId,
     session?: ClientSession,
   ): Promise<BaseQuestion | null> {
     await this.init();

--- a/backend/src/modules/quizzes/repositories/providers/mongodb/UserQuizMetricsRepository.ts
+++ b/backend/src/modules/quizzes/repositories/providers/mongodb/UserQuizMetricsRepository.ts
@@ -91,7 +91,19 @@ class UserQuizMetricsRepository {
     session?: ClientSession,
   ): Promise<IUserQuizMetrics> {
     await this.init();
-
+    updateData =  
+    {...updateData,
+      userId: new ObjectId(updateData.userId),
+      quizId: new ObjectId(updateData.quizId),
+      latestAttemptId: updateData.latestAttemptId ? new ObjectId(updateData.latestAttemptId): null,
+      latestSubmissionResultId:updateData.latestSubmissionResultId ?
+        new ObjectId(updateData.latestSubmissionResultId) :null,
+      attempts: updateData.attempts.map(attempt => ({
+        ...attempt,
+        attemptId: new ObjectId(attempt.attemptId),
+        submissionResultId: attempt.submissionResultId ? new ObjectId(attempt.submissionResultId): null,
+      }))
+    }
     const result = await this.userQuizMetricsCollection.findOneAndUpdate(
       {_id: new ObjectId(metricsId)},
       {$set: updateData},

--- a/backend/src/modules/quizzes/services/AttemptService.ts
+++ b/backend/src/modules/quizzes/services/AttemptService.ts
@@ -9,6 +9,8 @@ import {
   IQuestionInfo,
   IResponseAnswer,
   ISOLAnswer,
+  ISMLAnswer,
+  IOTLAnswer,
 } from '#quizzes/interfaces/grading.js';
 import {
   QuestionAnswerFeedback,
@@ -128,7 +130,7 @@ class AttemptService extends BaseService {
         true,
       )) as BaseQuestion;
       const questionDetail: IQuestionDetails = {
-        questionId: questionId,
+        questionId: new ObjectId(questionId),
         parameterMap: question.isParameterized
           ? generateRandomParameterMap(question.parameters)
           : null,
@@ -196,7 +198,7 @@ class AttemptService extends BaseService {
     // Now grade only the answered questions
     for (const answer of answers) {
       const question = await this.questionService.getById(
-        answer.questionId,
+        answer.questionId.toString(),
         true,
       );
 
@@ -329,6 +331,18 @@ class AttemptService extends BaseService {
           quizId,
           session,
         );
+        metrics = {...metrics,
+          userId: new ObjectId(metrics.userId),
+          quizId: new ObjectId(metrics.quizId),
+          latestAttemptId: metrics.latestAttemptId ? new ObjectId(metrics.latestAttemptId): null,
+          latestSubmissionResultId:metrics.latestSubmissionResultId ?
+            new ObjectId(metrics.latestSubmissionResultId) :null,
+          attempts: metrics.attempts.map(attempt => ({
+            ...attempt,
+            attemptId: new ObjectId(attempt.attemptId),
+            submissionResultId: attempt.submissionResultId ? new ObjectId(attempt.submissionResultId): null,
+          }))
+        }
       }
 
       // Ensure metrics exists after creation/fetch
@@ -375,9 +389,20 @@ class AttemptService extends BaseService {
       metrics.remainingAttempts =
         quiz.details.maxAttempts === -1 ? -1 : metrics.remainingAttempts - 1;
       metrics.attempts.push({ attemptId: attemptObjectId });
-      const updatedMetrics = await this.userQuizMetricsRepository.update(
+      const updatedMetrics = await this.userQuizMetricsRepository.update( 
         metrics._id.toString(),
-        metrics,
+        {...metrics,
+          userId: new ObjectId(metrics.userId),
+          quizId: new ObjectId(metrics.quizId),
+          latestAttemptId: metrics.latestAttemptId ? new ObjectId(metrics.latestAttemptId): null,
+          latestSubmissionResultId:metrics.latestSubmissionResultId ?
+            new ObjectId(metrics.latestSubmissionResultId) :null,
+          attempts: metrics.attempts.map(attempt => ({
+            ...attempt,
+            attemptId: new ObjectId(attempt.attemptId),
+            submissionResultId: attempt.submissionResultId ? new ObjectId(attempt.submissionResultId): null,
+          }))
+        }
       );
 
       //6. Return the attempt ID
@@ -458,7 +483,18 @@ class AttemptService extends BaseService {
 
         await this.userQuizMetricsRepository.update(
           metrics._id.toString(),
-          metrics,
+          {...metrics,
+            userId: new ObjectId(metrics.userId),
+            quizId: new ObjectId(metrics.quizId),
+            latestAttemptId: metrics.latestAttemptId ? new ObjectId(metrics.latestAttemptId): null,
+            latestSubmissionResultId:metrics.latestSubmissionResultId ?
+              new ObjectId(metrics.latestSubmissionResultId) :null,
+            attempts: metrics.attempts.map(attempt => ({
+              ...attempt,
+              attemptId: new ObjectId(attempt.attemptId),
+              submissionResultId: attempt.submissionResultId ? new ObjectId(attempt.submissionResultId): null,
+            }))
+          },
           session,
         );
 
@@ -489,7 +525,18 @@ class AttemptService extends BaseService {
 
       await this.userQuizMetricsRepository.update(
         metrics._id.toString(),
-        metrics,
+        {...metrics,
+          userId: new ObjectId(metrics.userId),
+          quizId: new ObjectId(metrics.quizId),
+          latestAttemptId: metrics.latestAttemptId ? new ObjectId(metrics.latestAttemptId): null,
+          latestSubmissionResultId:metrics.latestSubmissionResultId ?
+            new ObjectId(metrics.latestSubmissionResultId) :null,
+          attempts: metrics.attempts.map(attempt => ({
+            ...attempt,
+            attemptId: new ObjectId(attempt.attemptId),
+            submissionResultId: attempt.submissionResultId ? new ObjectId(attempt.submissionResultId): null,
+          }))
+        },
         session,
       );
     });
@@ -501,6 +548,13 @@ class AttemptService extends BaseService {
     }
 
     gradingResult = await this._grade(attemptId, quizId, answers);
+    gradingResult = {
+      ...gradingResult,
+      overallFeedback: gradingResult.overallFeedback.map(each => ({
+        ...each,
+        questionId: new ObjectId(each.questionId),
+      })),
+    };
 
     /* -------------------- UPDATE SUBMISSION (SMALL WRITE) -------------------- */
 
@@ -612,6 +666,58 @@ class AttemptService extends BaseService {
     });
   }
 
+  private async _normalizeAnswers(answers: IQuestionAnswer[]) {
+  return answers.map((item) => {
+    const normalizedQuestionId =
+      item.questionId instanceof ObjectId
+        ? item.questionId
+        : new ObjectId(item.questionId);
+
+    let normalizedAnswer = item.answer;
+
+    switch (item.questionType) {
+      case "SELECT_ONE_IN_LOT":
+        normalizedAnswer = {
+          lotItemId:
+            (item.answer as ISOLAnswer).lotItemId instanceof ObjectId
+              ? (item.answer as ISOLAnswer).lotItemId
+              : new ObjectId((item.answer as ISOLAnswer).lotItemId),
+        };
+        break;
+
+      case "SELECT_MULTIPLE_IN_LOT":
+        normalizedAnswer = {
+          lotItemIds: (item.answer as ISMLAnswer).lotItemIds.map((id) =>
+            id instanceof ObjectId ? id : new ObjectId(id)
+          ),
+        };
+        break;
+
+      case "ORDER_THE_LOT":
+        normalizedAnswer = {
+          orders: (item.answer as IOTLAnswer).orders.map((order) => ({
+            ...order,
+            lotItemId:
+              order.lotItemId instanceof ObjectId
+                ? order.lotItemId
+                : new ObjectId(order.lotItemId),
+          })),
+        };
+        break;
+
+      default:
+        // NAT and DES do not need ObjectId normalization
+        break;
+    }
+
+    return {
+      ...item,
+      questionId: normalizedQuestionId,
+      answer: normalizedAnswer,
+    };
+  });
+}
+
   async save(
     userId: string | ObjectId,
     quizId: string,
@@ -667,10 +773,9 @@ class AttemptService extends BaseService {
         if (isSkipped) {
           attempt.isSkipped = true;
         } else {
-          attempt.answers = answers;
+          attempt.answers = await (this._normalizeAnswers(answers));
         }
-
-        await this.attemptRepository.update(attemptId, attempt);
+        await this.attemptRepository.update(attemptId, {...attempt, quizId: new ObjectId(attempt.quizId), userId: new ObjectId(attempt.userId), });
       });
 
       return {

--- a/backend/src/modules/quizzes/services/AttemptService.ts
+++ b/backend/src/modules/quizzes/services/AttemptService.ts
@@ -389,20 +389,9 @@ class AttemptService extends BaseService {
       metrics.remainingAttempts =
         quiz.details.maxAttempts === -1 ? -1 : metrics.remainingAttempts - 1;
       metrics.attempts.push({ attemptId: attemptObjectId });
-      const updatedMetrics = await this.userQuizMetricsRepository.update( 
+      const updatedMetrics = await this.userQuizMetricsRepository.update(
         metrics._id.toString(),
-        {...metrics,
-          userId: new ObjectId(metrics.userId),
-          quizId: new ObjectId(metrics.quizId),
-          latestAttemptId: metrics.latestAttemptId ? new ObjectId(metrics.latestAttemptId): null,
-          latestSubmissionResultId:metrics.latestSubmissionResultId ?
-            new ObjectId(metrics.latestSubmissionResultId) :null,
-          attempts: metrics.attempts.map(attempt => ({
-            ...attempt,
-            attemptId: new ObjectId(attempt.attemptId),
-            submissionResultId: attempt.submissionResultId ? new ObjectId(attempt.submissionResultId): null,
-          }))
-        }
+        metrics,
       );
 
       //6. Return the attempt ID
@@ -483,18 +472,7 @@ class AttemptService extends BaseService {
 
         await this.userQuizMetricsRepository.update(
           metrics._id.toString(),
-          {...metrics,
-            userId: new ObjectId(metrics.userId),
-            quizId: new ObjectId(metrics.quizId),
-            latestAttemptId: metrics.latestAttemptId ? new ObjectId(metrics.latestAttemptId): null,
-            latestSubmissionResultId:metrics.latestSubmissionResultId ?
-              new ObjectId(metrics.latestSubmissionResultId) :null,
-            attempts: metrics.attempts.map(attempt => ({
-              ...attempt,
-              attemptId: new ObjectId(attempt.attemptId),
-              submissionResultId: attempt.submissionResultId ? new ObjectId(attempt.submissionResultId): null,
-            }))
-          },
+          metrics,
           session,
         );
 
@@ -525,18 +503,7 @@ class AttemptService extends BaseService {
 
       await this.userQuizMetricsRepository.update(
         metrics._id.toString(),
-        {...metrics,
-          userId: new ObjectId(metrics.userId),
-          quizId: new ObjectId(metrics.quizId),
-          latestAttemptId: metrics.latestAttemptId ? new ObjectId(metrics.latestAttemptId): null,
-          latestSubmissionResultId:metrics.latestSubmissionResultId ?
-            new ObjectId(metrics.latestSubmissionResultId) :null,
-          attempts: metrics.attempts.map(attempt => ({
-            ...attempt,
-            attemptId: new ObjectId(attempt.attemptId),
-            submissionResultId: attempt.submissionResultId ? new ObjectId(attempt.submissionResultId): null,
-          }))
-        },
+        metrics,
         session,
       );
     });

--- a/backend/src/modules/quizzes/services/QuestionService.ts
+++ b/backend/src/modules/quizzes/services/QuestionService.ts
@@ -13,7 +13,7 @@ import {BaseQuestion} from '../classes/transformers/Question.js';
 import {IQuestionRenderView} from '../question-processing/renderers/interfaces/RenderViews.js';
 import {QuestionProcessor} from '../question-processing/QuestionProcessor.js';
 import {QuizRepository} from '../repositories/providers/mongodb/QuizRepository.js';
-import {ClientSession} from 'mongodb';
+import {ClientSession, ObjectId} from 'mongodb';
 import {aiConfig} from '#root/config/ai.js';
 import {Anthropic} from '@anthropic-ai/sdk';
 import {TranscriptResponse} from '#root/shared/index.js';
@@ -43,7 +43,7 @@ class QuestionService extends BaseService {
   }
 
   private async _getQuestionSkipCount(
-    questionId: string,
+    questionId: string | ObjectId,
     session?: ClientSession,
   ): Promise<number> {
     try {
@@ -99,7 +99,7 @@ class QuestionService extends BaseService {
 
 
   public async getById(
-    questionId: string,
+    questionId: string | ObjectId,
     raw?: boolean,
     parameterMap?: ParameterMap,
   ): Promise<BaseQuestion | IQuestionRenderView> {

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -195,8 +195,8 @@ export class EnrollmentService extends BaseService {
       }
       const existingEnrollment = await this.enrollmentRepo.findEnrollment(
         userId,
-        courseVersionId,
         courseId,
+        courseVersionId,
       );
       // if (!existingEnrollment) {
       //   throw new Error('User is not enrolled in this course version');

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -376,6 +376,7 @@ class ProgressService extends BaseService {
       userId,
       courseId,
       courseVersionId,
+      session
     );
     if (!enrollment) throw new NotFoundError('User has no enrollments');
 

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -374,6 +374,7 @@ class ProgressService extends BaseService {
   ): Promise<void> {
     const enrollment = await this.enrollmentRepo.findEnrollment(
       userId,
+      courseId,
       courseVersionId,
       session
     );
@@ -1413,8 +1414,8 @@ class ProgressService extends BaseService {
 
       const enrollment = await this.enrollmentRepo.findEnrollment(
         userId,
-        courseVersionId,
         courseId,
+        courseVersionId,
         session,
       );
 
@@ -1450,8 +1451,8 @@ class ProgressService extends BaseService {
 
       const enrollment = await this.enrollmentRepo.findEnrollment(
         userId,
-        courseVersionId,
         courseId,
+        courseVersionId,
         existingSession,
       );
       if (!enrollment) {
@@ -1789,8 +1790,8 @@ class ProgressService extends BaseService {
 
     const enrollment = await this.enrollmentRepo.findEnrollment(
       userId,
-      courseVersionId,
       courseId,
+      courseVersionId,
     );
     if (!enrollment) return;
 
@@ -3327,7 +3328,7 @@ class ProgressService extends BaseService {
     const [completedItemIds, courseVersion, enrollment] = await Promise.all([
       this.progressRepository.getCompletedItems(userId, courseId, versionId),
       this.courseRepo.readVersion(versionId),
-      this.enrollmentRepo.findEnrollment(userId, versionId, courseId),
+      this.enrollmentRepo.findEnrollment(userId, courseId, versionId),
     ]);
 
     if (!courseVersion) {

--- a/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
@@ -1156,7 +1156,9 @@ export class CourseRepository implements ICourseRepository {
     await this.init();
     const isExistVersion = await this.courseVersionCollection.findOne({
         _id: new ObjectId(versionId),
-      });
+      },
+      { session },
+    );
     if (!isExistVersion)
       throw new NotFoundError('Course version not founded!',);
     return isExistVersion.versionStatus;

--- a/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
@@ -548,6 +548,19 @@ export class CourseRepository implements ICourseRepository {
   ): Promise<ICourseVersion | null> {
     await this.init();
     try {
+      courseVersion = {
+        ...courseVersion,
+        courseId: new ObjectId(courseVersion.courseId),
+        modules: (courseVersion.modules || []).map(module => ({
+          ...module,
+          moduleId: new ObjectId(module.moduleId),
+          sections: (module.sections || []).map(section => ({
+            ...section,
+            sectionId: new ObjectId(section.sectionId),
+            itemsGroupId: new ObjectId(section.itemsGroupId),
+          })),
+        })),
+      }
       const { _id: _, ...fields } = courseVersion;
 
       const isExistVersion = await this.courseVersionCollection.findOne({

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -89,17 +89,16 @@ export class EnrollmentRepository {
 
     const courseObjectId = new ObjectId(courseId);
     const courseVersionObjectId = new ObjectId(courseVersionId);
-
     const userObjectid = new ObjectId(userId);
 
     return await this.enrollmentCollection.findOne(
       {
-        userId: userObjectid,
-        courseId: courseObjectId,
-        courseVersionId: courseVersionObjectId,
+        userId: { $in: [userId, new ObjectId(userId)] },
+        courseId: { $in: [courseId, new ObjectId(courseId)] },
+        courseVersionId: { $in: [courseVersionId, new ObjectId(courseVersionId)] },
         isDeleted: { $ne: true },
       },
-      { session },
+      { session }
     );
   }
 
@@ -117,13 +116,13 @@ export class EnrollmentRepository {
 
     return await this.enrollmentCollection.findOne(
       {
-        userId: userObjectid,
-        courseId: courseObjectId,
-        courseVersionId: courseVersionObjectId,
+        userId: { $in: [userObjectid, userId] },
+        courseId: { $in: [courseObjectId, courseId] },
+        courseVersionId: { $in: [courseVersionObjectId, courseVersionId] },
         status: 'ACTIVE',
         isDeleted: { $ne: true },
       },
-      { session },
+      { session }
     );
   }
 
@@ -137,8 +136,8 @@ export class EnrollmentRepository {
     const enrollments = await this.enrollmentCollection
       .find(
         {
-          courseId: new ObjectId(courseId),
-          courseVersionId: new ObjectId(versionId),
+          courseId: { $in: [new ObjectId(courseId), courseId] },
+          courseVersionId: { $in: [new ObjectId(versionId), versionId] },
           role: 'INSTRUCTOR',
           status: 'ACTIVE',
         },
@@ -334,7 +333,7 @@ export class EnrollmentRepository {
       const aggregationPipeline: any[] = [
         {
           $match: {
-            userId: userObjectId,
+            userId: { $in: [userObjectId, userId] },
             role,
             isDeleted: { $ne: true },
             status: 'ACTIVE',
@@ -525,7 +524,7 @@ export class EnrollmentRepository {
     const pipeline: any[] = [
       {
         $match: {
-          userId: userObjectId,
+          userId: { $in: [userObjectId, userId] },
           role,
           isDeleted: { $ne: true },
           status: { $regex: /^active$/i },
@@ -789,7 +788,7 @@ export class EnrollmentRepository {
       /* ---------- EARLY FILTER (INDEXED) ---------- */
       {
         $match: {
-          userId: new ObjectId(userId),
+          userId: { $in: [new ObjectId(userId), userId] },
           role,
           isDeleted: { $ne: true },
           status: { $regex: /^active$/i },
@@ -1346,8 +1345,8 @@ export class EnrollmentRepository {
     await this.init();
 
     const baseMatch: any = {
-      courseId: new ObjectId(courseId),
-      courseVersionId: new ObjectId(courseVersionId),
+      courseId: { $in: [courseId, new ObjectId(courseId)] },
+      courseVersionId: { $in: [courseVersionId, new ObjectId(courseVersionId)] }
     };
 
     let matchStage: any = { ...baseMatch };
@@ -1510,8 +1509,12 @@ export class EnrollmentRepository {
         [
           {
             $match: {
-              courseId: new ObjectId(courseId),
-              courseVersionId: new ObjectId(courseVersionId),
+              courseId: {
+                $in: [courseId, new ObjectId(courseId)]
+              },
+              courseVersionId: {
+                $in: [courseVersionId, new ObjectId(courseVersionId)]
+              },
               role: 'STUDENT',
               status: { $regex: /^active$/i },
               isDeleted: { $ne: true }, // Exclude soft-deleted enrollments
@@ -1589,7 +1592,7 @@ export class EnrollmentRepository {
   ) {
     await this.init();
     const matchStage: any = {
-      userId: new ObjectId(userId),
+      userId: { $in: [new ObjectId(userId), userId] },
       role,
       isDeleted: { $ne: true },
       status: { $regex: /^active$/i },

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -81,8 +81,8 @@ export class EnrollmentRepository {
 
   async findEnrollment(
     userId: string | ObjectId,
-    courseVersionId: string,
     courseId: string,
+    courseVersionId: string,
     session?: ClientSession,
   ): Promise<IEnrollment | null> {
     await this.init();

--- a/backend/src/shared/database/providers/mongo/repositories/ItemRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ItemRepository.ts
@@ -219,6 +219,12 @@ export class ItemRepository implements IItemRepository {
   ): Promise<ItemsGroup> {
     await this.init();
     const { _id, ...fields } = itemsGroup;
+    fields.items = (fields.items).map(item => ({
+      ...item,
+      _id: typeof item._id === "string"
+        ? new ObjectId(item._id)
+        : item._id,
+    }));
     const result = await this.itemsGroupCollection.updateOne(
       { _id: new ObjectId(itemsGroupId) },
       { $set: fields },

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -98,41 +98,12 @@ class ProgressRepository {
   ): Promise<string[]> {
     await this.init();
 
-    // const distinctItemIds = await this.watchTimeCollection.distinct(
-    //   'itemId',
-    //   {
-    //     userId: new ObjectId(userId),
-    //     courseId: new ObjectId(courseId),
-    //     courseVersionId: new ObjectId(courseVersionId),
-    //     endTime: { $exists: true, $ne: null },
-    //     isDeleted: { $ne: true },
-
-    //   },
-    //   { session },
-    // );
     const distinctItemIds = await this.watchTimeCollection.distinct(
       'itemId',
       {
-        $and:[
-          {
-            $or:[
-              { userId: new ObjectId(userId) },
-              { userId: userId }
-            ]
-          },
-          {
-            $or:[
-              { courseId: new ObjectId(courseId) },
-              { courseId: courseId }
-            ]
-          },
-          {
-            $or:[
-              { courseVersionId: new ObjectId(courseVersionId) },
-              { courseVersionId: courseVersionId }
-            ]
-          },
-        ],
+        userId: new ObjectId(userId),
+        courseId: new ObjectId(courseId),
+        courseVersionId: new ObjectId(courseVersionId),
         endTime: { $exists: true, $ne: null },
         isDeleted: { $ne: true },
       },
@@ -443,45 +414,17 @@ class ProgressRepository {
     session?: ClientSession,
   ): Promise<IProgress | null> {
     await this.init();
-    // return await this.progressCollection.findOne(
-    //   {
-    //     userId: new ObjectId(userId),
-    //     courseId: new ObjectId(courseId),
-    //     courseVersionId: new ObjectId(courseVersionId),
-    //     isDeleted: { $ne: true },
-    //   },
-    //   {
-    //     session,
-    //   },
-    // );
-    const normalizedUserId =
-    typeof userId === "string" ? new ObjectId(userId) : userId;
-    return await this.progressCollection.findOne({
-      $and: [
-        {
-          $or: [
-            { userId: normalizedUserId },
-            { userId: userId }
-          ]
-        },
-        {
-          $or: [
-            { courseId: new ObjectId(courseId) },
-            { courseId: courseId }
-          ]
-        },
-        {
-          $or: [
-            { courseVersionId: new ObjectId(courseVersionId) },
-            { courseVersionId: courseVersionId }
-          ]
-        }
-      ],
-      isDeleted: { $ne: true }
-    },
-    {
-      session,
-    },);
+    return await this.progressCollection.findOne(
+      {
+        userId: { $in: [new ObjectId(userId), userId] },
+        courseId: { $in: [new ObjectId(courseId), courseId] },
+        courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
+        isDeleted: { $ne: true }
+      },
+      {
+        session,
+      }
+    );
   }
 
   async deleteProgress(
@@ -493,17 +436,15 @@ class ProgressRepository {
     await this.init();
     await this.progressCollection.updateOne(
       {
-        userId: new ObjectId(userId),
-        courseId: new ObjectId(courseId),
-        courseVersionId: new ObjectId(courseVersionId),
+        userId: { $in: [new ObjectId(userId), userId] },
+        courseId: { $in: [new ObjectId(courseId), courseId] },
+        courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
       },
       { $set: { isDeleted: true, deletedAt: new Date() } },
       {
         session,
       },
     );
-
-
   }
 
   async findById(
@@ -548,9 +489,9 @@ class ProgressRepository {
 
     const result = await this.progressCollection.findOneAndUpdate(
       {
-        userId: new ObjectId(userId),
-        courseId: new ObjectId(courseId),
-        courseVersionId: new ObjectId(courseVersionId),
+        userId: { $in: [new ObjectId(userId), userId] },
+        courseId: { $in: [new ObjectId(courseId), courseId] },
+        courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
       },
       { $set: normalizedProgress },
       { returnDocument: 'after', session },
@@ -682,9 +623,9 @@ class ProgressRepository {
     await this.init();
     const result = await this.progressCollection.findOneAndUpdate(
       {
-        userId: new ObjectId(userId),
-        courseId: new ObjectId(courseId),
-        courseVersionId: new ObjectId(courseVersionId),
+        userId: { $in: [new ObjectId(userId), userId] },
+        courseId: { $in: [new ObjectId(courseId), courseId] },
+        courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
         isDeleted: { $ne: true },
       },
       { $set: progress },
@@ -722,7 +663,7 @@ class ProgressRepository {
   async deleteProgressByVersionId(versionId: string, session?: ClientSession) {
     await this.init();
     await this.progressCollection.updateMany(
-      { courseVersionId: new ObjectId(versionId) },
+      { courseVersionId: { $in: [new ObjectId(versionId), versionId] }, },
       { $set: { isDeleted: true, deletedAt: new Date() } },
       { session },
     );
@@ -737,8 +678,8 @@ class ProgressRepository {
     const progressRecords = await this.progressCollection
       .find(
         {
-          courseId: new ObjectId(courseId),
-          courseVersionId: new ObjectId(courseVersionId),
+          courseId: { $in: [new ObjectId(courseId), courseId] },
+          courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
         },
         { session },
       )
@@ -778,7 +719,7 @@ class ProgressRepository {
   ): Promise<number> {
     await this.init();
     const result = await this.progressCollection.updateMany(
-      { currentItem: new ObjectId(itemId) },
+      { currentItem: { $in: [new ObjectId(itemId), itemId] } },
       { $set: updateData },
       { session },
     );
@@ -792,7 +733,7 @@ class ProgressRepository {
   ): Promise<number> {
     await this.init();
     const result = await this.progressCollection.updateMany(
-      { currentSection: new ObjectId(sectionId) },
+      { currentSection: { $in: [new ObjectId(sectionId), sectionId] } },
       { $set: updateData },
       { session },
     );
@@ -806,7 +747,7 @@ class ProgressRepository {
   ): Promise<number> {
     await this.init();
     const result = await this.progressCollection.updateMany(
-      { currentModule: new ObjectId(moduleId) },
+      { currentModule: { $in: [new ObjectId(moduleId), moduleId] } },
       { $set: updateData },
       { session },
     );
@@ -821,8 +762,8 @@ class ProgressRepository {
     await this.init();
     const progress = await this.progressCollection.findOne(
       {
-        userId: new ObjectId(userId),
-        courseVersionId: new ObjectId(courseVersionId),
+        userId: { $in: [new ObjectId(userId), userId] },
+        courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
         isDeleted: { $ne: true },
       },
       { session },

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -275,12 +275,10 @@ class ProgressRepository {
     session?: ClientSession,
   ): Promise<void> {
     await this.init();
-    console.log("---deleteUserWatchTimeByCourseVersion-", userId, courseId, courseVersionId)
     if (!this.watchTimeCollection) {
       console.log('[ProgressRepository] watchTimeCollection not initialized');
       return;
     }
-    console.log("---deleteUserWatchTimeByCourseVersion-")
     const result = await this.watchTimeCollection.updateMany(
       {
         userId: new ObjectId(userId),
@@ -290,7 +288,6 @@ class ProgressRepository {
       { $set: { isDeleted: true, deletedAt: new Date() } },
       { session },
     );
-    console.log("--------deleteUserWatchTimeByCourseVersion-", result);
     if (result?.modifiedCount === 0) {
       console.log(
         `No watch time records found for course version ID: ${courseVersionId}, user ID: ${userId} and course ID: ${courseId}`,

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -98,19 +98,46 @@ class ProgressRepository {
   ): Promise<string[]> {
     await this.init();
 
+    // const distinctItemIds = await this.watchTimeCollection.distinct(
+    //   'itemId',
+    //   {
+    //     userId: new ObjectId(userId),
+    //     courseId: new ObjectId(courseId),
+    //     courseVersionId: new ObjectId(courseVersionId),
+    //     endTime: { $exists: true, $ne: null },
+    //     isDeleted: { $ne: true },
+
+    //   },
+    //   { session },
+    // );
     const distinctItemIds = await this.watchTimeCollection.distinct(
       'itemId',
       {
-        userId: new ObjectId(userId),
-        courseId: new ObjectId(courseId),
-        courseVersionId: new ObjectId(courseVersionId),
+        $and:[
+          {
+            $or:[
+              { userId: new ObjectId(userId) },
+              { userId: userId }
+            ]
+          },
+          {
+            $or:[
+              { courseId: new ObjectId(courseId) },
+              { courseId: courseId }
+            ]
+          },
+          {
+            $or:[
+              { courseVersionId: new ObjectId(courseVersionId) },
+              { courseVersionId: courseVersionId }
+            ]
+          },
+        ],
         endTime: { $exists: true, $ne: null },
         isDeleted: { $ne: true },
-
       },
       { session },
     );
-
     return distinctItemIds.map(id => id.toString());
   }
 
@@ -248,10 +275,12 @@ class ProgressRepository {
     session?: ClientSession,
   ): Promise<void> {
     await this.init();
+    console.log("---deleteUserWatchTimeByCourseVersion-", userId, courseId, courseVersionId)
     if (!this.watchTimeCollection) {
       console.log('[ProgressRepository] watchTimeCollection not initialized');
       return;
     }
+    console.log("---deleteUserWatchTimeByCourseVersion-")
     const result = await this.watchTimeCollection.updateMany(
       {
         userId: new ObjectId(userId),
@@ -261,7 +290,7 @@ class ProgressRepository {
       { $set: { isDeleted: true, deletedAt: new Date() } },
       { session },
     );
-
+    console.log("--------deleteUserWatchTimeByCourseVersion-", result);
     if (result?.modifiedCount === 0) {
       console.log(
         `No watch time records found for course version ID: ${courseVersionId}, user ID: ${userId} and course ID: ${courseId}`,
@@ -417,17 +446,45 @@ class ProgressRepository {
     session?: ClientSession,
   ): Promise<IProgress | null> {
     await this.init();
-    return await this.progressCollection.findOne(
-      {
-        userId: new ObjectId(userId),
-        courseId: new ObjectId(courseId),
-        courseVersionId: new ObjectId(courseVersionId),
-        isDeleted: { $ne: true },
-      },
-      {
-        session,
-      },
-    );
+    // return await this.progressCollection.findOne(
+    //   {
+    //     userId: new ObjectId(userId),
+    //     courseId: new ObjectId(courseId),
+    //     courseVersionId: new ObjectId(courseVersionId),
+    //     isDeleted: { $ne: true },
+    //   },
+    //   {
+    //     session,
+    //   },
+    // );
+    const normalizedUserId =
+    typeof userId === "string" ? new ObjectId(userId) : userId;
+    return await this.progressCollection.findOne({
+      $and: [
+        {
+          $or: [
+            { userId: normalizedUserId },
+            { userId: userId }
+          ]
+        },
+        {
+          $or: [
+            { courseId: new ObjectId(courseId) },
+            { courseId: courseId }
+          ]
+        },
+        {
+          $or: [
+            { courseVersionId: new ObjectId(courseVersionId) },
+            { courseVersionId: courseVersionId }
+          ]
+        }
+      ],
+      isDeleted: { $ne: true }
+    },
+    {
+      session,
+    },);
   }
 
   async deleteProgress(

--- a/backend/src/shared/middleware/auditTrails.ts
+++ b/backend/src/shared/middleware/auditTrails.ts
@@ -48,6 +48,7 @@ import { InterceptorInterface, Action} from 'routing-controllers';
 import {injectable, inject} from 'inversify';
 import {AUDIT_TRAILS_TYPES} from '#root/modules/auditTrails/types.js';
 import {IAuditTrailsRepository} from '#root/modules/auditTrails/interfaces/IAuditTrailsRepository.js';
+import { ObjectId } from 'mongodb';
 
 @injectable()
 export class AuditTrailsHandler implements InterceptorInterface {
@@ -80,6 +81,7 @@ export class AuditTrailsHandler implements InterceptorInterface {
       //To-be implemented -> implement the background queue job.
       await this.auditTrailsRepo.createAuditTrail({
         ...auditData,
+        actor: new ObjectId(String(auditData.actor)),
         createdAt: new Date(),
       });
     } catch (err) {

--- a/frontend/src/app/pages/teacher/FeedbackFormEditor.tsx
+++ b/frontend/src/app/pages/teacher/FeedbackFormEditor.tsx
@@ -103,6 +103,7 @@ export default function FeedbackFormEditor({
       await updateItem.mutateAsync({
         params: {
           path: {
+            courseId: courseId,
             versionId: courseVersionId,
             itemId: feedbackId,
           },

--- a/frontend/src/app/pages/teacher/components/enhanced-blog-editor.tsx
+++ b/frontend/src/app/pages/teacher/components/enhanced-blog-editor.tsx
@@ -93,6 +93,7 @@ const EnhancedBlogEditor: React.FC<EnhancedBlogEditorProps> = ({
   details,
   onDelete,
   onRefetch,
+  courseId
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -911,6 +912,7 @@ const EnhancedBlogEditor: React.FC<EnhancedBlogEditorProps> = ({
       await updateItem.mutateAsync({
         params: {
           path: {
+            courseId: courseId,
             versionId: courseVersionId,
             itemId: blogId,
           },

--- a/frontend/src/app/pages/teacher/components/enhanced-quiz-editor.tsx
+++ b/frontend/src/app/pages/teacher/components/enhanced-quiz-editor.tsx
@@ -524,6 +524,7 @@ const EnhancedQuizEditor: React.FC<EnhancedQuizEditorProps> = ({
       await updateItem.mutateAsync({
         params: {
           path: {
+            courseId: courseId,
             versionId: courseVersionId,
             // moduleId,
             // sectionId,

--- a/frontend/src/app/pages/teacher/teacher-course-page.tsx
+++ b/frontend/src/app/pages/teacher/teacher-course-page.tsx
@@ -3011,6 +3011,7 @@ function TeacherCourseContent() {
                                   deleteItemAsync({
                                     params: {
                                       path: {
+                                        courseId: courseId || "",
                                         itemsGroupId: selectedEntity.parentIds?.itemsGroupId || "",
                                         itemId: selectedEntity.data._id
                                       }
@@ -3068,7 +3069,7 @@ function TeacherCourseContent() {
                           questionId={currentCourse?.questionId || null}
                           onDelete={() => {
                             deleteItemAsync({
-                              params: { path: { itemsGroupId: selectedEntity.parentIds?.itemsGroupId || "", itemId: selectedQuizId } }
+                              params: { path: { courseId: courseId, itemsGroupId: selectedEntity.parentIds?.itemsGroupId || "", itemId: selectedQuizId } }
                             }).then((res) => {
                               refetchVersion();
                               refetchItems();
@@ -3108,7 +3109,7 @@ function TeacherCourseContent() {
                             if (selectedEntity.parentIds?.itemsGroupId && projectId) {
 
                               await deleteItemAsync({
-                                params: { path: { itemsGroupId: selectedEntity.parentIds.itemsGroupId, itemId: projectId } },
+                                params: { path: {courseId:courseId, itemsGroupId: selectedEntity.parentIds.itemsGroupId, itemId: projectId } },
                               });
                               refetchVersion();
                               refetchItems();
@@ -3140,7 +3141,7 @@ function TeacherCourseContent() {
                           }}
                           onDelete={() => {
                             deleteItemAsync({
-                              params: { path: { itemsGroupId: selectedEntity.parentIds?.itemsGroupId || "", itemId: selectedEntity.data._id } }
+                              params: { path: {courseId:courseId, itemsGroupId: selectedEntity.parentIds?.itemsGroupId || "", itemId: selectedEntity.data._id } }
                             }).then((res) => {
                               refetchVersion();
                               refetchItems();
@@ -3173,7 +3174,7 @@ function TeacherCourseContent() {
                           }}
                           onDelete={() => {
                             deleteItemAsync({
-                              params: { path: { itemsGroupId: selectedEntity.parentIds?.itemsGroupId || "", itemId: selectedEntity.data._id } }
+                              params: { path: {courseId: courseId || "", itemsGroupId: selectedEntity.parentIds?.itemsGroupId || "", itemId: selectedEntity.data._id } }
                             }).then(() => {
                               refetchVersion();
                               refetchItems();

--- a/frontend/src/app/pages/teacher/teacher-course-page.tsx
+++ b/frontend/src/app/pages/teacher/teacher-course-page.tsx
@@ -334,7 +334,9 @@ function TeacherCourseContent() {
   } = useItemById(
     shouldFetchItem ? courseId : '',
     shouldFetchItem ? versionId : '',
-    shouldFetchItem ? selectedEntity?.data?._id : ''
+    shouldFetchItem ? selectedEntity?.data?._id : '',
+    shouldFetchItem ? activeSectionInfo!.moduleId : '',
+    shouldFetchItem ? activeSectionInfo!.sectionId : '',
   );
 
   const [videoAnalyticsPage, setVideoAnalyticsPage] = useState(1);

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -1169,8 +1169,8 @@ export function useVideoUserAnalytics(
 
 
 export function useUpdateCourseItem(): {
-  mutate: (variables: { params: { path: { versionId: string, itemId: string } }, body: components['schemas']['UpdateItemBody'] }) => void,
-  mutateAsync: (variables: { params: { path: { versionId: string, itemId: string } }, body: components['schemas']['UpdateItemBody'] }) => Promise<components['schemas']['ItemDataResponse']>,
+  mutate: (variables: { params: { path: { courseId: string, versionId: string, itemId: string } }, body: components['schemas']['UpdateItemBody'] }) => void,
+  mutateAsync: (variables: { params: { path: { courseId: string, versionId: string, itemId: string } }, body: components['schemas']['UpdateItemBody'] }) => Promise<components['schemas']['ItemDataResponse']>,
   data: components['schemas']['ItemDataResponse'] | undefined,
   error: string | null,
   isPending: boolean,
@@ -1180,7 +1180,7 @@ export function useUpdateCourseItem(): {
   reset: () => void,
   status: 'idle' | 'pending' | 'success' | 'error'
 } {
-  const result = api.useMutation("put", "/courses/versions/{versionId}/items/{itemId}");
+  const result = api.useMutation("put", "/courses/{courseId}/versions/{versionId}/items/{itemId}");
   return {
     ...result,
     error: result.error ? (result.error.message || 'Item update failed') : null

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -1229,9 +1229,9 @@ export function useUpdateItem(): {
 }
 
 // DELETE /courses/itemGroups/{itemsGroupId}/items/{itemId}
-export function useDeleteItem(): {
-  mutate: (variables: { params: { path: { itemsGroupId: string, itemId: string } } }) => void,
-  mutateAsync: (variables: { params: { path: { itemsGroupId: string, itemId: string } } }) => Promise<components['schemas']['DeletedItemResponse']>,
+export function useDeleteItem(): { 
+  mutate: (variables: { params: { path: { courseId: string, itemsGroupId: string, itemId: string } } }) => void,
+  mutateAsync: (variables: { params: { path: { courseId : string, itemsGroupId: string, itemId: string } } }) => Promise<components['schemas']['DeletedItemResponse']>,
   data: components['schemas']['DeletedItemResponse'] | undefined,
   error: string | null,
   isPending: boolean,
@@ -1241,7 +1241,7 @@ export function useDeleteItem(): {
   reset: () => void,
   status: 'idle' | 'pending' | 'success' | 'error'
 } {
-  const result = api.useMutation("delete", "/courses/itemGroups/{itemsGroupId}/items/{itemId}");
+  const result = api.useMutation("delete", "/courses/{courseId}/itemGroups/{itemsGroupId}/items/{itemId}");
   return {
     ...result,
     error: result.error ? (result.error.message || 'Item deletion failed') : null


### PR DESCRIPTION
- Fix: While we save documents in database, the id reference should be saved as Object Id but some times it got saved as normal string. Therefore founded the leakages where the ids were saved as string instead of Object Id and corrected it.
- Also added the logic to fetch data with string as well as object Id both in few cases where the id reference may have been saved with string instead of Object Id.