### PR TITLE
fix/view progress error

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -1346,7 +1346,7 @@ class ProgressService extends BaseService {
       }
 
       const section = module.sections.find(
-        s => s.sectionId === currentSection.toString(),
+        s => s.sectionId.toString() === currentSection.toString(),
       );
 
       if (!section) {

--- a/frontend/src/components/quiz.tsx
+++ b/frontend/src/components/quiz.tsx
@@ -498,6 +498,13 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
     [currentCourse, stopItem, attemptId]
   );
 
+  useEffect(() => {
+    return () => {
+      if (emptyQuizNextTimerRef.current) {
+        clearTimeout(emptyQuizNextTimerRef.current);
+      }
+    };
+  }, []);
 
   // Handle empty quiz without attempting to start it
   const handleEmptyQuiz = useCallback(async () => {


### PR DESCRIPTION
- issue: view progress was throwing null error
-fix: Compare both side with string instead of objectid and string

- issue: While on an empty quiz if another item was clicked the emptyquiz timer was still On
-fix: Have added code to remove emptyquiz timer when page reloads.
