### PR TITLE
Avoid watchtime recreation for completed item

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -1,10 +1,10 @@
-import { Item, ItemsGroup } from '#courses/classes/transformers/Item.js';
-import { COURSES_TYPES } from '#courses/types.js';
-import { BaseService } from '#root/shared/classes/BaseService.js';
-import { ICourseRepository } from '#root/shared/database/interfaces/ICourseRepository.js';
-import { IItemRepository } from '#root/shared/database/interfaces/IItemRepository.js';
-import { IUserRepository } from '#root/shared/database/interfaces/IUserRepository.js';
-import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {Item, ItemsGroup} from '#courses/classes/transformers/Item.js';
+import {COURSES_TYPES} from '#courses/types.js';
+import {BaseService} from '#root/shared/classes/BaseService.js';
+import {ICourseRepository} from '#root/shared/database/interfaces/ICourseRepository.js';
+import {IItemRepository} from '#root/shared/database/interfaces/IItemRepository.js';
+import {IUserRepository} from '#root/shared/database/interfaces/IUserRepository.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
 import {
   ICourseVersion,
   IWatchTime,
@@ -13,25 +13,21 @@ import {
   IBlogDetails,
   ICurrentProgressPath,
 } from '#root/shared/interfaces/models.js';
-import { GLOBAL_TYPES } from '#root/types.js';
-import { ProgressRepository } from '#shared/database/providers/mongo/repositories/ProgressRepository.js';
-import { Progress } from '#users/classes/transformers/Progress.js';
-import { USERS_TYPES } from '#users/types.js';
-import { injectable, inject } from 'inversify';
-import { ClientSession, ObjectId } from 'mongodb';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {ProgressRepository} from '#shared/database/providers/mongo/repositories/ProgressRepository.js';
+import {Progress} from '#users/classes/transformers/Progress.js';
+import {USERS_TYPES} from '#users/types.js';
+import {injectable, inject} from 'inversify';
+import {ClientSession, ObjectId} from 'mongodb';
 import {
   NotFoundError,
   BadRequestError,
   InternalServerError,
 } from 'routing-controllers';
-import { SubmissionRepository } from '#quizzes/repositories/providers/mongodb/SubmissionRepository.js';
-import { QUIZZES_TYPES } from '#quizzes/types.js';
-import { WatchTime } from '../classes/transformers/WatchTime.js';
-import {
-
-  ISettingRepository,
-
-} from '#shared/index.js';
+import {SubmissionRepository} from '#quizzes/repositories/providers/mongodb/SubmissionRepository.js';
+import {QUIZZES_TYPES} from '#quizzes/types.js';
+import {WatchTime} from '../classes/transformers/WatchTime.js';
+import {ISettingRepository} from '#shared/index.js';
 import {
   CompletedProgressResponse,
   GetLeaderboardResponse,
@@ -41,14 +37,14 @@ import {
   QuizRepository,
   UserQuizMetricsRepository,
 } from '#root/modules/quizzes/repositories/index.js';
-import { EnrollmentRepository } from '#root/shared/index.js';
-import { PROJECTS_TYPES } from '#root/modules/projects/types.js';
-import { IProjectSubmissionRepository } from '#root/modules/projects/interfaces/IProjectSubmissionRepository.js';
-import { FeedbackRepository } from '#root/modules/quizzes/repositories/providers/mongodb/FeedbackRepository.js';
-import { GetCurrentProgressPathResponse } from '../classes/dtos/GetCurrentProgressPathResponse.js';
-import { SETTING_TYPES } from '#root/modules/setting/types.js';
-import { CourseSettingService } from '#root/modules/setting/index.js';
-import { getContainer } from '#root/bootstrap/loadModules.js';
+import {EnrollmentRepository} from '#root/shared/index.js';
+import {PROJECTS_TYPES} from '#root/modules/projects/types.js';
+import {IProjectSubmissionRepository} from '#root/modules/projects/interfaces/IProjectSubmissionRepository.js';
+import {FeedbackRepository} from '#root/modules/quizzes/repositories/providers/mongodb/FeedbackRepository.js';
+import {GetCurrentProgressPathResponse} from '../classes/dtos/GetCurrentProgressPathResponse.js';
+import {SETTING_TYPES} from '#root/modules/setting/types.js';
+import {CourseSettingService} from '#root/modules/setting/index.js';
+import {getContainer} from '#root/bootstrap/loadModules.js';
 
 @injectable()
 class ProgressService extends BaseService {
@@ -101,7 +97,7 @@ class ProgressService extends BaseService {
    * Private helper method for the enrollment process.
    */
 
-  private getFirstByOrder<T extends { order?: string }>(arr?: T[]): T | null {
+  private getFirstByOrder<T extends {order?: string}>(arr?: T[]): T | null {
     if (!arr?.length) return null;
 
     return arr.reduce((min, curr) => {
@@ -150,7 +146,7 @@ class ProgressService extends BaseService {
       }
     }
 
-    return { itemIds, quizItemIds };
+    return {itemIds, quizItemIds};
   }
 
   private async clearWatchTime(
@@ -160,7 +156,7 @@ class ProgressService extends BaseService {
   ) {
     if (!itemIds.length) return 0;
 
-    const { deletedCount } =
+    const {deletedCount} =
       await this.progressRepository.deleteUserWatchTimeByItemIds(
         userId,
         itemIds,
@@ -376,7 +372,7 @@ class ProgressService extends BaseService {
       userId,
       courseId,
       courseVersionId,
-      session
+      session,
     );
     if (!enrollment) throw new NotFoundError('User has no enrollments');
 
@@ -402,14 +398,14 @@ class ProgressService extends BaseService {
       //   ));
       const [totalItems, completedItems] = await Promise.all([
         totalItemCount ??
-        this.itemRepo.getTotalItemsCount(courseId, courseVersionId, session),
+          this.itemRepo.getTotalItemsCount(courseId, courseVersionId, session),
         completedItemCount ??
-        this.getUserProgressPercentageWithoutTotal(
-          userId,
-          courseId,
-          courseVersionId,
-          session,
-        ),
+          this.getUserProgressPercentageWithoutTotal(
+            userId,
+            courseId,
+            courseVersionId,
+            session,
+          ),
       ]);
 
       percentCompleted = this._calculateProgress(
@@ -914,7 +910,7 @@ class ProgressService extends BaseService {
     currentItemId: string,
     quizMetrics: any,
     enrollment: any,
-  ): Promise<{ nextItemId?: string }> {
+  ): Promise<{nextItemId?: string}> {
     try {
       if (quizMetrics?.remainingAttempts !== 0) {
         return {}; // No permission update needed
@@ -942,7 +938,7 @@ class ProgressService extends BaseService {
       const nextItem = items[currentIndex + 1];
 
       if (nextItem && nextItem?._id) {
-        return { nextItemId: nextItem?._id?.toString() };
+        return {nextItemId: nextItem?._id?.toString()};
       }
 
       // No next item → check next section/module
@@ -966,7 +962,7 @@ class ProgressService extends BaseService {
         throw new NotFoundError('Invalid course version');
       }
 
-      const { moduleId, sectionId } = groupInfo;
+      const {moduleId, sectionId} = groupInfo;
       if (!moduleId || !sectionId) {
         throw new NotFoundError(
           'Invalid course mapping: Module or Section missing',
@@ -981,7 +977,7 @@ class ProgressService extends BaseService {
       );
 
       if (nextItemDetails?.itemId) {
-        return { nextItemId: nextItemDetails.itemId.toString() };
+        return {nextItemId: nextItemDetails.itemId.toString()};
       }
 
       return {};
@@ -1040,7 +1036,7 @@ class ProgressService extends BaseService {
     );
 
     if (!isBlank) {
-      return { moduleId, sectionId, itemId, skippedBlankQuizIds };
+      return {moduleId, sectionId, itemId, skippedBlankQuizIds};
     }
 
     // Blank quiz → auto-skip
@@ -1182,7 +1178,7 @@ class ProgressService extends BaseService {
   }
 
   private parseTimeToSeconds(timeStr: string) {
-    const parts = timeStr.split(":").map(Number);
+    const parts = timeStr.split(':').map(Number);
 
     if (parts.length === 3) {
       // HH:MM:SS
@@ -1196,7 +1192,7 @@ class ProgressService extends BaseService {
       return minutes * 60 + seconds;
     }
 
-    throw new Error("Invalid time format");
+    throw new Error('Invalid time format');
   }
 
   private isValidWatchTime(watchTime: IWatchTime, item: Item) {
@@ -1223,11 +1219,15 @@ class ProgressService extends BaseService {
         if (!videoDetails.startTime || !videoDetails.endTime) return false;
 
         // parse it to seconds through liabrary
-        const videoEndTimeInSeconds = this.parseTimeToSeconds(videoDetails.endTime)
+        const videoEndTimeInSeconds = this.parseTimeToSeconds(
+          videoDetails.endTime,
+        );
         // parseInt(videoDetails.endTime.split(':')[0]) * 3600 +
         // parseInt(videoDetails.endTime.split(':')[1]) * 60 +
         // parseInt(videoDetails.endTime.split(':')[2]);
-        const videoStartTimeInSeconds = this.parseTimeToSeconds(videoDetails.startTime)
+        const videoStartTimeInSeconds = this.parseTimeToSeconds(
+          videoDetails.startTime,
+        );
         // parseInt(videoDetails.startTime.split(':')[0]) * 3600 +
         // parseInt(videoDetails.startTime.split(':')[1]) * 60 +
         // parseInt(videoDetails.startTime.split(':')[2]);
@@ -1328,7 +1328,7 @@ class ProgressService extends BaseService {
       };
     }
 
-    const { currentModule, currentSection, currentItem } = progress;
+    const {currentModule, currentSection, currentItem} = progress;
 
     try {
       const module = await this.courseRepo.getModulebyId(
@@ -1351,7 +1351,7 @@ class ProgressService extends BaseService {
 
       if (!section) {
         return {
-          module: { id: module.moduleId.toString(), name: module.name },
+          module: {id: module.moduleId.toString(), name: module.name},
           section: null,
           item: null,
           message: 'Section not found',
@@ -1365,8 +1365,8 @@ class ProgressService extends BaseService {
       );
 
       return {
-        module: { id: module.moduleId.toString(), name: module.name },
-        section: { id: section.sectionId.toString(), name: section.name },
+        module: {id: module.moduleId.toString(), name: module.name},
+        section: {id: section.sectionId.toString(), name: section.name},
         item: {
           id: itemDetails?._id?.toString() || currentItem.toString(),
           name: itemDetails?.name || 'Unknown Item',
@@ -1567,15 +1567,19 @@ class ProgressService extends BaseService {
        1. READ-ONLY PRE-VALIDATION (NO TRANSACTION)
     ---------------------------------------------------- */
 
-    const [user, course, courseVersion, linearProgressionEnabled, progress] = await Promise.all([
-      this.userRepo.findById(userId),
-      this.courseRepo.read(courseId),
-      this.courseRepo.readVersion(courseVersionId),
-      this.settingsRepo.isLinearProgressionEnabled(courseId, courseVersionId),
-      this.progressRepository.findProgress(userId, courseId, courseVersionId),
-    ]);
+    const [user, course, courseVersion, linearProgressionEnabled, progress] =
+      await Promise.all([
+        this.userRepo.findById(userId),
+        this.courseRepo.read(courseId),
+        this.courseRepo.readVersion(courseVersionId),
+        this.settingsRepo.isLinearProgressionEnabled(courseId, courseVersionId),
+        this.progressRepository.findProgress(userId, courseId, courseVersionId),
+      ]);
 
-    console.log("Linear progression setting in stopItem:", linearProgressionEnabled)
+    console.log(
+      'Linear progression setting in stopItem:',
+      linearProgressionEnabled,
+    );
 
     if (!user) throw new NotFoundError('User not found');
     if (!course) throw new NotFoundError('Course not found');
@@ -1616,7 +1620,8 @@ class ProgressService extends BaseService {
     if (
       (progress.currentModule.toString() !== moduleId ||
         progress.currentSection.toString() !== sectionId ||
-        progress.currentItem.toString() !== itemId) && linearProgressionEnabled
+        progress.currentItem.toString() !== itemId) &&
+      linearProgressionEnabled
     ) {
       if (item.type !== 'QUIZ' && !isItemCompleted) {
         throw new BadRequestError('Progress mismatch');
@@ -1648,7 +1653,7 @@ class ProgressService extends BaseService {
       let stoppedWatchTime = null;
       // Only stop tracking (set endTime) for non-quiz items or when we're certain it should be marked as completed
       // For quizzes, endTime should only be set when they are actually submitted and graded
-      if (!isQuizFailed && (item.type !== 'QUIZ')) {
+      if (!isQuizFailed && item.type !== 'QUIZ') {
         stoppedWatchTime = await this.progressRepository.stopItemTracking(
           watchItemId,
           session,
@@ -1720,7 +1725,6 @@ class ProgressService extends BaseService {
           itemId,
           completedItemsSet,
         );
-
 
         if (nextItem) {
           newProgress = {
@@ -1802,10 +1806,7 @@ class ProgressService extends BaseService {
     const rawPercent =
       totalItems > 0 ? (completedItemsSet.size / totalItems) * 100 : 0;
 
-    const percentCompleted = Math.min(
-      100,
-      parseFloat(rawPercent.toFixed(2)),
-    );
+    const percentCompleted = Math.min(100, parseFloat(rawPercent.toFixed(2)));
 
     await this.enrollmentRepo.updateProgressPercentById(
       enrollment._id.toString(),
@@ -1818,7 +1819,6 @@ class ProgressService extends BaseService {
       await this.recalculateStudentProgress(userId, courseId, courseVersionId);
     }
   }
-
 
   async stopItem(
     userId: string,
@@ -1837,7 +1837,7 @@ class ProgressService extends BaseService {
     const [courseVersion, progress, item] = await Promise.all([
       this.courseRepo.readVersion(courseVersionId),
       this.progressRepository.findProgress(userId, courseId, courseVersionId),
-      this.itemRepo.readItemById(itemId)
+      this.itemRepo.readItemById(itemId),
     ]);
 
     // Validate existence of course, progress, and item
@@ -1871,7 +1871,10 @@ class ProgressService extends BaseService {
       // For quizzes, only set endTime if they are passed
       // For non-quizzes, set endTime normally
       if (item.type !== 'QUIZ') {
-        stoppedWatchTime = await this.progressRepository.stopItemTracking(watchItemId, session);
+        stoppedWatchTime = await this.progressRepository.stopItemTracking(
+          watchItemId,
+          session,
+        );
 
         if (!stoppedWatchTime) {
           throw new NotFoundError('Watch time not found or already stopped');
@@ -1886,7 +1889,7 @@ class ProgressService extends BaseService {
           courseVersionId,
           attemptId,
           isSkipped,
-          stoppedWatchTime
+          stoppedWatchTime,
         );
       }
 
@@ -1920,18 +1923,18 @@ class ProgressService extends BaseService {
       // Prepare the progress update payload
       let newProgress: Partial<IProgress> = isCompleted
         ? {
-          currentModule: moduleId,
-          currentSection: sectionId,
-          currentItem: itemId,
-          completed: true,
-          completedAt: new Date(),
-        }
+            currentModule: moduleId,
+            currentSection: sectionId,
+            currentItem: itemId,
+            completed: true,
+            completedAt: new Date(),
+          }
         : {
-          completed: false,
-          currentModule: nextItem.moduleId,
-          currentSection: nextItem.sectionId,
-          currentItem: nextItem.itemId,
-        };
+            completed: false,
+            currentModule: nextItem.moduleId,
+            currentSection: nextItem.sectionId,
+            currentItem: nextItem.itemId,
+          };
 
       if (item.type === 'QUIZ' && !isSkipped) {
         let isQuizFailed = false;
@@ -1966,13 +1969,11 @@ class ProgressService extends BaseService {
             currentItem: previousVideoItem.itemId,
             // skippedBlankQuizIds: [],
           };
-
         } else {
           // Quiz passed - set endTime, progress update is handled by the original logic above
           await this.progressRepository.stopItemTracking(watchItemId, session);
         }
       }
-
 
       /* ----------------------------------------------------
       4. DERIVED DATA UPDATE (NO TRANSACTION)
@@ -1987,7 +1988,10 @@ class ProgressService extends BaseService {
 
       const totalItems =
         courseVersion.totalItems ??
-        (await this.itemRepo.CalculateTotalItemsCount(courseId, courseVersionId));
+        (await this.itemRepo.CalculateTotalItemsCount(
+          courseId,
+          courseVersionId,
+        ));
 
       // Get completed items for progress calculation
       const completedItemsArray =
@@ -1996,15 +2000,14 @@ class ProgressService extends BaseService {
           courseId,
           courseVersionId,
         );
-      const completedItemsSet = new Set(completedItemsArray.map(id => id.toString()));
+      const completedItemsSet = new Set(
+        completedItemsArray.map(id => id.toString()),
+      );
 
       const rawPercent =
         totalItems > 0 ? (completedItemsSet.size / totalItems) * 100 : 0;
 
-      const percentCompleted = Math.min(
-        100,
-        parseFloat(rawPercent.toFixed(2)),
-      );
+      const percentCompleted = Math.min(100, parseFloat(rawPercent.toFixed(2)));
 
       await this.enrollmentRepo.updateProgressPercentById(
         enrollment._id.toString(),
@@ -2014,7 +2017,11 @@ class ProgressService extends BaseService {
       );
 
       if (percentCompleted > 99) {
-        await this.recalculateStudentProgress(userId, courseId, courseVersionId);
+        await this.recalculateStudentProgress(
+          userId,
+          courseId,
+          courseVersionId,
+        );
       }
 
       // Update progress in a transaction
@@ -2027,7 +2034,6 @@ class ProgressService extends BaseService {
       );
     });
   }
-
 
   private validateProgressPosition(
     progress: IProgress,
@@ -2065,13 +2071,7 @@ class ProgressService extends BaseService {
     isSkipped?: boolean,
     stoppedWatchTime?: IWatchTime,
   ): Promise<void> {
-
-
-
-    const WATCH_TIME_REQUIRED_ITEMS = new Set<string>([
-      'VIDEO',
-      'BLOG',
-    ]);
+    const WATCH_TIME_REQUIRED_ITEMS = new Set<string>(['VIDEO', 'BLOG']);
 
     // 1 Watch-time based items
     if (WATCH_TIME_REQUIRED_ITEMS.has(item.type)) {
@@ -2091,13 +2091,9 @@ class ProgressService extends BaseService {
       await this.validateProjectStop(itemId, userId, courseId, courseVersionId);
       return;
     }
-
   }
 
-  private validateWatchTime(
-    item: Item,
-    stoppedWatchTime?: IWatchTime,
-  ): void {
+  private validateWatchTime(item: Item, stoppedWatchTime?: IWatchTime): void {
     if (!stoppedWatchTime) {
       throw new BadRequestError('Watch time not found');
     }
@@ -2107,7 +2103,8 @@ class ProgressService extends BaseService {
     }
   }
 
-  private async validateQuizStop( // when a quiz is failed then also stop is being called at frontend
+  private async validateQuizStop(
+    // when a quiz is failed then also stop is being called at frontend
     itemId: string,
     userId: string,
     courseId: string,
@@ -2138,12 +2135,11 @@ class ProgressService extends BaseService {
     courseId: string,
     courseVersionId: string,
   ): Promise<void> {
-    const projectSubmission =
-      await this.projectSubmissionRepo.getByUser(
-        userId,
-        courseVersionId,
-        courseId,
-      );
+    const projectSubmission = await this.projectSubmissionRepo.getByUser(
+      userId,
+      courseVersionId,
+      courseId,
+    );
 
     if (
       !projectSubmission ||
@@ -2152,8 +2148,6 @@ class ProgressService extends BaseService {
       throw new BadRequestError('Project not submitted');
     }
   }
-
-
 
   async updateProgress(
     userId: string,
@@ -2328,7 +2322,7 @@ class ProgressService extends BaseService {
     );
 
     // Collect attemptIds to delete and bulk ops for all collections
-    const { attemptDeletes, metricsUpdates, submissionDeletes } =
+    const {attemptDeletes, metricsUpdates, submissionDeletes} =
       await this.progressRepository.prepareBulkQuizOperations(
         userId,
         quizItemIds,
@@ -2375,8 +2369,6 @@ class ProgressService extends BaseService {
     courseVersionId: string,
     isPassed: boolean,
   ) {
-
-
     // Fetch progress and course version in parallel
     const [progress, courseVersion] = await Promise.all([
       this.progressRepository.findProgress(userId, courseId, courseVersionId),
@@ -2386,7 +2378,6 @@ class ProgressService extends BaseService {
     if (!progress || !courseVersion) {
       throw new NotFoundError('Progress or Course Version not found');
     }
-
 
     // const courseVersion = await this.courseRepo.readVersion(courseVersionId);
 
@@ -2422,7 +2413,6 @@ class ProgressService extends BaseService {
           courseVersionId,
           newProgress,
         );
-
       } else {
         const newProgress = {
           currentModule: nextItemDetails.moduleId,
@@ -2459,7 +2449,7 @@ class ProgressService extends BaseService {
       );
     }
     // if we refresh the quiz page after passing then the student will land on next item
-    //  and as the stop item is not called for that quiz endtime will never be created 
+    //  and as the stop item is not called for that quiz endtime will never be created
     // Only mark quiz as completed (set endTime) if it was actually passed
     if (isPassed) {
       const watchTime = await this.progressRepository.getWatchTime(
@@ -2473,10 +2463,12 @@ class ProgressService extends BaseService {
         courseId,
         courseVersionId,
         quizId,
-      )
+      );
 
       if (!isItemCompleted && watchTime && watchTime.length > 0) {
-        await this.progressRepository.stopItemTracking(watchTime[0]._id.toString());
+        await this.progressRepository.stopItemTracking(
+          watchTime[0]._id.toString(),
+        );
       }
     }
   }
@@ -2553,11 +2545,11 @@ class ProgressService extends BaseService {
           : Promise.resolve(),
         projectItemIds.length
           ? this.resetUserProjectData(
-            userId,
-            projectItemIds,
-            courseVersionId,
-            session,
-          )
+              userId,
+              projectItemIds,
+              courseVersionId,
+              session,
+            )
           : Promise.resolve(),
       ]);
 
@@ -2673,11 +2665,11 @@ class ProgressService extends BaseService {
         //   : Promise.resolve(),
         projectItemIds.length
           ? this.resetUserProjectData(
-            userId,
-            projectItemIds,
-            courseVersionId,
-            session,
-          )
+              userId,
+              projectItemIds,
+              courseVersionId,
+              session,
+            )
           : Promise.resolve(),
       ]);
     });
@@ -2744,7 +2736,7 @@ class ProgressService extends BaseService {
 
       const itemsGroupIds = module.sections.map(s => s.itemsGroupId as string);
 
-      const { itemIds, quizItemIds } = await this.collectItemsFromGroups(
+      const {itemIds, quizItemIds} = await this.collectItemsFromGroups(
         itemsGroupIds,
         session,
       );
@@ -2815,7 +2807,7 @@ class ProgressService extends BaseService {
         sectionId,
       );
 
-      const { itemIds, quizItemIds } = await this.collectItemsFromGroups(
+      const {itemIds, quizItemIds} = await this.collectItemsFromGroups(
         [section.itemsGroupId as string],
         session,
       );
@@ -2965,7 +2957,7 @@ class ProgressService extends BaseService {
     courseVersionId: string,
     itemId: string,
     session?: ClientSession,
-  ): Promise<{ message: String }> {
+  ): Promise<{message: String; alreadyCompleted: Boolean}> {
     const item = await this.itemRepo.readItem(courseVersionId, itemId);
     if (!item) {
       throw new NotFoundError(`Item ${itemId} not found`);
@@ -2995,38 +2987,87 @@ class ProgressService extends BaseService {
       throw new NotFoundError('Course version not found');
     }
 
-    // First, check if a watch time record already exists for this item
-    const existingWatchTime = await this.progressRepository.getWatchTime(
+    // // First, check if a watch time record already exists for this item
+    // const existingWatchTime = await this.progressRepository.getWatchTime(
+    //   userId,
+    //   itemId,
+    //   courseId,
+    //   courseVersionId,
+    //   session,
+    // );
+
+    // let watchTimeId;
+    // if (!existingWatchTime || existingWatchTime.length === 0) {
+    //   // No existing watch time, create a new one
+    //   watchTimeId = await this.progressRepository.startItemTracking(
+    //     userId,
+    //     courseId,
+    //     courseVersionId,
+    //     itemId,
+    //     session,
+    //   );
+
+    //   if (watchTimeId) {
+    //     // Mark the item as completed by stopping the watch time
+    //     await this.progressRepository.stopItemTracking(watchTimeId, session);
+    //   }
+    // } else {
+    //   // Use the existing watch time ID
+    //   if (existingWatchTime && existingWatchTime.length > 0) {
+    //     watchTimeId = existingWatchTime[0]._id;
+    //     // Ensure the watch time is marked as completed
+    //     await this.progressRepository.stopItemTracking(watchTimeId, session);
+    //   }
+    // }
+
+    const alreadyCompleted = await this.progressRepository.isItemCompleted(
       userId,
-      itemId,
       courseId,
       courseVersionId,
+      itemId,
       session,
     );
 
-    let watchTimeId;
-    if (!existingWatchTime || existingWatchTime.length === 0) {
-      // No existing watch time, create a new one
-      watchTimeId = await this.progressRepository.startItemTracking(
+    if (!alreadyCompleted) {
+      // ── ###. Item not yet completed → create + immediately close a watchTime ──
+      const existingWatchTime = await this.progressRepository.getWatchTime(
         userId,
+        itemId,
         courseId,
         courseVersionId,
-        itemId,
         session,
       );
 
-      if (watchTimeId) {
-        // Mark the item as completed by stopping the watch time
+      if (!existingWatchTime || existingWatchTime.length === 0) {
+        // No open record at all → start one and stop it right away
+        const watchTimeId = await this.progressRepository.startItemTracking(
+          userId,
+          courseId,
+          courseVersionId,
+          itemId,
+          session,
+        );
+
+        if (!watchTimeId) {
+          throw new InternalServerError(
+            `Failed to create watch-time record for item ${itemId}`,
+          );
+        }
+
         await this.progressRepository.stopItemTracking(watchTimeId, session);
-      }
-    } else {
-      // Use the existing watch time ID
-      if (existingWatchTime && existingWatchTime.length > 0) {
-        watchTimeId = existingWatchTime[0]._id;
-        // Ensure the watch time is marked as completed
-        await this.progressRepository.stopItemTracking(watchTimeId, session);
+      } else {
+        // An open (no endTime) record exists - close it to mark completion
+        const openRecord = existingWatchTime.find(wt => !wt.endTime);
+        if (openRecord) {
+          await this.progressRepository.stopItemTracking(
+            openRecord._id.toString(),
+            session,
+          );
+        }
       }
     }
+    // ── ### Already completed  fall through without touching watchTime
+
     // Get the next item
     const nextItem = await this.getNextItemInSequence(
       courseVersion,
@@ -3068,7 +3109,7 @@ class ProgressService extends BaseService {
         session,
       );
 
-      return { message: 'Course completed - reset to start' };
+      return {message: 'Course completed - reset to start', alreadyCompleted};
     }
 
     // Update progress to the next item
@@ -3084,7 +3125,12 @@ class ProgressService extends BaseService {
       session,
     );
 
-    return { message: 'Item skipped successfully' };
+    return {
+      message: alreadyCompleted
+        ? 'Item was already completed – progress advanced'
+        : 'Item skipped successfully',
+      alreadyCompleted,
+    };
   }
   async getFirstItem(versionId: string) {
     if (!versionId) {
@@ -3377,7 +3423,6 @@ class ProgressService extends BaseService {
       throw new BadRequestError('userId, courseId and versionId are required');
     }
 
-
     // 1. Fetch progress
     const progress = await this.progressRepository.findProgress(
       userId,
@@ -3450,16 +3495,22 @@ class ProgressService extends BaseService {
     const totalCompletedItemsCount =
       completedItemSet.size + missedItemIds.length;
 
-    const normalizedTotalItemsCount = Math.max(totalItemsCount, totalCompletedItemsCount);
+    const normalizedTotalItemsCount = Math.max(
+      totalItemsCount,
+      totalCompletedItemsCount,
+    );
 
     const percentCompleted =
       normalizedTotalItemsCount > 0
         ? Math.min(
-          parseFloat(
-            ((totalCompletedItemsCount / normalizedTotalItemsCount) * 100).toFixed(2),
-          ),
-          100,
-        )
+            parseFloat(
+              (
+                (totalCompletedItemsCount / normalizedTotalItemsCount) *
+                100
+              ).toFixed(2),
+            ),
+            100,
+          )
         : 0;
 
     // 5. Update enrollment progress
@@ -3647,7 +3698,7 @@ class ProgressService extends BaseService {
     for (const enrollment of enrollments) {
       enrollmentMap.set(enrollment.userId.toString(), {
         completionPercentage: enrollment.percentCompleted || 0,
-        enrolledAt: enrollment.enrollmentDate
+        enrolledAt: enrollment.enrollmentDate,
       });
     }
 
@@ -3665,7 +3716,7 @@ class ProgressService extends BaseService {
         const fullName =
           `${user.firstName || ''} ${user.lastName || ''}`.trim() ||
           'Unknown User';
-        userMap.set(user._id?.toString(), { name: fullName, email: user.email });
+        userMap.set(user._id?.toString(), {name: fullName, email: user.email});
       }
     }
 
@@ -3743,4 +3794,4 @@ class ProgressService extends BaseService {
   }
 }
 
-export { ProgressService };
+export {ProgressService};

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -190,6 +190,14 @@ export default function CoursePage() {
   // State for sidebar visibility
   const [isDesktopSidebarVisible, setIsDesktopSidebarVisible] = useState(true);
 
+    // Separate state purely for pre-loading the next section in the background.
+// Must NOT share activeSectionInfo — that state drives useItemById for the current item.
+const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
+  moduleId: string;
+  sectionId: string;
+} | null>(null);
+  const [isGoingToNext, setIsGoingToNext] = useState(false);
+
 
   // State to track when we're waiting for next section items to load
   const [waitingForNextSection, setWaitingForNextSection] = useState<{
@@ -1063,7 +1071,7 @@ export default function CoursePage() {
 
         // 2️⃣ Determine next item
         const nextItem = findNextItem();
-
+       
         if (!nextItem) {
           console.log("🎉 Course complete");
           setIsNavigatingToNext(false);
@@ -1382,6 +1390,97 @@ export default function CoursePage() {
     // Navigate back to courses page
     window.history.back();
   };
+  
+
+
+
+const shouldFetchBackgroundItems =
+  !!backgroundSectionInfo?.moduleId &&
+  !!backgroundSectionInfo?.sectionId &&
+  !sectionItems[backgroundSectionInfo.sectionId]; // skip if already cached
+
+const {
+  data: backgroundSectionItems,
+  isLoading: backgroundItemsLoading,
+} = useItemsBySectionId(
+  shouldFetchBackgroundItems ? VERSION_ID : '',
+  shouldFetchBackgroundItems ? backgroundSectionInfo!.moduleId : '',
+  shouldFetchBackgroundItems ? backgroundSectionInfo!.sectionId : '',
+);
+  // Determine whether the "Go to Next Item" button should be shown.
+// Rules:
+//   - Current item must already be completed
+//   - A next item must exist in the sequence
+//   - That next item must also already be completed (i.e. sidebar shows it as done)
+const nextItemInfo = findNextItem();
+
+const isCurrentItemCompleted = Boolean((currentItem as any)?.isCompleted);
+
+// "Go to Next Item" — only when a next completed item actually exists
+const showGoToNextButton =
+  isCurrentItemCompleted &&
+  !!nextItemInfo &&
+  !!(nextItemInfo as any).itemId && // excludes needsLoading case where itemId is null
+  !isGoingToNext;
+
+const handleGoToNextItem = async () => {
+  if (isGoingToNext || !nextItemInfo) return; // guard against double-clicks
+
+  setIsGoingToNext(true);
+  try {
+    const { moduleId, sectionId: nextSectionId, itemId } = nextItemInfo as any;
+    if (!moduleId || !nextSectionId || !itemId) return;
+
+    handleSelectItem(moduleId, nextSectionId, itemId);
+  } finally {
+    // Re-enable after navigation state has been handed off
+    setTimeout(() => setIsGoingToNext(false), 800);
+  }
+};
+// Auto-redirect to dashboard when the learner lands on the last item
+// and it is already completed (no next item exists in the sequence).
+useEffect(() => {
+  if (!currentItem) return;
+  if (!(currentItem as any).isCompleted) return;
+
+  const next = findNextItem();
+  if (next) return; // not the last item
+  // Small delay so the learner briefly sees the item before redirect
+  const timer = setTimeout(() => {
+    router.navigate({ to: '/student' });
+  }, 2000);
+  return () => clearTimeout(timer);
+}, [currentItem, findNextItem, router]);
+// When the current item is already completed, eagerly fetch the next section's
+// items so isNextItemAlreadyCompleted has data to check against.
+useEffect(() => {
+  if (
+    !shouldFetchBackgroundItems ||
+    !backgroundSectionInfo?.sectionId ||
+    !backgroundSectionItems ||
+    backgroundItemsLoading
+  ) return;
+
+  let itemsArray: any[] = [];
+  if (Array.isArray(backgroundSectionItems)) {
+    itemsArray = backgroundSectionItems;
+  } else if ((backgroundSectionItems as any)?.items) {
+    itemsArray = (backgroundSectionItems as any).items;
+  }
+
+  setSectionItems(prev => ({
+    ...prev,
+    [backgroundSectionInfo.sectionId]: sortItemsByOrder(itemsArray),
+  }));
+
+  setBackgroundSectionInfo(null); // clear after storing
+}, [
+  backgroundSectionItems,
+  backgroundItemsLoading,
+  shouldFetchBackgroundItems,
+  backgroundSectionInfo,
+]);
+
 
   // Autoscroll to selected sidebar item when selectedItemId changes
   useEffect(() => {
@@ -1977,19 +2076,38 @@ export default function CoursePage() {
                           <span className="max-sm:hidden">Submit Flag</span>
                         </Button>
                       }
-                      {currentItem?.isOptional && (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="text-xs gap-1 border-amber-500 text-amber-500 hover:bg-amber-50 hover:text-amber-600"
-                          title="Skip this optional item"
-                          onClick={handleSkipItem}
-                          disabled={isSkippingItem || isSkipping}
-                        >
-                          <span className="max-sm:hidden">Skip</span>
-                          <ChevronRight className="h-4 w-4" />
-                        </Button>
-                      )}
+               
+{(currentItem as any)?.isOptional && (
+  <Button
+    size="sm"
+    variant="outline"
+    className="text-xs gap-1 border-amber-500 text-amber-500 hover:bg-amber-50 hover:text-amber-600"
+    title="Skip this optional item"
+    onClick={handleSkipItem}
+    disabled={isSkippingItem || isSkipping}
+  >
+    <span className="max-sm:hidden">Skip</span>
+    <ChevronRight className="h-4 w-4" />
+  </Button>
+)}
+
+{showGoToNextButton && (
+  <Button
+    size="sm"
+    variant="outline"
+    className="text-xs gap-1 border-green-500 text-green-600 hover:bg-green-50 hover:text-green-700"
+    title="Go to next item"
+    onClick={handleGoToNextItem}
+    disabled={isGoingToNext}
+  >
+    <CircleCheckIcon className="h-4 w-4" />
+    <span className="max-sm:hidden">Go to Next Item</span>
+    <ChevronRight className="h-4 w-4" />
+  </Button>
+)}
+
+
+
                     </div>
                     {currentItem?.type === 'PROJECT' ? (
                       <StudentProjectItem

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -1391,37 +1391,21 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
     window.history.back();
   };
   
-
-
-
-const shouldFetchBackgroundItems =
-  !!backgroundSectionInfo?.moduleId &&
-  !!backgroundSectionInfo?.sectionId &&
-  !sectionItems[backgroundSectionInfo.sectionId]; // skip if already cached
-
-const {
-  data: backgroundSectionItems,
-  isLoading: backgroundItemsLoading,
-} = useItemsBySectionId(
-  shouldFetchBackgroundItems ? VERSION_ID : '',
-  shouldFetchBackgroundItems ? backgroundSectionInfo!.moduleId : '',
-  shouldFetchBackgroundItems ? backgroundSectionInfo!.sectionId : '',
-);
-  // Determine whether the "Go to Next Item" button should be shown.
-// Rules:
-//   - Current item must already be completed
-//   - A next item must exist in the sequence
-//   - That next item must also already be completed (i.e. sidebar shows it as done)
 const nextItemInfo = findNextItem();
 
 const isCurrentItemCompleted = Boolean((currentItem as any)?.isCompleted);
 
-// "Go to Next Item" — only when a next completed item actually exists
+const isNextItemAlreadyCompleted = (() => {
+  if (!nextItemInfo || (nextItemInfo as any).needsLoading) return false;
+  const { sectionId: nextSectionId, itemId: nextItemId } = nextItemInfo;
+  const nextSectionItems = sectionItems[nextSectionId] ?? [];
+  return nextSectionItems.some(
+    (item: any) => item._id === nextItemId && item.isCompleted,
+  );
+})();
+
 const showGoToNextButton =
-  isCurrentItemCompleted &&
-  !!nextItemInfo &&
-  !!(nextItemInfo as any).itemId && // excludes needsLoading case where itemId is null
-  !isGoingToNext;
+  isCurrentItemCompleted && !!nextItemInfo && isNextItemAlreadyCompleted && !isGoingToNext;
 
 const handleGoToNextItem = async () => {
   if (isGoingToNext || !nextItemInfo) return; // guard against double-clicks
@@ -1451,35 +1435,7 @@ useEffect(() => {
   }, 2000);
   return () => clearTimeout(timer);
 }, [currentItem, findNextItem, router]);
-// When the current item is already completed, eagerly fetch the next section's
-// items so isNextItemAlreadyCompleted has data to check against.
-useEffect(() => {
-  if (
-    !shouldFetchBackgroundItems ||
-    !backgroundSectionInfo?.sectionId ||
-    !backgroundSectionItems ||
-    backgroundItemsLoading
-  ) return;
 
-  let itemsArray: any[] = [];
-  if (Array.isArray(backgroundSectionItems)) {
-    itemsArray = backgroundSectionItems;
-  } else if ((backgroundSectionItems as any)?.items) {
-    itemsArray = (backgroundSectionItems as any).items;
-  }
-
-  setSectionItems(prev => ({
-    ...prev,
-    [backgroundSectionInfo.sectionId]: sortItemsByOrder(itemsArray),
-  }));
-
-  setBackgroundSectionInfo(null); // clear after storing
-}, [
-  backgroundSectionItems,
-  backgroundItemsLoading,
-  shouldFetchBackgroundItems,
-  backgroundSectionInfo,
-]);
 
 
   // Autoscroll to selected sidebar item when selectedItemId changes

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -1656,10 +1656,16 @@ export function useSkipOptionalItem(): {
   isError: boolean,
   isIdle: boolean,
 } {
-  const result = api.useMutation("post", "/users/items/{itemId}/skip");
+  const result = api.useMutation("post", "/users/items/{itemId}/skip") as any;
+  const rawError = result.error as { message?: string; response?: { data?: { message?: string } } } | null;
   return {
     ...result,
-    error: result.error ? (result.error.message || 'Failed to skip item') : null
+    // error: result.error ? (result.error.message || 'Failed to skip item') : null
+   error: rawError
+      ? rawError.message
+        ?? rawError.response?.data?.message
+        ?? "Failed to skip item"
+      : null,
   }
 }
 


### PR DESCRIPTION
### Task:
Improve both backend and frontend handling of already completed course items.

#### Backend:
Update the skip endpoint to verify whether the requested item has already been completed by the learner. If the item is already completed, the system must not create a new watchTime entry. This prevents duplicate tracking data and ensures accurate learning analytics and progress records.


#### Frontend:
- When a learner opens an item that is already completed, display a “Go to Next Item” (or equivalent) action.
- Show “Go to Next Item” Button (Conditional)
- Display the “Go to Next Item” button only if the next item exists and it is also already completed.
- Clicking the button should navigate to the next item in the course sequence.
- Prevent multiple clicks on the button 

_Last Item Handling_
- If the learner is on the last item and that last item is already completed, automatically redirect the learner to the dashboard (instead of keeping them on the completed last item screen).

### What was done:
- added a check for already completed items in `ProgressService.skipItem` so that no duplicate watch-time gets created.
- Based on completion of an item, the `Go to next item` button is shown in `course-page.tsx`.
- Guards in the button against multiple clicks.
- Redirection to the dashboard directly if the last item is already completed.
