### PR TITLE
Fix Redirect Loss on Role Switch During Login

### DIFF
--- a/frontend/src/app/pages/SelectRolePage.tsx
+++ b/frontend/src/app/pages/SelectRolePage.tsx
@@ -9,77 +9,87 @@ const SelectRolePage = () => {
     const navigate = useNavigate()
     return (
         <div className="relative min-h-screen overflow-hidden bg-background">
-        
-              {/* Animated Grid Background */}
-              <AnimatedGridPattern
+
+            {/* Animated Grid Background */}
+            <AnimatedGridPattern
                 numSquares={30}
                 maxOpacity={0.1}
                 duration={3}
                 repeatDelay={1}
                 className={cn(
-                  "[mask-image:radial-gradient(500px_circle_at_center,white,transparent)]",
-                  "absolute inset-0 h-full w-full",
+                    "[mask-image:radial-gradient(500px_circle_at_center,white,transparent)]",
+                    "absolute inset-0 h-full w-full",
                 )}
-              />
-        <div className="relative z-10 flex flex-col lg:flex-row min-h-screen">
-            <LeftHeroSection />
-            <div className="flex flex-1 flex-col justify-center px-4 py-12 sm:px-6 lg:px-8">
-                <div className="mx-auto w-full max-w-md space-y-8">
-                    {/* Role Selection */}
-                    <div className="text-center space-y-4">
-                        <h2 className="text-3xl font-bold tracking-tight">
-                            Welcome to Vibe
-                        </h2>
-                        <p className="text-muted-foreground">
-                            Choose how you want to continue
-                        </p>
-                    </div>
-
-                    <div className="space-y-4">
-                        <Button
-                            onClick={() => {
-                                navigate({ to: '/student/login' })
-                            }}
-                            className="w-full h-14 text-lg"
-                            variant="outline"
-                        >
-                            <span className="flex items-center justify-center gap-2">
-                                <svg width="20" height="20" fill="none" viewBox="0 0 24 24" className="text-primary">
-                                    <path d="M12 12c2.7 0 8 1.34 8 4v2H4v-2c0-2.66 5.3-4 8-4Zm0-2a4 4 0 1 1 0-8 4 4 0 0 1 0 8Z" fill="currentColor" />
-                                </svg>
-                               Join to Learn
-                            </span>
-                        </Button>
-
-                        <div className="relative">
-                            <div className="absolute inset-0 flex items-center">
-                                <span className="w-full border-t" />
-                            </div>
-                            <div className="relative flex justify-center text-xs uppercase">
-                                <span className="bg-background px-2 text-muted-foreground">
-                                    Or
-                                </span>
-                            </div>
+            />
+            <div className="relative z-10 flex flex-col lg:flex-row min-h-screen">
+                <LeftHeroSection />
+                <div className="flex flex-1 flex-col justify-center px-4 py-12 sm:px-6 lg:px-8">
+                    <div className="mx-auto w-full max-w-md space-y-8">
+                        {/* Role Selection */}
+                        <div className="text-center space-y-4">
+                            <h2 className="text-3xl font-bold tracking-tight">
+                                Welcome to Vibe
+                            </h2>
+                            <p className="text-muted-foreground">
+                                Choose how you want to continue
+                            </p>
                         </div>
 
-                        <Button
-                            onClick={() => {
-                                navigate({ to: '/teacher/login' })
-                            }}
-                            className="w-full h-14 text-lg"
-                            variant="outline"
-                        >
-                            <span className="flex items-center justify-center gap-2">
-                                <svg width="20" height="20" fill="none" viewBox="0 0 24 24" className="text-primary">
-                                    <path d="M12 12c2.7 0 8 1.34 8 4v2H4v-2c0-2.66 5.3-4 8-4Zm0-2a4 4 0 1 1 0-8 4 4 0 0 1 0 8Zm6-2V7a6 6 0 1 0-12 0v1a2 2 0 0 0-2 2v2h16V9a2 2 0 0 0-2-2Z" fill="currentColor" />
-                                </svg>
-                               Join to Teach
-                            </span>
-                        </Button>
+                        <div className="space-y-4">
+                            <Button
+                                onClick={() => {
+                                    const searchParams = new URLSearchParams(window.location.search);
+                                    const redirectUrl = searchParams.get("redirect");
+                                    navigate({
+                                        to: '/student/login',
+                                        search: redirectUrl ? { redirect: redirectUrl } : undefined
+                                    })
+                                }}
+                                className="w-full h-14 text-lg"
+                                variant="outline"
+                            >
+                                <span className="flex items-center justify-center gap-2">
+                                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24" className="text-primary">
+                                        <path d="M12 12c2.7 0 8 1.34 8 4v2H4v-2c0-2.66 5.3-4 8-4Zm0-2a4 4 0 1 1 0-8 4 4 0 0 1 0 8Z" fill="currentColor" />
+                                    </svg>
+                                    Join to Learn
+                                </span>
+                            </Button>
+
+                            <div className="relative">
+                                <div className="absolute inset-0 flex items-center">
+                                    <span className="w-full border-t" />
+                                </div>
+                                <div className="relative flex justify-center text-xs uppercase">
+                                    <span className="bg-background px-2 text-muted-foreground">
+                                        Or
+                                    </span>
+                                </div>
+                            </div>
+
+                            <Button
+                                onClick={() => {
+                                    const searchParams = new URLSearchParams(window.location.search);
+                                    const redirectUrl = searchParams.get("redirect");
+                                    navigate({
+                                        to: '/teacher/login',
+                                        search: redirectUrl ? { redirect: redirectUrl } : undefined
+                                    })
+                                }}
+                                className="w-full h-14 text-lg"
+                                variant="outline"
+                            >
+                                <span className="flex items-center justify-center gap-2">
+                                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24" className="text-primary">
+                                        <path d="M12 12c2.7 0 8 1.34 8 4v2H4v-2c0-2.66 5.3-4 8-4Zm0-2a4 4 0 1 1 0-8 4 4 0 0 1 0 8Zm6-2V7a6 6 0 1 0-12 0v1a2 2 0 0 0-2 2v2h16V9a2 2 0 0 0-2-2Z" fill="currentColor" />
+                                    </svg>
+                                    Join to Teach
+                                </span>
+                            </Button>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
         </div>
     )
 }

--- a/frontend/src/components/Auth/AuthPage.tsx
+++ b/frontend/src/components/Auth/AuthPage.tsx
@@ -381,7 +381,14 @@ export default function AuthPage({ role }: AuthPageProps) {
               <div className="inline-flex items-center gap-3 px-4 py-2">
                 <span className="text-md text-muted-foreground">Want to teach on ViBe?</span>
                 <button
-                  onClick={() => navigate({ to: "/select-role" })}
+                  onClick={() => {
+                    const searchParams = new URLSearchParams(window.location.search);
+                    const redirectUrl = searchParams.get("redirect");
+                    navigate({
+                      to: "/select-role",
+                      search: redirectUrl ? { redirect: redirectUrl } : undefined
+                    });
+                  }}
                   className="cursor-pointer text-md font-medium text-primary hover:text-primary/80 hover:underline hover:underline-offset-4 transition-colors"
                 >
                   Switch role
@@ -496,7 +503,7 @@ export default function AuthPage({ role }: AuthPageProps) {
                         onClick={handleEmailLogin}
                         disabled={loading || (!recaptchaToken && isRecaptchaEnabled)}
                       >
-                       {loading ? "Signing in..." : `Sign in as ${activeRole=="student"?'learner':activeRole}`}
+                        {loading ? "Signing in..." : `Sign in as ${activeRole == "student" ? 'learner' : activeRole}`}
                       </Button>
 
                       {/* Divider */}


### PR DESCRIPTION
### Description
This PR fixes an issue where users who attempt to visit a protected route (e.g., a course registration link) and are redirected to login lose their original destination URL if they use the "Switch role" functionality or select a role on the `SelectRolePage`.
### Changes Made
- **`AuthPage.tsx`**: Updated the "Switch role" button's navigation behavior to extract the `redirect` query parameter from `window.location.search` and forward it when navigating to `/select-role`.
- **`SelectRolePage.tsx`**: Updated the "Join to Learn" and "Join to Teach" buttons to extract the `redirect` query parameter from `window.location.search` and forward it when navigating to `/student/login` and `/teacher/login`, respectively.
