### PR TITLE
Show average watch hours

### DIFF
--- a/backend/src/modules/users/classes/validators/EnrollmentValidators.ts
+++ b/backend/src/modules/users/classes/validators/EnrollmentValidators.ts
@@ -534,6 +534,9 @@ export class EnrollmentStatisticsResponse {
 
   @IsNumber()
   averageProgressPercent: number;
+
+  @IsNumber()
+  averageWatchHoursPerUser: number; // newly added to support watch hours stats
 }
 
 export const ENROLLMENT_VALIDATORS = [

--- a/backend/src/modules/users/controllers/EnrollmentController.ts
+++ b/backend/src/modules/users/controllers/EnrollmentController.ts
@@ -656,7 +656,7 @@ export class EnrollmentController {
   @OpenAPI({
     summary: 'Get enrollment statistics for a course version',
     description:
-      'Provides total enrollments, completed enrollments count, and average progress percentage for a specific course version.',
+      'Provides total enrollments, completed enrollments count, average progress percentage, and average watch hours per user for a specific course version.',
   })
   @Authorized()
   @Get('/enrollments/courses/:courseId/versions/:versionId/statistics')
@@ -686,12 +686,14 @@ export class EnrollmentController {
         courseId,
         versionId,
       );
+    // stats now includes averageWatchHoursPerUser
 
     if (!stats || stats.totalEnrollments === 0) {
       return {
         totalEnrollments: 0,
         completedCount: 0,
         averageProgressPercent: 0,
+        averageWatchHoursPerUser: 0,
       };
     }
 

--- a/backend/src/modules/users/controllers/EnrollmentController.ts
+++ b/backend/src/modules/users/controllers/EnrollmentController.ts
@@ -485,9 +485,8 @@ export class EnrollmentController {
         statusTab,
       );
 
-      // console.log("Enrollments Data:", enrollmentsData)
-      // console.log("Enrollments Data:", enrollmentsData.enrollments.map(e => e.userInfo));
-      console.log("Enrollments Data:", enrollmentsData.enrollments.map(e => e.contentCounts));
+    // console.log("Enrollments Data:", enrollmentsData)
+    // console.log("Enrollments Data:", enrollmentsData.enrollments.map(e => e.userInfo));
 
     if (
       !enrollmentsData ||
@@ -523,9 +522,7 @@ export class EnrollmentController {
           user: { ...enrollment.userInfo, _id: enrollment.userId },
           progress: enrollment.percentCompleted,
           completedItemsCount: enrollment.completedItemsCount || 0,
-          totalQuizScore: enrollment.totalQuizScore || 0,
-          totalQuizMaxScore: enrollment.totalQuizMaxScore || 0,
-          contentCounts: enrollment.contentCounts,
+          assignedTimeSlots: enrollment.assignedTimeSlots || [],
         }))
         .sort((a, b) => {
           // sort by isDeleted deleted should be at the bottom
@@ -537,6 +534,72 @@ export class EnrollmentController {
       totalPages,
       currentPage: page,
     };
+  }
+
+  @OpenAPI({
+    summary: 'Get student progress detail for the View Progress modal',
+    description: 'Returns content summary (completion %, total items, quiz score, item type counts) for a specific enrolled student. Intended to be called only when the instructor opens the View Progress modal.',
+  })
+  @Authorized()
+  @Get('/:userId/enrollments/courses/:courseId/versions/:versionId/progress-detail')
+  @HttpCode(200)
+  async getStudentProgressDetail(
+    @Params() params: EnrollmentParams,
+    @Ability(getEnrollmentAbility) { ability }: any,
+  ): Promise<any> {
+    const { userId, courseId, versionId } = params;
+
+    const enrollmentResource = subject('Enrollment', { courseId, versionId });
+    if (!ability.can(EnrollmentActions.ViewAll, enrollmentResource)) {
+      throw new ForbiddenError(
+        'You do not have permission to view this student progress',
+      );
+    }
+
+    const detail = await this.enrollmentService.getStudentProgressDetail(
+      userId,
+      courseId,
+      versionId,
+    );
+
+    if (!detail) {
+      return { message: 'Enrollment not found' };
+    }
+
+    return detail;
+  }
+
+  @OpenAPI({
+    summary: 'Get student course structure for the View Course Structure panel',
+    description: 'Returns the full course module/section structure and the current learning position for a specific enrolled student. Intended to be called lazily when the instructor clicks View Course Structure.',
+  })
+  @Authorized()
+  @Get('/:userId/enrollments/courses/:courseId/versions/:versionId/course-structure')
+  @HttpCode(200)
+  async getStudentCourseStructure(
+    @Params() params: EnrollmentParams,
+    @Ability(getEnrollmentAbility) { ability }: any,
+  ): Promise<any> {
+    const { userId, courseId, versionId } = params;
+
+    const enrollmentResource = subject('Enrollment', { courseId, versionId });
+    if (!ability.can(EnrollmentActions.ViewAll, enrollmentResource)) {
+      throw new ForbiddenError(
+        'You do not have permission to view this student course structure',
+      );
+    }
+
+    const structure = await this.enrollmentService.getStudentCourseStructure(
+      userId,
+      courseId,
+      versionId,
+    );
+
+    if (!structure) {
+      return { message: 'Enrollment not found' };
+    }
+
+    return structure;
   }
   @OpenAPI({
     summary: 'Update Enrollment Progress',

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -783,59 +783,90 @@ export class EnrollmentService extends BaseService {
           statusTab,
           session,
         );
-        // console.log("Enrollment Data from service is ", enrollmentsData.enrollments[0].contentCounts)
 
-      // if (enrollmentsData.enrollments.length > 0 && filter === 'STUDENT') {
-      //   await this.enrichEnrollmentsWithQuizScores(
-      //     enrollmentsData.enrollments,
-      //     courseVersionId,
-      //   );
-      //   // Log sample enrollment to verify mutation
-      //   console.log(
-      //     '🔍 Sample enriched enrollment:',
-      //     JSON.stringify(enrollmentsData.enrollments[0], null, 2),
-      //   );
-      // }
+      return enrollmentsData;
+    });
+  }
 
-      if (enrollmentsData.enrollments.length > 0 && filter === 'STUDENT') {
-        // existing quiz score enrichment
-        await this.enrichEnrollmentsWithQuizScores(
-          enrollmentsData.enrollments,
-          courseVersionId,
-        );
+  /**
+   * API 2: Get detailed progress summary for a single student.
+   * Called when instructor opens the "View Progress" modal.
+   */
+  async getStudentProgressDetail(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+  ) {
+    return this._withTransaction(async (session: ClientSession) => {
+      const detail = await this.enrollmentRepo.getStudentProgressDetail(
+        userId,
+        courseId,
+        courseVersionId,
+        session,
+      );
+      if (!detail) return null;
 
-        // NEW: reuse getEnrollments()
-        const studentUserIds = enrollmentsData.enrollments.map(e =>
-          e.userId?.toString(),
-        );
+      // Enrich with quiz scores for this student only
+      const courseVersion = await this.courseRepo.readVersion(courseVersionId);
+      let totalQuizScore = 0;
+      let totalQuizMaxScore = 0;
 
-        // call getEnrollments for each student (parallel)
-        const allStudentEnrollments = await Promise.all(
-          studentUserIds.map(uid =>
-            this.getEnrollments(uid, 0, 100, 'STUDENT', ''),
-          ),
-        );
-
-        // flatten
-        const flattened = allStudentEnrollments.flat();
-        // console.log("Fetched detailed enrollments for students:", flattened);
-        // build lookup map
-        const contentCountsMap = new Map<string, any>();
-
-        flattened.forEach(enr => {
-          const key = `${enr.courseVersionId}-${enr._id}`;
-          contentCountsMap.set(key, enr.contentCounts);
+      if (courseVersion) {
+        const itemGroupIds: string[] = [];
+        courseVersion.modules.forEach((module: any) => {
+          module.sections.forEach((section: any) => {
+            if (section.itemsGroupId) {
+              itemGroupIds.push(section.itemsGroupId.toString());
+            }
+          });
         });
 
-        // attach to instructor enrollments
-        // enrollmentsData.enrollments.forEach(enr => {
-        //   const key = `${enr.courseVersionId.toString()}-${enr._id.toString()}`;
-        //   enr.contentCounts = contentCountsMap.get(key);
-        // });
+        if (itemGroupIds.length > 0) {
+          const quizInfo = await this.itemRepo.getQuizInfo(itemGroupIds);
+          const allQuizIds = quizInfo
+            .filter((quiz: any) => quiz.items?._id)
+            .map((quiz: any) => quiz.items._id.toString());
+
+          if (allQuizIds.length > 0) {
+            const quizSubmissions =
+              await this.enrollmentRepo.getBatchQuizSubmissionGrades(
+                [userId],
+                allQuizIds,
+              );
+
+            quizSubmissions.forEach((submission: any) => {
+              const gradingResult = submission.gradingResult;
+              totalQuizScore += gradingResult.totalScore || 0;
+              totalQuizMaxScore += gradingResult.totalMaxScore || 0;
+            });
+          }
+        }
       }
-      // console.log("Enrollment data before return from service, " , enrollmentsData)
-      //       console.log("Enrollment data before return from service of enrollments, " , enrollmentsData.enrollments)
-      return enrollmentsData;
+
+      return {
+        ...detail,
+        totalQuizScore,
+        totalQuizMaxScore,
+      };
+    });
+  }
+
+  /**
+   * API 3: Get the current learning position and course structure for a student.
+   * Called when instructor clicks "View Course Structure" (lazy load).
+   */
+  async getStudentCourseStructure(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+  ) {
+    return this._withTransaction(async (session: ClientSession) => {
+      return this.enrollmentRepo.getStudentCourseStructure(
+        userId,
+        courseId,
+        courseVersionId,
+        session,
+      );
     });
   }
 

--- a/backend/src/modules/users/types.ts
+++ b/backend/src/modules/users/types.ts
@@ -17,4 +17,5 @@ export interface EnrollmentStats {
   totalEnrollments: number;
   completedCount: number;
   averageProgressPercent: number;
+  averageWatchHoursPerUser: number; // average hours watched per enrolled user
 }

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -1570,12 +1570,66 @@ export class EnrollmentRepository {
           },
         },
       },
+      // include watch hours for the student within this course/version
+      {
+        $lookup: {
+          from: 'watchTime',
+          let: { uid: '$userId' },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $and: [
+                    { $eq: ['$userId', { $toObjectId: '$$uid' }] },
+                    { $in: ['$courseId', [courseId, courseIdObj]] },
+                    { $in: ['$courseVersionId', [courseVersionId, versionIdObj]] },
+                    { $ne: ['$isDeleted', true] },
+                    { $ne: ['$endTime', null] },
+                  ],
+                },
+              },
+            },
+            {
+              $project: {
+                duration: {
+                  $divide: [
+                    { $subtract: ['$endTime', '$startTime'] },
+                    3600000,
+                  ],
+                },
+              },
+            },
+            {
+              $group: {
+                _id: null,
+                totalHours: { $sum: '$duration' },
+              },
+            },
+          ],
+          as: 'watchInfo',
+        },
+      },
+      {
+        $addFields: {
+          watchHours: {
+            $round: [
+              { $ifNull: [{ $arrayElemAt: ['$watchInfo.totalHours', 0] }, 0] },
+              2,
+            ],
+          },
+        },
+      },
+      { $project: { watchInfo: 0 } },
       { $limit: 1 },
     ];
 
     const result = await this.enrollmentCollection
       .aggregate(pipeline, { session })
       .toArray();
+
+    if (result[0]) {
+      console.debug('Student progress detail for user', userId, 'course', courseId, 'version', courseVersionId, 'watchHours=', result[0].watchHours);
+    }
 
     return result[0] || null;
   }
@@ -1645,6 +1699,9 @@ export class EnrollmentRepository {
     courseVersionId: string,
     session?: ClientSession,
   ): Promise<EnrollmentStats> {
+    await this.init();
+
+    // first run the existing aggregation to calculate enrollments and progress
     const [result] = await this.enrollmentCollection
       .aggregate<{
         totalEnrollments: number;
@@ -1705,13 +1762,74 @@ export class EnrollmentRepository {
       )
       .toArray();
 
-    return (
+    const baseStats =
       result || {
         totalEnrollments: 0,
         completedCount: 0,
         averageProgressPercent: 0,
-      }
-    );
+      };
+
+    // second aggregation to compute average watch hours per user for this course version
+    const watchAgg = await this.watchTimeCollection
+      .aggregate<{
+        averageWatchHoursPerUser: number;
+      }>(
+        [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  { $in: ['$courseId', [courseId, new ObjectId(courseId)]] },
+                  { $in: ['$courseVersionId', [courseVersionId, new ObjectId(courseVersionId)]] },
+                  { $ne: ['$isDeleted', true] },
+                  { $ne: ['$endTime', null] },
+                ],
+              },
+            },
+          },
+          {
+            $project: {
+              userId: 1,
+              duration: {
+                $divide: [
+                  { $subtract: ['$endTime', '$startTime'] },
+                  3600000, // convert ms to hours
+                ],
+              },
+            },
+          },
+          {
+            $group: {
+              _id: '$userId',
+              totalHours: { $sum: '$duration' },
+            },
+          },
+          {
+            $group: {
+              _id: null,
+              averageWatchHoursPerUser: { $avg: '$totalHours' },
+            },
+          },
+          {
+            $project: { _id: 0, averageWatchHoursPerUser: 1 },
+          },
+        ],
+        { session },
+      )
+      .toArray();
+
+    const watchStats = watchAgg[0] || { averageWatchHoursPerUser: 0 };
+    // debug log
+    console.debug('Computed averageWatchHoursPerUser for course', courseId, courseVersionId, watchStats.averageWatchHoursPerUser);
+
+    return {
+      totalEnrollments: baseStats.totalEnrollments,
+      completedCount: baseStats.completedCount,
+      averageProgressPercent: baseStats.averageProgressPercent,
+      averageWatchHoursPerUser: Number(
+        (watchStats.averageWatchHoursPerUser || 0).toFixed(2),
+      ),
+    };
   }
 
   /**

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -1470,114 +1470,8 @@ export class EnrollmentRepository {
       { $limit: limit },
     ];
 
-    // 4. Enrich only the current page records with expensive lookups
+    // 4. Enrich only with basic user data and assigned time slots (no heavy watchTime/itemsGroup lookups)
     paginatedPipeline.push(
-      {
-        $lookup: {
-          from: 'newCourseVersion',
-          let: { versionId: { $toObjectId: '$courseVersionId' } },
-          pipeline: [
-            {
-              $match: {
-                $expr: {
-                  $eq: ['$_id', '$$versionId'],
-                },
-              },
-            },
-            {
-              $project: {
-                totalItems: 1,
-                itemCounts: 1,
-              },
-            },
-          ],
-          as: 'courseVersionInfo',
-        },
-      },
-      {
-        $unwind: {
-          path: '$courseVersionInfo',
-          preserveNullAndEmptyArrays: true,
-        },
-      },
-      {
-        $lookup: {
-          from: 'watchTime',
-          let: {
-            userIdObj: '$userIdObj',
-            versionIdObj: { $toObjectId: '$courseVersionId' },
-            courseIdObj: { $toObjectId: '$courseId' },
-          },
-          pipeline: [
-            {
-              $match: {
-                $expr: {
-                  $and: [
-                    { $eq: ['$userId', '$$userIdObj'] },
-                    { $eq: ['$courseVersionId', '$$versionIdObj'] },
-                    { $eq: ['$courseId', '$$courseIdObj'] },
-                    { $ne: [{ $ifNull: ['$endTime', null] }, null] },
-                    { $ne: ['$isDeleted', true] },
-                  ],
-                },
-              },
-            },
-            { $project: { itemId: 1 } },
-          ],
-          as: 'watchRecords',
-        },
-      },
-      {
-        $addFields: {
-          completedItemIds: '$watchRecords.itemId',
-        },
-      },
-      {
-        $lookup: {
-          from: 'itemsGroup',
-          let: { completedItemIds: '$completedItemIds' },
-          pipeline: [
-            { $unwind: '$items' },
-            {
-              $match: {
-                $expr: {
-                  $in: ['$items._id', '$$completedItemIds'],
-                },
-              },
-            },
-            {
-              $project: {
-                type: '$items.type',
-              },
-            },
-          ],
-          as: 'completedItems',
-        },
-      },
-      {
-        $addFields: {
-          completedItemCounts: {
-            $arrayToObject: {
-              $map: {
-                input: { $setUnion: ['$completedItems.type'] },
-                as: 'type',
-                in: {
-                  k: '$$type',
-                  v: {
-                    $size: {
-                      $filter: {
-                        input: '$completedItems',
-                        as: 'item',
-                        cond: { $eq: ['$$item.type', '$$type'] },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
       {
         $addFields: {
           userId: { $toString: '$userInfo._id' },
@@ -1588,12 +1482,6 @@ export class EnrollmentRepository {
           lastName: '$userInfo.lastName',
           email: '$userInfo.email',
           completedItemsCount: { $ifNull: ['$completedItemsCount', 0] },
-          contentCounts: {
-            total: { $ifNull: ['$courseVersionInfo.totalItems', 0] },
-            completed: { $ifNull: ['$completedItemsCount', 0] },
-            itemCounts: { $ifNull: ['$courseVersionInfo.itemCounts', {}] },
-            completedItemCounts: { $ifNull: ['$completedItemCounts', {}] },
-          },
         },
       },
     );
@@ -1609,6 +1497,147 @@ export class EnrollmentRepository {
       currentPage: limit > 0 ? Math.floor(skip / limit) + 1 : 1,
       enrollments,
     };
+  }
+
+  /**
+   * API 2: Get basic content summary for a specific student's enrollment.
+   * Used by the "View Progress" modal. Only fetches enrollment + courseVersion content counts.
+   */
+  async getStudentProgressDetail(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ) {
+    await this.init();
+
+    const userIdObj = ObjectId.isValid(userId) ? new ObjectId(userId) : null;
+    const courseIdObj = ObjectId.isValid(courseId) ? new ObjectId(courseId) : null;
+    const versionIdObj = ObjectId.isValid(courseVersionId) ? new ObjectId(courseVersionId) : null;
+
+    if (!userIdObj || !courseIdObj || !versionIdObj) return null;
+
+    const pipeline: any[] = [
+      {
+        $match: {
+          userId: { $in: [userId, userIdObj] },
+          courseId: { $in: [courseId, courseIdObj] },
+          courseVersionId: { $in: [courseVersionId, versionIdObj] },
+          role: 'STUDENT',
+        },
+      },
+      // Join user info
+      {
+        $lookup: {
+          from: 'users',
+          let: { uid: { $toObjectId: '$userId' } },
+          pipeline: [
+            { $match: { $expr: { $eq: ['$_id', '$$uid'] } } },
+            { $project: { firstName: 1, lastName: 1, email: 1, avatar: 1 } },
+          ],
+          as: 'userInfo',
+        },
+      },
+      { $unwind: { path: '$userInfo', preserveNullAndEmptyArrays: true } },
+      // Join course version for content counts (totalItems, itemCounts)
+      {
+        $lookup: {
+          from: 'newCourseVersion',
+          let: { vid: { $toObjectId: '$courseVersionId' } },
+          pipeline: [
+            { $match: { $expr: { $eq: ['$_id', '$$vid'] } } },
+            { $project: { totalItems: 1, itemCounts: 1 } },
+          ],
+          as: 'courseVersionInfo',
+        },
+      },
+      { $unwind: { path: '$courseVersionInfo', preserveNullAndEmptyArrays: true } },
+      {
+        $project: {
+          _id: { $toString: '$_id' },
+          userId: { $toString: '$userInfo._id' },
+          firstName: '$userInfo.firstName',
+          lastName: '$userInfo.lastName',
+          email: '$userInfo.email',
+          avatar: '$userInfo.avatar',
+          enrollmentDate: 1,
+          percentCompleted: { $ifNull: ['$percentCompleted', 0] },
+          completedItemsCount: { $ifNull: ['$completedItemsCount', 0] },
+          assignedTimeSlots: 1,
+          contentCounts: {
+            totalItems: { $ifNull: ['$courseVersionInfo.totalItems', 0] },
+            itemCounts: { $ifNull: ['$courseVersionInfo.itemCounts', {}] },
+          },
+        },
+      },
+      { $limit: 1 },
+    ];
+
+    const result = await this.enrollmentCollection
+      .aggregate(pipeline, { session })
+      .toArray();
+
+    return result[0] || null;
+  }
+
+  /**
+   * API 3: Get current learning position and course structure for a student.
+   * Used when instructor clicks "View Course Structure" (lazy load on demand).
+   */
+  async getStudentCourseStructure(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ) {
+    await this.init();
+
+    const userIdObj = ObjectId.isValid(userId) ? new ObjectId(userId) : null;
+    const courseIdObj = ObjectId.isValid(courseId) ? new ObjectId(courseId) : null;
+    const versionIdObj = ObjectId.isValid(courseVersionId) ? new ObjectId(courseVersionId) : null;
+
+    if (!userIdObj || !courseIdObj || !versionIdObj) return null;
+
+    // Get course structure (modules/sections) from courseVersion
+    const pipeline: any[] = [
+      {
+        $match: {
+          userId: { $in: [userId, userIdObj] },
+          courseId: { $in: [courseId, courseIdObj] },
+          courseVersionId: { $in: [courseVersionId, versionIdObj] },
+          role: 'STUDENT',
+        },
+      },
+      // Join course version for full module/section structure
+      {
+        $lookup: {
+          from: 'newCourseVersion',
+          let: { vid: { $toObjectId: '$courseVersionId' } },
+          pipeline: [
+            { $match: { $expr: { $eq: ['$_id', '$$vid'] } } },
+            { $project: { modules: 1, totalItems: 1, itemCounts: 1 } },
+          ],
+          as: 'courseVersionInfo',
+        },
+      },
+      { $unwind: { path: '$courseVersionInfo', preserveNullAndEmptyArrays: true } },
+      {
+        $project: {
+          _id: { $toString: '$_id' },
+          userId: { $toString: '$userId' },
+          courseStructure: '$courseVersionInfo.modules',
+          totalItems: { $ifNull: ['$courseVersionInfo.totalItems', 0] },
+          itemCounts: { $ifNull: ['$courseVersionInfo.itemCounts', {}] },
+        },
+      },
+      { $limit: 1 },
+    ];
+
+    const result = await this.enrollmentCollection
+      .aggregate(pipeline, { session })
+      .toArray();
+
+    return result[0] || null;
   }
 
   async getVersionEnrollmentStats(

--- a/frontend/src/app/pages/teacher/course-enrollments.tsx
+++ b/frontend/src/app/pages/teacher/course-enrollments.tsx
@@ -914,7 +914,7 @@ export default function CourseEnrollments() {
                 <div className="flex items-center gap-3">
                   <div className="h-8 w-1 bg-gradient-to-b from-primary to-accent rounded-full"></div>
                   <h2 className="text-lg md:text-xl lg:text-2xl font-bold text-foreground">{course.name}</h2>
-                  <span className="text-lg text-muted-foreground">â€¢</span>
+                  <span className="text-lg text-muted-foreground">&bull;</span>
                   <h3 className="text-base md:text-lg lg:text-xl font-semibold text-accent">{version.version}</h3>
                 </div>
                 <div className="h-1 w-32 bg-gradient-to-r from-primary to-accent rounded-full ml-4"></div>
@@ -1222,13 +1222,13 @@ export default function CourseEnrollments() {
                             {currentPath.module.name}
                           </span>
 
-                          <span className="text-muted-foreground">â€º</span>
+                          <ChevronRight className="h-4 w-4 text-muted-foreground" />
 
                           <span className="px-2 py-1 rounded bg-emerald-100 text-emerald-700">
                             {currentPath.section.name}
                           </span>
 
-                          <span className="text-muted-foreground">â€º</span>
+                          <ChevronRight className="h-4 w-4 text-muted-foreground" />
 
                           <span className="px-2 py-1 rounded bg-purple-100 text-purple-700">
                             {currentPath.item.name}

--- a/frontend/src/app/pages/teacher/course-enrollments.tsx
+++ b/frontend/src/app/pages/teacher/course-enrollments.tsx
@@ -1,8 +1,8 @@
-"use client"
+﻿"use client"
 
 import { useState, useEffect } from "react"
 import { useNavigate, useSearch } from "@tanstack/react-router"
-import { Search, Users, TrendingUp, CheckCircle, RotateCcw, UserX, BookOpen, FileText, List, Play, AlertTriangle, X, Loader2, Eye, Clock, ChevronRight, ChevronDown, ArrowUp, ArrowDown, BarChart3, Download, FileDown, CheckSquare, Check } from 'lucide-react'
+import { Search, Users, TrendingUp, CheckCircle, RotateCcw, UserX, BookOpen, FileText, List, Play, AlertTriangle, X, Loader2, Eye, Clock, ChevronRight, ChevronDown, ArrowUp, ArrowDown, BarChart3, Download, FileDown, CheckSquare, Check, Video, HelpCircle } from 'lucide-react'
 import { Pagination } from "@/components/ui/Pagination"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -35,8 +35,10 @@ import {
   useRecalculateProgress,
   useBulkUnenrollUsers,
   useUserModuleProgress,
-  useRecalculateStudentProgress,
   useGetTimeSlots,
+  useStudentProgressDetail,
+  useStudentCourseStructure,
+  useRecalculateStudentProgress,
 } from "@/hooks/hooks"
 import { toast } from "sonner"
 import { useCourseStore } from "@/store/course-store"
@@ -128,7 +130,7 @@ const getRoleBadge = (role: EnrollmentRole) => {
     STUDENT: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
     MANAGER: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
     TA: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-    STAFF: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300",
+    STAFF: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-purple-300",
   }
 
   return (
@@ -136,6 +138,20 @@ const getRoleBadge = (role: EnrollmentRole) => {
       {role}
     </Badge>
   )
+}
+
+const getItemIcon = (type: string) => {
+  switch (type?.toUpperCase()) {
+    case "VIDEO":
+      return <Video className="h-4 w-4 text-blue-600" />
+    case "QUIZ":
+      return <HelpCircle className="h-4 w-4 text-amber-600" />
+    case "ARTICLE":
+    case "BLOG":
+      return <FileText className="h-4 w-4 text-emerald-600" />
+    default:
+      return <FileText className="h-4 w-4 text-muted-foreground" />
+  }
 }
 
 export default function CourseEnrollments() {
@@ -147,11 +163,11 @@ export default function CourseEnrollments() {
   const courseId = currentCourse?.courseId
   const versionId = currentCourse?.versionId
 
-  if (!currentCourse || !courseId || !versionId) {
-    navigate({ to: '/teacher' });
-    return null
-  }
-
+  useEffect(() => {
+    if (!currentCourse || !courseId || !versionId) {
+      navigate({ to: '/teacher' });
+    }
+  }, [currentCourse, courseId, versionId, navigate]);
   // Fetch course and version data
   const { data: course, isLoading: courseLoading, error: courseError } = useCourseById(courseId || "")
   const { data: version, isLoading: versionLoading, error: versionError } = useCourseVersionById(versionId || "")
@@ -182,6 +198,8 @@ export default function CourseEnrollments() {
   const [selectedViewItem, setSelectedViewItem] = useState<string>("")
   const [selectedViewItemType, setSelectedViewItemType] = useState<string>("")
   const [selectedViewItemName, setSelectedViewItemName] = useState<string>("")
+  // Controls lazy-load of API 3 (Course Structure panel)
+  const [showCourseStructure, setShowCourseStructure] = useState(false)
 
   // Sorting state
   const [sortBy, setSortBy] = useState<'name' | 'enrollmentDate' | 'progress' | 'unenrolledAt'>('name')
@@ -200,11 +218,11 @@ export default function CourseEnrollments() {
 
   // Time slots data for exclusion logic
   const { data: timeSlotsData } = useGetTimeSlots(
-    courseId && courseId.length === 24 && versionId && versionId.length === 24 
-      ? courseId 
-      : undefined, 
-    versionId && versionId.length === 24 
-      ? versionId 
+    courseId && courseId.length === 24 && versionId && versionId.length === 24
+      ? courseId
+      : undefined,
+    versionId && versionId.length === 24
+      ? versionId
       : undefined
   );
 
@@ -220,7 +238,7 @@ export default function CourseEnrollments() {
   // Get assigned timeslot for a student
   const getStudentTimeSlot = (studentId: string) => {
     if (!timeSlotsData?.slots) return null;
-    
+
     for (const slot of timeSlotsData.slots) {
       if (slot.studentIds?.includes(studentId)) {
         return slot;
@@ -410,7 +428,7 @@ export default function CourseEnrollments() {
     }
 
     try {
-      // ⚡ FAST: single-pass formatting, no unused maps
+      // âš¡ FAST: single-pass formatting, no unused maps
       const formattedData = quizScores.data.map(
         (student: any, index: number) => ({
           studentId: student.studentId ?? `student-${index}`,
@@ -442,12 +460,12 @@ export default function CourseEnrollments() {
         return;
       }
 
-      // ⏱️ Stable filename (no locale overhead)
+      // â±ï¸ Stable filename (no locale overhead)
       const timestamp = new Date().toISOString().replace(/[:.]/g, '_');
       const statusLabel = enrollmentTab === 'ACTIVE' ? 'active' : 'inactive';
       const filename = `quiz_scores_${statusLabel}_${timestamp}.xlsx`;
 
-      // 🧠 Let UI breathe before heavy Excel generation
+      // ðŸ§  Let UI breathe before heavy Excel generation
       await new Promise(resolve => setTimeout(resolve, 0));
 
       generateExcel(formattedData, filename);
@@ -517,17 +535,15 @@ export default function CourseEnrollments() {
 
   // const studentEnrollments = enrollmentsData?.enrollments || [];
   const studentEnrollments = enrollmentsData?.enrollments || []
-  console.log("Fetched Enrollments:", enrollmentsData)
   // Filter out already assigned students if excludeAssigned is true
-  const filteredStudentEnrollments = excludeAssigned 
+  const filteredStudentEnrollments = excludeAssigned
     ? studentEnrollments.filter((enrollment: any) => {
-        const assignedIds = getAssignedStudentIds();
-        const studentId = enrollment.user?._id || enrollment.user?.id;
-        return !assignedIds.has(studentId);
-      })
+      const assignedIds = getAssignedStudentIds();
+      const studentId = enrollment.user?._id || enrollment.user?.id;
+      return !assignedIds.has(studentId);
+    })
     : studentEnrollments;
 
-    console.log("Filtered Enrollments:", filteredStudentEnrollments)
 
   const handleSelectAll = (checked: boolean) => {
     const visibleUserIds = filteredStudentEnrollments.map((e: any) => e.user?._id || e.user?.id).filter(Boolean)
@@ -606,6 +622,7 @@ export default function CourseEnrollments() {
       setSelectedViewItem("")
       setSelectedViewItemType("")
       setSelectedViewItemName("")
+      setShowCourseStructure(false)
     }
   }, [isViewProgressDialogOpen])
 
@@ -622,7 +639,6 @@ export default function CourseEnrollments() {
   }
 
   const handleViewProgress = (user: EnrollmentDetails) => {
-    console.log("Selected user for progress view:", user)
     setSelectedUser(user)
 
     setIsViewProgressDialogOpen(true)
@@ -720,25 +736,19 @@ export default function CourseEnrollments() {
     }
   }
 
-  // Get available modules from version data
+  // Get available modules from version data or API 3
   const getAvailableModules = () => {
-    return version?.modules || []
+    return courseStructureData?.courseStructure?.modules || version?.modules || []
   }
 
   // Get available sections from selected module
   const getAvailableSections = () => {
-    if (!selectedModule || !version?.modules) return []
-    const module = version.modules.find((m: any) => m.moduleId === selectedModule)
+    const modules = getAvailableModules()
+    if (!selectedModule || !modules) return []
+    const module = modules.find((m: any) => m.moduleId === selectedModule)
     return module?.sections || []
   }
 
-  // Get available items from selected section
-  const getAvailableItems = () => {
-    if (!selectedModule || !selectedSection || !version?.modules) return []
-    const module = version.modules.find((m: any) => m.moduleId === selectedModule)
-    const section = module?.sections.find((s: any) => s.sectionId === selectedSection)
-    return section?.items || []
-  }
 
   const isFormValid = () => {
     switch (resetScope) {
@@ -755,19 +765,6 @@ export default function CourseEnrollments() {
     }
   }
 
-  const getItemIcon = (type: string) => {
-    switch (type?.toUpperCase()) {
-      case "VIDEO":
-        return "🎥"
-      case "QUIZ":
-        return "❓"
-      case "ARTICLE":
-      case "BLOG":
-        return "📖"
-      default:
-        return "📄"
-    }
-  }
 
   // Toggle functions for expanding/collapsing modules and sections
   const toggleModule = (moduleId: string) => {
@@ -835,15 +832,39 @@ export default function CourseEnrollments() {
     selectedUser?.id,
     courseId,
     versionId,
+    isViewProgressDialogOpen && showCourseStructure
+  )
+
+
+  // API 2: Student progress detail — fetched when View Progress modal opens
+  const {
+    data: progressDetail,
+    isLoading: progressDetailLoading,
+  } = useStudentProgressDetail(
+    selectedUser?.id,
+    courseId,
+    versionId,
     isViewProgressDialogOpen
   )
 
+  // API 3: Course structure — fetched lazily when View Course Structure is clicked
+  const {
+    data: courseStructureData,
+    isLoading: courseStructureLoading,
+  } = useStudentCourseStructure(
+    selectedUser?.id,
+    courseId,
+    versionId,
+    isViewProgressDialogOpen && showCourseStructure
+  )
+
   // ===== Derived progress helpers =====
-  const totalItems = version?.totalItems ?? 0
 
-  const completedItems = selectedUser?.completedItemsCount ?? 0
 
-  const hasCompletedCourse = totalItems > 0 && completedItems >= totalItems
+  // Redirect state
+  if (!currentCourse || !courseId || !versionId) {
+    return null;
+  }
 
   // Loading state
   if ((courseLoading || versionLoading) && !course && !version) {
@@ -893,966 +914,929 @@ export default function CourseEnrollments() {
                 <div className="flex items-center gap-3">
                   <div className="h-8 w-1 bg-gradient-to-b from-primary to-accent rounded-full"></div>
                   <h2 className="text-lg md:text-xl lg:text-2xl font-bold text-foreground">{course.name}</h2>
-                  <span className="text-lg text-muted-foreground">•</span>
+                  <span className="text-lg text-muted-foreground">â€¢</span>
                   <h3 className="text-base md:text-lg lg:text-xl font-semibold text-accent">{version.version}</h3>
                 </div>
                 <div className="h-1 w-32 bg-gradient-to-r from-primary to-accent rounded-full ml-4"></div>
+              </div>
             </div>
-          </div>
-          <div className="flex items-center gap-3">
-            <Button
-              className="gap-2 bg-primary hover:bg-accent text-primary-foreground cursor-pointer"
-              onClick={() => {
-                const { setCurrentCourse } = useCourseStore.getState()
-                setCurrentCourse({
-                  courseId: courseId || "",
-                  versionId: versionId || "",
-                  moduleId: null,
-                  sectionId: null,
-                  itemId: null,
-                  watchItemId: null,
-                })
-                navigate({ to: "/teacher/courses/invite" })
-              }}
-            >
-              Send Invites
-            </Button>
-          </div>
-        </div>
-
-        {/* Stats */}
-        <div className="flex lg:flex-nowrap flex-wrap gap-6">
-          {stats.map((stat) => (
-            <Card key={stat.title} className="border-0 shadow-sm hover:shadow-md transition-shadow w-full">
-              <CardContent className="p-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm font-medium text-muted-foreground">{stat.title}</p>
-                    <p className="text-2xl font-bold mt-1">{stat.value}</p>
-                  </div>
-                  <div className={`p-3 rounded-full ${stat.bgColor}`}>
-                    <stat.icon className={`h-5 w-5 ${stat.color}`} />
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-
-        {/* Search */}
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="relative flex-1">
-            <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 h-5 w-5 text-muted-foreground" />
-            <Input
-              placeholder="Search students by user ID..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value?.toLowerCase())}
-              className="pl-12 h-12 border-border bg-card text-card-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-200"
-            />
-            <X className="absolute right-4 top-1/2 transform -translate-y-1/2 h-5 w-5 text-muted-foreground cursor-pointer"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                setSearchQuery("");
-              }} />
-          </div>
-          
-          
-          {/* Time Slot Selection Mode Header */}
-          {(selectMode || isSelectionMode) && (
             <div className="flex items-center gap-3">
-              <div className="bg-card border border-border rounded-lg px-4 py-2">
-                <p className="text-sm text-card-foreground font-medium">
-                  Select students for time slot assignment
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {selectedUsers.size} student{selectedUsers.size !== 1 ? 's' : ''} selected
-                </p>
-              </div>
               <Button
-                onClick={handleTimeSlotStudentSelection}
-                disabled={selectedUsers.size === 0}
-                className="bg-primary hover:bg-primary/90 text-primary-foreground"
+                className="gap-2 bg-primary hover:bg-accent text-primary-foreground cursor-pointer"
+                onClick={() => {
+                  const { setCurrentCourse } = useCourseStore.getState()
+                  setCurrentCourse({
+                    courseId: courseId || "",
+                    versionId: versionId || "",
+                    moduleId: null,
+                    sectionId: null,
+                    itemId: null,
+                    watchItemId: null,
+                  })
+                  navigate({ to: "/teacher/courses/invite" })
+                }}
               >
-                <Check className="h-4 w-4 mr-2" />
-                Confirm Selection
-              </Button>
-              <Button
-                variant="outline"
-                onClick={() => setIsSelectionMode(false)}
-                className="border-border text-foreground hover:bg-muted"
-              >
-                Cancel
+                Send Invites
               </Button>
             </div>
-          )}
-        </div>
-
-
-
-        {/* Students Table */}
-        {/* Students Table + Tabs */}
-        <Tabs
-          value={enrollmentTab}
-          onValueChange={(v) => setEnrollmentTab(v as "ACTIVE" | "INACTIVE")}
-          className="w-full"
-        >
-          {/* Tabs Header */}
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <TabsList className="grid w-full sm:w-[420px] grid-cols-2 h-11 bg-muted/30 p-1 rounded-xl">
-              <TabsTrigger
-                value="ACTIVE"
-                className="rounded-lg data-[state=active]:bg-card data-[state=active]:shadow-sm font-semibold"
-              >
-                Active Students({activeCount})
-              </TabsTrigger>
-
-              <TabsTrigger
-                value="INACTIVE"
-                className="rounded-lg data-[state=active]:bg-card data-[state=active]:shadow-sm font-semibold"
-              >
-                Inactive Students({inactiveCount})
-              </TabsTrigger>
-            </TabsList>
           </div>
-          {/* Active Tab */}
-          <TabsContent value="ACTIVE" className="mt-4">
-            <EnrollmentsTable
-              totalDocuments={totalDocuments}
-              studentEnrollments={filteredStudentEnrollments}
-              enrollmentsLoading={enrollmentsLoading}
-              isSearching={isSearching}
-              enrollmentTab={enrollmentTab}
-              searchQuery={searchQuery}
-              limit={limit}
-              handleLimitChange={handleLimitChange}
-              handleSort={handleSort}
-              sortBy={sortBy}
-              sortOrder={sortOrder}
-              isLoadingQuizScores={isLoadingQuizScores}
-              setIsExporting={setIsExporting}
-              unenrollMutation={unenrollMutation}
-              user={user}
-              handleViewProgress={handleViewProgress}
-              handleRemoveStudent={handleRemoveStudent}
-              getRoleBadge={getRoleBadge}
-              isSelectionMode={isSelectionMode}
-              selectedUsers={selectedUsers}
-              onSelectUser={handleSelectUser}
-              onSelectAll={handleSelectAll}
-              toggleSelectionMode={toggleSelectionMode}
-              handleBulkUnenroll={handleBulkUnenroll}
-              setIsTimeSlotsModalOpen={setIsTimeSlotsModalOpen}
-              timeSlotsData={timeSlotsData}
-              getStudentTimeSlot={getStudentTimeSlot}
-            />
-          </TabsContent>
 
-          {/* Inactive Tab */}
-          <TabsContent value="INACTIVE" className="mt-4">
-            <EnrollmentsTable
-              totalDocuments={totalDocuments}
-              studentEnrollments={studentEnrollments}
-              enrollmentsLoading={enrollmentsLoading}
-              isSearching={isSearching}
-              enrollmentTab={enrollmentTab}
-              searchQuery={searchQuery}
-              limit={limit}
-              handleLimitChange={handleLimitChange}
-              handleSort={handleSort}
-              sortBy={sortBy}
-              sortOrder={sortOrder}
-              isLoadingQuizScores={isLoadingQuizScores}
-              setIsExporting={setIsExporting}
-              unenrollMutation={unenrollMutation}
-              user={user}
-              handleViewProgress={handleViewProgress}
-              handleRemoveStudent={handleRemoveStudent}
-              getRoleBadge={getRoleBadge}
-              isSelectionMode={false}
-              selectedUsers={new Set()}
-              onSelectUser={handleSelectUser}
-              onSelectAll={handleSelectAll}
-              toggleSelectionMode={toggleSelectionMode}
-              handleBulkUnenroll={handleBulkUnenroll}
-              setIsTimeSlotsModalOpen={setIsTimeSlotsModalOpen}
-              timeSlotsData={timeSlotsData}
-              getStudentTimeSlot={getStudentTimeSlot}
-            />
-          </TabsContent>
-        </Tabs>
-
-
-        {/* Enhanced View Progress Modal */}
-
-        {isViewProgressDialogOpen && selectedUser && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center mb-0">
-            {/* Enhanced Backdrop */}
-            <div
-              className="absolute inset-0 bg-black/60 backdrop-blur-md cursor-pointer"
-              onClick={() => setIsViewProgressDialogOpen(false)}
-            />
-            {/* Enhanced Modal */}
-            <div className="relative bg-card border border-border rounded-2xl shadow-2xl max-w-4xl w-full mx-4 p-8 space-y-6 max-h-[90vh] overflow-y-auto animate-in fade-in-0 zoom-in-95 duration-300 cursor-default">
-              {/* Header */}
-              <div className="flex items-center justify-between">
-                <h2 className="text-xl md:text-2xl font-semibold text-card-foreground">Student Progress Details</h2>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setIsViewProgressDialogOpen(false)}
-                  className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground rounded-full cursor-pointer"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-
-              {/* Enhanced Student Info */}
-              <div className="flex flex-wrap items-center gap-4 p-6 bg-gradient-to-r from-muted/30 to-muted/10 rounded-xl border border-border">
-                <Avatar className="h-12 w-12 border-2 border-primary/20 shadow-md">
-                  <AvatarImage src={selectedUser.avatar || "/placeholder.svg"} alt={selectedUser.name} />
-                  <AvatarFallback className="bg-gradient-to-br from-primary to-accent text-primary-foreground font-bold">
-                    {selectedUser.name
-                      .split(" ")
-                      .map((n) => n[0])
-                      .join("")}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="flex-1">
-                  <p className="font-medium text-card-foreground truncate text-base md:text-lg">{selectedUser.name}</p>
-                  <p className="text-muted-foreground truncate">{selectedUser.email}</p>
-
-
-
-                </div>
-
-                {/* Content Summary Dropdown */}
-                {selectedUser?.contentCounts && (
-                  <div className="border border-border rounded-lg ml-auto p-2">
-
-                    {/* Header */}
-                    {/* <button
-                      onClick={() => setShowContentSummary(prev => !prev)}
-                      className="flex items-center gap-2 px-3 py-2 text-sm font-medium hover:bg-muted/20 rounded-md"
-                    > */}
-                    <p>Content Summary</p>
-                    {/* {showContentSummary ? (
-                      <ChevronDown className="h-4 w-4" />
-                    ) : (
-                      <ChevronRight className="h-4 w-4" />
-                    )} */}
-                    {/* </button> */}
-                    <div className="flex justify-between items-center mt-2 mb-2">
-                      <p className="text-sm text-muted-foreground mb-2">Completion Percentage</p>
-                      <EnrollmentProgress progress={(selectedUser.progress || 0)} />
+          {/* Stats */}
+          <div className="flex lg:flex-nowrap flex-wrap gap-6">
+            {stats.map((stat) => (
+              <Card key={stat.title} className="border-0 shadow-sm hover:shadow-md transition-shadow w-full">
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-muted-foreground">{stat.title}</p>
+                      <p className="text-2xl font-bold mt-1">{stat.value}</p>
                     </div>
-                    {/* Body */}
-                    {
-                      // showContentSummary &&
-                      (
-                        <div className=" grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-
-                          <SummaryRow label="Total Items" value={selectedUser.contentCounts.totalItems} />
-
-                          <SummaryRow
-                            label="Videos"
-                            value={`${selectedUser.contentCounts.completedVideos} / ${selectedUser.contentCounts.videos}`}
-                          />
-
-                          <SummaryRow
-                            label="Quizzes"
-                            value={`${selectedUser.contentCounts.completedQuizzes} / ${selectedUser.contentCounts.quizzes}`}
-                          />
-
-                          <SummaryRow
-                            label="Articles"
-                            value={`${selectedUser.contentCounts.completedArticles} / ${selectedUser.contentCounts.articles}`}
-                          />
-
-                          <SummaryRow
-                            label="Projects"
-                            value={`${selectedUser.contentCounts.completedProjects} / ${selectedUser.contentCounts.projects}`}
-                          />
-
-                          <SummaryRow
-                            label="Quiz Score"
-                            value={`${selectedUser.contentCounts.totalQuizScore || 0} / ${selectedUser.contentCounts.totalQuizMaxScore || 0}`}
-                          />
-
-                          <SummaryRow
-                            label="Items Completed"
-                            value={`${selectedUser.completedItemsCount || 0} / ${version?.totalItems ?? 0}`}
-                          />
-
-
-
-
-                        </div>
-                      )}
+                    <div className={`p-3 rounded-full ${stat.bgColor}`}>
+                      <stat.icon className={`h-5 w-5 ${stat.color}`} />
+                    </div>
                   </div>
-                )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
 
-              </div>
+          {/* Search */}
+          <div className="flex flex-col sm:flex-row gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 h-5 w-5 text-muted-foreground" />
+              <Input
+                placeholder="Search students by user ID..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value?.toLowerCase())}
+                className="pl-12 h-12 border-border bg-card text-card-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all duration-200"
+              />
+              <X className="absolute right-4 top-1/2 transform -translate-y-1/2 h-5 w-5 text-muted-foreground cursor-pointer"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setSearchQuery("");
+                }} />
+            </div>
 
-              <div className="mt-4">
-                {/* {hasCompletedCourse ? (
-    <div className="p-4 rounded-lg bg-green-50 border border-green-200 text-green-700 font-medium">
-      🎉 Student has completed the course
-    </div>
-  ) : (
-    <div className="p-4 rounded-lg bg-amber-50 border border-amber-200 text-amber-700 font-medium">
-      ⏳ Course is still in progress
-    </div>
-  )} */}
-              </div>
 
-              {/* Current Learning Position */}
-              <div className="space-y-2 p-4 rounded-lg border border-border bg-muted/20">
-                <h4 className="text-sm font-semibold text-muted-foreground">
-                  Current Learning Position
-                </h4>
-
-                {pathError && (
-                  <div className="text-sm text-destructive">
-                    <p>Failed to load current progress</p>
-                    <p className="text-xs mt-1">Error: {pathError.message || 'Unknown error'}</p>
-                  </div>
-                )}
-
-                {!currentPath && !pathError && (
-                  <p className="text-sm text-muted-foreground">
-                    Progress not started yet
+            {/* Time Slot Selection Mode Header */}
+            {(selectMode || isSelectionMode) && (
+              <div className="flex items-center gap-3">
+                <div className="bg-card border border-border rounded-lg px-4 py-2">
+                  <p className="text-sm text-card-foreground font-medium">
+                    Select students for time slot assignment
                   </p>
-                )}
-
-                {currentPath && currentPath.message && (
-                  <div className="text-sm text-muted-foreground">
-                    <p>{currentPath.message}</p>
-                  </div>
-                )}
-
-                {currentPath && currentPath.module && (
-                  <div className="flex flex-wrap items-center gap-2 text-sm font-medium">
-                    <span className="px-2 py-1 rounded bg-blue-100 text-blue-700">
-                      {currentPath.module.name}
-                    </span>
-
-                    <span className="text-muted-foreground">›</span>
-
-                    <span className="px-2 py-1 rounded bg-emerald-100 text-emerald-700">
-                      {currentPath.section.name}
-                    </span>
-
-                    <span className="text-muted-foreground">›</span>
-
-                    <span className="px-2 py-1 rounded bg-purple-100 text-purple-700">
-                      {currentPath.item.name}
-                    </span>
-
-                    <span className="ml-2 text-xs px-2 py-0.5 rounded border">
-                      {currentPath.item.type}
-                    </span>
-                  </div>
-                )}
-              </div>
-
-
-              {/* Course Structure */}
-              <div className="space-y-4">
-                {enrollmentTab === "ACTIVE" && (
-                  <div className="flex justify-between">
-                    <TooltipProvider delayDuration={300}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() =>
-                              handleResetProgress({
-                                id: selectedUser.id,
-                                name: `${selectedUser.name || ""}`.trim() || "Unknown User",
-                                email: selectedUser.email,
-                                enrolledDate: selectedUser.enrolledDate,
-                                progress: 0,
-                              })
-                            }
-                            className="text-amber-600 hover:text-amber-700 hover:bg-amber-50 dark:hover:bg-amber-950/30 transition-all duration-200 cursor-pointer"
-                            disabled={resetProgressMutation.isPending || selectedUser.isDeleted}
-                          >
-                            {resetProgressMutation.isPending ? (
-                              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                            ) : (
-                              <RotateCcw className="h-4 w-4 mr-2" />
-                            )}
-                            Reset
-                          </Button>
-                        </TooltipTrigger>
-
-                        <TooltipContent>
-                          <p>Reset student progress</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() =>
-                              handleRecalculateProgress({
-                                id: selectedUser.id,
-                                name: `${selectedUser.name || ""}`.trim() || "Unknown User",
-                                email: selectedUser.email,
-                                enrolledDate: selectedUser.enrolledDate,
-                                progress: 0,
-                              })
-                            }
-                            className="text-indigo-600 hover:text-indigo-700 hover:bg-indigo-50 dark:hover:bg-indigo-950/30"
-                            disabled={
-                              unenrollMutation.isPending ||
-                              user?.email == selectedUser.email ||
-                              selectedUser.isDeleted
-                            }
-                          >
-                            {unenrollMutation.isPending ? (
-                              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                            ) : (
-                              <RotateCcw className="h-4 w-4 mr-2" />
-                            )}
-                            Recalculate
-                          </Button>
-                        </TooltipTrigger>
-
-                        <TooltipContent>Recalculate student progress</TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </div>
-                )}
-                {/* add the code here */}
-                <h3 className="text-lg font-semibold text-foreground">Course Structure</h3>
-                <div className="space-y-2 max-h-96 overflow-y-auto border border-border rounded-lg p-4">
-                  {getAvailableModules().map((module: any) => (
-                    <div key={module.moduleId} className="space-y-2">
-                      {/* Module */}
-                      <div
-                        className="flex items-center gap-2 p-3 bg-muted/20 rounded-lg cursor-pointer hover:bg-muted/30 transition-colors"
-                        onClick={() => toggleModule(module.moduleId)}
-                      >
-                        {expandedModules.has(module.moduleId) ? (
-                          <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                        ) : (
-                          <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                        )}
-                        <BookOpen className="h-5 w-5 text-blue-600" />
-                        <span className="font-semibold text-foreground flex-1">{module.name}</span>
-
-                        {/* Module completion count */}
-                        {(() => {
-                          // Find progress for this module from the API response
-                          const moduleProgress = userModuleProgress?.modules?.find(
-                            (m: any) => m.moduleId === module.moduleId
-                          );
-
-                          if (moduleProgress) {
-                            const { totalItems, completedItems } = moduleProgress;
-                            const completedText = totalItems > 0
-                              ? `${completedItems}/${totalItems} completed`
-                              : 'No items';
-
-                            return (
-                              <span className="text-xs ml-auto text-muted-foreground">
-                                {completedText}
-                              </span>
-                            );
-                          }
-
-                          let totalItems = 0;
-                          module.sections?.forEach((section: any) => {
-                            totalItems += section.itemCount || 0;
-                          });
-
-                          const loadingText = moduleProgressLoading
-                            ? `${totalItems} items (loading...)`
-                            : `${totalItems} items`;
-
-                          return (
-                            <span className="text-xs ml-auto text-muted-foreground">
-                              {loadingText}
-                            </span>
-                          );
-                        })()}
-                      </div>
-
-                      {/* Sections */}
-                      {expandedModules.has(module.moduleId) && (
-                        <div className="ml-6 space-y-2">
-                          {module.sections?.map((section: any) => (
-                            <div key={section.sectionId} className="space-y-2">
-                              <div
-                                className="flex items-center gap-2 p-2 bg-muted/10 rounded-lg cursor-pointer hover:bg-muted/20 transition-colors"
-                                onClick={() => toggleSection(section.sectionId)}
-                              >
-                                {expandedSections.has(section.sectionId) ? (
-                                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                                ) : (
-                                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                                )}
-                                <FileText className="h-4 w-4 text-emerald-600" />
-                                <span className="font-medium text-foreground">{section.name}</span>
-                              </div>
-
-                              {/* Items */}
-                              {expandedSections.has(section.sectionId) && (
-                                <SectionItems
-                                  versionId={versionId!}
-                                  moduleId={module.moduleId}
-                                  sectionId={section.sectionId}
-                                  selectedViewItem={selectedViewItem}
-                                  onItemSelect={(itemId, itemType, itemName) => {
-                                    setSelectedViewItem(itemId)
-                                    setSelectedViewItemType(itemType)
-                                    setSelectedViewItemName(itemName)
-                                  }}
-                                  getItemIcon={getItemIcon}
-                                />
-                              )}
-                            </div>
-                          )) || (
-                              <p className="text-sm text-muted-foreground ml-6">
-                                No sections in this module
-                              </p>
-                            )}
-                        </div>
-                      )}
-                    </div>
-                  ))}
+                  <p className="text-xs text-muted-foreground">
+                    {selectedUsers.size} student{selectedUsers.size !== 1 ? 's' : ''} selected
+                  </p>
                 </div>
-              </div>
-
-
-              {/* Item Details Display */}
-              {selectedViewItem && (
-                <div className="space-y-4">
-                  {selectedViewItemType?.toUpperCase() === 'QUIZ' ? (
-                    <QuizSubmissionDisplay
-                      userId={selectedUser.id}
-                      quizId={selectedViewItem}
-                      itemName={selectedViewItemName}
-                    />
-                  ) : (
-                    <WatchTimeDisplay
-                      userId={selectedUser.id}
-                      itemId={selectedViewItem}
-                      courseId={courseId!}
-                      courseVersionId={versionId}
-                      itemName={selectedViewItemName}
-                      itemType={selectedViewItemType}
-                    />
-                  )}
-                </div>
-              )}
-
-              {!selectedViewItem && (
-                <div className="p-8 text-center text-muted-foreground">
-                  <Clock className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                  <p>Select an item from the course structure above to view details.</p>
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-
-        {/* Enhanced Remove Student Confirmation Modal */}
-        {isRemoveDialogOpen && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center mb-0">
-            <div
-              className="absolute inset-0 bg-black/60 backdrop-blur-md cursor-pointer"
-              onClick={() => setIsRemoveDialogOpen(false)}
-            />
-            <div className="relative bg-card border border-border rounded-2xl shadow-2xl sm:max-w-lg max-[425px]:w-[90vw] w-full mx-4 sm:p-10 p-5 space-y-8 animate-in fade-in-0 zoom-in-95 duration-300 cursor-default">
-              <div className="flex items-center justify-between">
-                <h2 className="text-xl md:text-2xl font-bold text-card-foreground">Remove Student</h2>
                 <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setIsRemoveDialogOpen(false)}
-                  className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground rounded-full cursor-pointer"
+                  onClick={handleTimeSlotStudentSelection}
+                  disabled={selectedUsers.size === 0}
+                  className="bg-primary hover:bg-primary/90 text-primary-foreground"
                 >
-                  <X className="h-4 w-4" />
+                  <Check className="h-4 w-4 mr-2" />
+                  Confirm Selection
                 </Button>
-              </div>
-
-              <div className="space-y-8">
-                <p className="text-lg text-card-foreground">
-                  Want to remove <strong className="text-primary">{userToRemove?.name}</strong> from{" "}
-                  <strong className="text-primary">
-                    {course.name} ({version.version})
-                  </strong>
-                  ?
-                </p>
-
-                <div className="flex gap-4 p-6 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl">
-                  <div><AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" /></div>
-                  <div className="text-sm text-red-800 dark:text-red-200">
-                    <strong>Warning:</strong> This action cannot be undone. The student will lose access to the course
-                    version and all their progress data.
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex justify-end gap-3 pt-4">
                 <Button
                   variant="outline"
-                  onClick={() => setIsRemoveDialogOpen(false)}
-                  className="min-w-[100px] cursor-pointer"
+                  onClick={() => setIsSelectionMode(false)}
+                  className="border-border text-foreground hover:bg-muted"
                 >
-                  No, Cancel
+                  Cancel
                 </Button>
-                <Button
-                  variant="destructive"
-                  onClick={confirmRemoveStudent}
-                  disabled={unenrollMutation.isPending}
-                  className="min-w-[100px] shadow-lg cursor-pointer"
+              </div>
+            )}
+          </div>
+
+
+
+          {/* Students Table */}
+          {/* Students Table + Tabs */}
+          <Tabs
+            value={enrollmentTab}
+            onValueChange={(v) => setEnrollmentTab(v as "ACTIVE" | "INACTIVE")}
+            className="w-full"
+          >
+            {/* Tabs Header */}
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <TabsList className="grid w-full sm:w-[420px] grid-cols-2 h-11 bg-muted/30 p-1 rounded-xl">
+                <TabsTrigger
+                  value="ACTIVE"
+                  className="rounded-lg data-[state=active]:bg-card data-[state=active]:shadow-sm font-semibold"
                 >
-                  {unenrollMutation.isPending ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      Removing...
-                    </>
-                  ) : (
-                    "Yes, Remove"
-                  )}
-                </Button>
+                  Active Students({activeCount})
+                </TabsTrigger>
+
+                <TabsTrigger
+                  value="INACTIVE"
+                  className="rounded-lg data-[state=active]:bg-card data-[state=active]:shadow-sm font-semibold"
+                >
+                  Inactive Students({inactiveCount})
+                </TabsTrigger>
+              </TabsList>
+            </div>
+            {/* Active Tab */}
+            <TabsContent value="ACTIVE" className="mt-4">
+              <EnrollmentsTable
+                studentEnrollments={filteredStudentEnrollments}
+                enrollmentsLoading={enrollmentsLoading}
+                isSearching={isSearching}
+                enrollmentTab={enrollmentTab}
+                searchQuery={searchQuery}
+                limit={limit}
+                handleLimitChange={handleLimitChange}
+                handleSort={handleSort}
+                sortBy={sortBy}
+                sortOrder={sortOrder}
+                isLoadingQuizScores={isLoadingQuizScores}
+                setIsExporting={setIsExporting}
+                unenrollMutation={unenrollMutation}
+                user={user}
+                handleViewProgress={handleViewProgress}
+                handleRemoveStudent={handleRemoveStudent}
+                isSelectionMode={isSelectionMode}
+                selectedUsers={selectedUsers}
+                onSelectUser={handleSelectUser}
+                onSelectAll={handleSelectAll}
+                toggleSelectionMode={toggleSelectionMode}
+                handleBulkUnenroll={handleBulkUnenroll}
+                setIsTimeSlotsModalOpen={setIsTimeSlotsModalOpen}
+                getStudentTimeSlot={getStudentTimeSlot}
+              />
+            </TabsContent>
+
+            {/* Inactive Tab */}
+            <TabsContent value="INACTIVE" className="mt-4">
+              <EnrollmentsTable
+                studentEnrollments={studentEnrollments}
+                enrollmentsLoading={enrollmentsLoading}
+                isSearching={isSearching}
+                enrollmentTab={enrollmentTab}
+                searchQuery={searchQuery}
+                limit={limit}
+                handleLimitChange={handleLimitChange}
+                handleSort={handleSort}
+                sortBy={sortBy}
+                sortOrder={sortOrder}
+                isLoadingQuizScores={isLoadingQuizScores}
+                setIsExporting={setIsExporting}
+                unenrollMutation={unenrollMutation}
+                user={user}
+                handleViewProgress={handleViewProgress}
+                handleRemoveStudent={handleRemoveStudent}
+                isSelectionMode={false}
+                selectedUsers={new Set()}
+                onSelectUser={handleSelectUser}
+                onSelectAll={handleSelectAll}
+                toggleSelectionMode={toggleSelectionMode}
+                handleBulkUnenroll={handleBulkUnenroll}
+                setIsTimeSlotsModalOpen={setIsTimeSlotsModalOpen}
+                getStudentTimeSlot={getStudentTimeSlot}
+              />
+            </TabsContent>
+          </Tabs>
+
+
+          {/* Enhanced View Progress Modal */}
+
+          {isViewProgressDialogOpen && selectedUser && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center mb-0">
+              {/* Enhanced Backdrop */}
+              <div
+                className="absolute inset-0 bg-black/60 backdrop-blur-md cursor-pointer"
+                onClick={() => setIsViewProgressDialogOpen(false)}
+              />
+              {/* Enhanced Modal */}
+              <div className="relative bg-card border border-border rounded-2xl shadow-2xl max-w-4xl w-full mx-4 p-8 space-y-6 max-h-[90vh] overflow-y-auto animate-in fade-in-0 zoom-in-95 duration-300 cursor-default">
+                {/* Header */}
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xl md:text-2xl font-semibold text-card-foreground">Student Progress Details</h2>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsViewProgressDialogOpen(false)}
+                    className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground rounded-full cursor-pointer"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+
+                {/* Enhanced Student Info & Content Summary */}
+                <div className="flex flex-wrap items-center gap-4 p-6 bg-gradient-to-r from-muted/30 to-muted/10 rounded-xl border border-border">
+                  <Avatar className="h-12 w-12 border-2 border-primary/20 shadow-md">
+                    <AvatarImage src={selectedUser.avatar || "/placeholder.svg"} alt={selectedUser.name} />
+                    <AvatarFallback className="bg-gradient-to-br from-primary to-accent text-primary-foreground font-bold">
+                      {selectedUser.name.split(" ").map((n) => n[0]).join("")}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1">
+                    <p className="font-medium text-card-foreground truncate text-base md:text-lg">{selectedUser.name}</p>
+                    <p className="text-muted-foreground truncate">{selectedUser.email}</p>
+                  </div>
+
+                  {/* Content Summary — loaded from API 2 */}
+                  <div className="border border-border rounded-lg ml-auto p-3 min-w-[240px]">
+                    <p className="font-medium text-sm mb-2">Content Summary</p>
+                    {progressDetailLoading ? (
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Loading progress...
+                      </div>
+                    ) : progressDetail ? (
+                      <>
+                        <div className="flex justify-between items-center mb-3">
+                          <p className="text-sm text-muted-foreground">Completion</p>
+                          <EnrollmentProgress progress={progressDetail.percentCompleted || 0} />
+                        </div>
+                        <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+                          <SummaryRow label="Total Items" value={progressDetail.contentCounts?.totalItems ?? 0} />
+                          <SummaryRow label="Videos" value={progressDetail.contentCounts?.itemCounts?.VIDEO ?? 0} />
+                          <SummaryRow label="Quizzes" value={progressDetail.contentCounts?.itemCounts?.QUIZ ?? 0} />
+                          <SummaryRow label="Articles" value={progressDetail.contentCounts?.itemCounts?.BLOG ?? 0} />
+                          <SummaryRow label="Projects" value={progressDetail.contentCounts?.itemCounts?.PROJECT ?? 0} />
+                          <SummaryRow
+                            label="Quiz Score"
+                            value={`${progressDetail.totalQuizScore ?? 0} / ${progressDetail.totalQuizMaxScore ?? 0}`}
+                          />
+                          <SummaryRow
+                            label="Items Completed"
+                            value={`${progressDetail.completedItemsCount ?? 0} / ${progressDetail.contentCounts?.totalItems ?? 0}`}
+                          />
+                        </div>
+                      </>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">No progress data found</p>
+                    )}
+                  </div>
+                </div>
+
+                {/* View Course Structure button — lazy loads API 3 */}
+                <div className="flex justify-center mt-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowCourseStructure(true)}
+                    disabled={showCourseStructure}
+                    className="gap-2 cursor-pointer"
+                  >
+                    {courseStructureLoading ? (
+                      <><Loader2 className="h-4 w-4 animate-spin" /> Loading Course Structure...</>
+                    ) : (
+                      <><BookOpen className="h-4 w-4" /> View Course Structure</>
+                    )}
+                  </Button>
+                </div>
+                {/* Current Learning Position & Course Structure gated by API 3 */}
+                {showCourseStructure && (
+                  <div className="space-y-6">
+
+                    {/* Current Learning Position */}
+                    <div className="space-y-2 p-4 rounded-lg border border-border bg-muted/20">
+                      <h4 className="text-sm font-semibold text-muted-foreground">
+                        Current Learning Position
+                      </h4>
+
+                      {pathError && (
+                        <div className="text-sm text-destructive">
+                          <p>Failed to load current progress</p>
+                          <p className="text-xs mt-1">Error: {pathError.message || 'Unknown error'}</p>
+                        </div>
+                      )}
+
+                      {!currentPath && !pathError && (
+                        <p className="text-sm text-muted-foreground">
+                          Progress not started yet
+                        </p>
+                      )}
+
+                      {currentPath && currentPath.message && (
+                        <div className="text-sm text-muted-foreground">
+                          <p>{currentPath.message}</p>
+                        </div>
+                      )}
+
+                      {currentPath && currentPath.module && (
+                        <div className="flex flex-wrap items-center gap-2 text-sm font-medium">
+                          <span className="px-2 py-1 rounded bg-blue-100 text-blue-700">
+                            {currentPath.module.name}
+                          </span>
+
+                          <span className="text-muted-foreground">â€º</span>
+
+                          <span className="px-2 py-1 rounded bg-emerald-100 text-emerald-700">
+                            {currentPath.section.name}
+                          </span>
+
+                          <span className="text-muted-foreground">â€º</span>
+
+                          <span className="px-2 py-1 rounded bg-purple-100 text-purple-700">
+                            {currentPath.item.name}
+                          </span>
+
+                          <span className="ml-2 text-xs px-2 py-0.5 rounded border">
+                            {currentPath.item.type}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+
+
+                    {/* Course Structure */}
+                    <div className="space-y-4">
+                      {enrollmentTab === "ACTIVE" && (
+                        <div className="flex justify-between">
+                          <TooltipProvider delayDuration={300}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() =>
+                                    handleResetProgress({
+                                      id: selectedUser.id,
+                                      name: `${selectedUser.name || ""}`.trim() || "Unknown User",
+                                      email: selectedUser.email,
+                                      enrolledDate: selectedUser.enrolledDate,
+                                      progress: 0,
+                                    })
+                                  }
+                                  className="text-amber-600 hover:text-amber-700 hover:bg-amber-50 dark:hover:bg-amber-950/30 transition-all duration-200 cursor-pointer"
+                                  disabled={resetProgressMutation.isPending || selectedUser.isDeleted}
+                                >
+                                  {resetProgressMutation.isPending ? (
+                                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                                  ) : (
+                                    <RotateCcw className="h-4 w-4 mr-2" />
+                                  )}
+                                  Reset
+                                </Button>
+                              </TooltipTrigger>
+
+                              <TooltipContent>
+                                <p>Reset student progress</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() =>
+                                    handleRecalculateProgress({
+                                      id: selectedUser.id,
+                                      name: `${selectedUser.name || ""}`.trim() || "Unknown User",
+                                      email: selectedUser.email,
+                                      enrolledDate: selectedUser.enrolledDate,
+                                      progress: 0,
+                                    })
+                                  }
+                                  className="text-indigo-600 hover:text-indigo-700 hover:bg-indigo-50 dark:hover:bg-indigo-950/30"
+                                  disabled={
+                                    unenrollMutation.isPending ||
+                                    user?.email == selectedUser.email ||
+                                    selectedUser.isDeleted
+                                  }
+                                >
+                                  {unenrollMutation.isPending ? (
+                                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                                  ) : (
+                                    <RotateCcw className="h-4 w-4 mr-2" />
+                                  )}
+                                  Recalculate
+                                </Button>
+                              </TooltipTrigger>
+
+                              <TooltipContent>Recalculate student progress</TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        </div>
+                      )}
+                      {/* add the code here */}
+                      <h3 className="text-lg font-semibold text-foreground">Course Structure</h3>
+                      <div className="space-y-2 max-h-96 overflow-y-auto border border-border rounded-lg p-4">
+                        {getAvailableModules().map((module: any) => (
+                          <div key={module.moduleId} className="space-y-2">
+                            {/* Module */}
+                            <div
+                              className="flex items-center gap-2 p-3 bg-muted/20 rounded-lg cursor-pointer hover:bg-muted/30 transition-colors"
+                              onClick={() => toggleModule(module.moduleId)}
+                            >
+                              {expandedModules.has(module.moduleId) ? (
+                                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                              ) : (
+                                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                              )}
+                              <BookOpen className="h-5 w-5 text-blue-600" />
+                              <span className="font-semibold text-foreground flex-1">{module.name}</span>
+
+                              {/* Module completion count */}
+                              {(() => {
+                                // Find progress for this module from the API response
+                                const moduleProgress = userModuleProgress?.modules?.find(
+                                  (m: any) => m.moduleId === module.moduleId
+                                );
+
+                                if (moduleProgress) {
+                                  const { totalItems, completedItems } = moduleProgress;
+                                  const completedText = totalItems > 0
+                                    ? `${completedItems}/${totalItems} completed`
+                                    : 'No items';
+
+                                  return (
+                                    <span className="text-xs ml-auto text-muted-foreground">
+                                      {completedText}
+                                    </span>
+                                  );
+                                }
+
+                                let totalItems = 0;
+                                module.sections?.forEach((section: any) => {
+                                  totalItems += section.itemCount || 0;
+                                });
+
+                                const loadingText = moduleProgressLoading
+                                  ? `${totalItems} items (loading...)`
+                                  : `${totalItems} items`;
+
+                                return (
+                                  <span className="text-xs ml-auto text-muted-foreground">
+                                    {loadingText}
+                                  </span>
+                                );
+                              })()}
+                            </div>
+
+                            {/* Sections */}
+                            {expandedModules.has(module.moduleId) && (
+                              <div className="ml-6 space-y-2">
+                                {module.sections?.map((section: any) => (
+                                  <div key={section.sectionId} className="space-y-2">
+                                    <div
+                                      className="flex items-center gap-2 p-2 bg-muted/10 rounded-lg cursor-pointer hover:bg-muted/20 transition-colors"
+                                      onClick={() => toggleSection(section.sectionId)}
+                                    >
+                                      {expandedSections.has(section.sectionId) ? (
+                                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                                      ) : (
+                                        <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                                      )}
+                                      <FileText className="h-4 w-4 text-emerald-600" />
+                                      <span className="font-medium text-foreground">{section.name}</span>
+                                    </div>
+
+                                    {/* Items */}
+                                    {expandedSections.has(section.sectionId) && (
+                                      <SectionItems
+                                        versionId={versionId!}
+                                        moduleId={module.moduleId}
+                                        sectionId={section.sectionId}
+                                        selectedViewItem={selectedViewItem}
+                                        onItemSelect={(itemId, itemType, itemName) => {
+                                          setSelectedViewItem(itemId)
+                                          setSelectedViewItemType(itemType)
+                                          setSelectedViewItemName(itemName)
+                                        }}
+                                      />
+                                    )}
+                                  </div>
+                                )) || (
+                                    <p className="text-sm text-muted-foreground ml-6">
+                                      No sections in this module
+                                    </p>
+                                  )}
+                              </div>
+                            )}
+                          </div>
+                        ))}
+                      </div>              {/* Item Details Display */}
+                      {selectedViewItem && (
+                        <div className="space-y-4">
+                          {selectedViewItemType?.toUpperCase() === 'QUIZ' ? (
+                            <QuizSubmissionDisplay
+                              userId={selectedUser.id}
+                              quizId={selectedViewItem}
+                              itemName={selectedViewItemName}
+                            />
+                          ) : (
+                            <WatchTimeDisplay
+                              userId={selectedUser.id}
+                              itemId={selectedViewItem}
+                              courseId={courseId!}
+                              courseVersionId={versionId}
+                              itemName={selectedViewItemName}
+                              itemType={selectedViewItemType}
+                            />
+                          )}
+                        </div>
+                      )}
+
+                      {!selectedViewItem && (
+                        <div className="p-8 text-center text-muted-foreground">
+                          <Clock className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                          <p>Select an item from the course structure above to view details.</p>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {isRecalculateProgressOpen && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center mb-0">
-            <div
-              className="absolute inset-0 bg-black/60 backdrop-blur-md cursor-pointer"
-              onClick={() => setIsRecalculateProgressOpen(false)}
-            />
-            <div className="relative bg-card border border-border rounded-2xl shadow-2xl sm:max-w-lg max-[425px]:w-[90vw] w-full mx-4 sm:p-10 p-5 space-y-8 animate-in fade-in-0 zoom-in-95 duration-300 cursor-default">
-              <div className="flex items-center justify-between">
-                <h2 className="text-xl md:text-2xl font-bold text-card-foreground">Recalculate Progress</h2>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setIsRecalculateProgressOpen(false)}
-                  className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground rounded-full cursor-pointer"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
+          {isRemoveDialogOpen && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center mb-0">
+              <div
+                className="absolute inset-0 bg-black/60 backdrop-blur-md cursor-pointer"
+                onClick={() => setIsRemoveDialogOpen(false)}
+              />
+              <div className="relative bg-card border border-border rounded-2xl shadow-2xl sm:max-w-lg max-[425px]:w-[90vw] w-full mx-4 sm:p-10 p-5 space-y-8 animate-in fade-in-0 zoom-in-95 duration-300 cursor-default">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xl md:text-2xl font-bold text-card-foreground">Remove Student</h2>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsRemoveDialogOpen(false)}
+                    className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground rounded-full cursor-pointer"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+
+                <div className="space-y-8">
+                  <p className="text-lg text-card-foreground">
+                    Want to remove <strong className="text-primary">{userToRemove?.name}</strong> from{" "}
+                    <strong className="text-primary">
+                      {course.name} ({version.version})
+                    </strong>
+                    ?
+                  </p>
+
+                  <div className="flex gap-4 p-6 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl">
+                    <div><AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" /></div>
+                    <div className="text-sm text-red-800 dark:text-red-200">
+                      <strong>Warning:</strong> This action cannot be undone. The student will lose access to the course
+                      version and all their progress data.
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex justify-end gap-3 pt-4">
+                  <Button
+                    variant="outline"
+                    onClick={() => setIsRemoveDialogOpen(false)}
+                    className="min-w-[100px] cursor-pointer"
+                  >
+                    No, Cancel
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={confirmRemoveStudent}
+                    disabled={unenrollMutation.isPending}
+                    className="min-w-[100px] shadow-lg cursor-pointer"
+                  >
+                    {unenrollMutation.isPending ? (
+                      <>
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        Removing...
+                      </>
+                    ) : (
+                      "Yes, Remove"
+                    )}
+                  </Button>
+                </div>
               </div>
+            </div>
+          )}
 
-              <div className="space-y-8">
-                <p className="text-lg text-card-foreground">
-                  Want to Recalculate progress of <strong className="text-primary">{userToRecalculate?.name}</strong>
-                  ?
-                </p>
+          {isRecalculateProgressOpen && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center mb-0">
+              <div
+                className="absolute inset-0 bg-black/60 backdrop-blur-md cursor-pointer"
+                onClick={() => setIsRecalculateProgressOpen(false)}
+              />
+              <div className="relative bg-card border border-border rounded-2xl shadow-2xl sm:max-w-lg max-[425px]:w-[90vw] w-full mx-4 sm:p-10 p-5 space-y-8 animate-in fade-in-0 zoom-in-95 duration-300 cursor-default">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xl md:text-2xl font-bold text-card-foreground">Recalculate Progress</h2>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsRecalculateProgressOpen(false)}
+                    className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground rounded-full cursor-pointer"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
 
-                {/* <div className="flex gap-4 p-6 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl">
+                <div className="space-y-8">
+                  <p className="text-lg text-card-foreground">
+                    Want to Recalculate progress of <strong className="text-primary">{userToRecalculate?.name}</strong>
+                    ?
+                  </p>
+
+                  {/* <div className="flex gap-4 p-6 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl">
                   <div><AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" /></div>
                   <div className="text-sm text-red-800 dark:text-red-200">
                     <strong>Warning:</strong> This action cannot be undone. The student will lose access to the course
                     version and all their progress data.
                   </div>
                 </div> */}
-              </div>
+                </div>
 
-              <div className="flex justify-end gap-3 pt-4">
-                <Button
-                  variant="outline"
-                  onClick={() => setIsRecalculateProgressOpen(false)}
-                  className="min-w-[100px] cursor-pointer"
-                >
-                  No, Cancel
-                </Button>
-                <Button
-                  variant="destructive"
-                  onClick={confirmReCalculateProgress}
-                  disabled={recalculateMutation.isPending}
-                  className="min-w-[100px] shadow-lg cursor-pointer"
-                >
-                  {unenrollMutation.isPending ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      Recalculating...
-                    </>
-                  ) : (
-                    "Yes, Recalculate"
-                  )}
-                </Button>
+                <div className="flex justify-end gap-3 pt-4">
+                  <Button
+                    variant="outline"
+                    onClick={() => setIsRecalculateProgressOpen(false)}
+                    className="min-w-[100px] cursor-pointer"
+                  >
+                    No, Cancel
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={confirmReCalculateProgress}
+                    disabled={recalculateMutation.isPending}
+                    className="min-w-[100px] shadow-lg cursor-pointer"
+                  >
+                    {unenrollMutation.isPending ? (
+                      <>
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        Recalculating...
+                      </>
+                    ) : (
+                      "Yes, Recalculate"
+                    )}
+                  </Button>
+                </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Enhanced Reset Progress Modal */}
-        {isResetDialogOpen && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center mb-0">
-            <div
-              className="absolute inset-0 bg-black/60 backdrop-blur-md cursor-pointer"
-              onClick={() => setIsResetDialogOpen(false)}
-            />
-            <div className="relative bg-card border border-border rounded-2xl shadow-2xl max-w-3xl w-full mx-4 sm:p-8 p-4 space-y-6 max-h-[90vh] overflow-y-auto animate-in fade-in-0 zoom-in-95 duration-300 cursor-default">
-              <div className="flex items-center justify-between">
-                <h2 className="text-xl md:text-2xl font-bold text-card-foreground">Reset Student Progress</h2>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setIsResetDialogOpen(false)}
-                  className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground rounded-full cursor-pointer"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-
-              {selectedUser && (
-                <div className="flex items-center gap-4 p-6 bg-gradient-to-r from-muted/30 to-muted/10 rounded-xl border border-border">
-                  <Avatar className="h-12 w-12 border-2 border-primary/20 shadow-md">
-                    <AvatarImage src={selectedUser.avatar || "/placeholder.svg"} alt={selectedUser.name} />
-                    <AvatarFallback className="bg-gradient-to-br from-primary to-accent text-primary-foreground font-bold">
-                      {selectedUser.name
-                        .split(" ")
-                        .map((n) => n[0])
-                        .join("")}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="min-w-0 flex-1">
-                    <p className="font-bold text-card-foreground truncate text-lg">{selectedUser.name}</p>
-                    <p className="text-muted-foreground truncate">{selectedUser.email}</p>
-                  </div>
-                </div>
-              )}
-
-              <p className="text-muted-foreground">
-                Choose the scope of progress reset for this student in{" "}
-                <strong>
-                  {course.name} ({version.version})
-                </strong>
-                . This action cannot be undone.
-              </p>
-
-              <div className="space-y-8 flex justify-around flex-wrap">
-                <div className="space-y-3">
-                  <Label htmlFor="reset-scope" className="text-sm font-bold text-foreground">
-                    Reset Scope
-                  </Label>
-                  <Select value={resetScope} onValueChange={(value: any) => setResetScope(value)}>
-                    <SelectTrigger className="h-16 border-border bg-card text-card-foreground cursor-pointer">
-                      <SelectValue placeholder="Select reset scope" />
-                    </SelectTrigger>
-                    <SelectContent className="bg-card border-border cursor-pointer">
-                      <SelectItem value="course" className="cursor-pointer">
-                        <div className="flex items-center sm:gap-3 gap-1 py-3 sm:px-2">
-                          <BookOpen className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-                          <div>
-                            <div className="font-semibold">Entire Course Version</div>
-                            <div className="text-xs text-muted-foreground">Reset all progress in this version</div>
-                          </div>
-                        </div>
-                      </SelectItem>
-                      <SelectItem value="module" className="cursor-pointer" >
-                        <div className="flex items-center sm:gap-3 gap-1 py-3 sm:px-2">
-                          <List className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-                          <div>
-                            <div className="font-semibold">Specific Module</div>
-                            <div className="text-xs text-muted-foreground">Reset module progress</div>
-                          </div>
-                        </div>
-                      </SelectItem>
-                      <SelectItem value="section" className="cursor-pointer" >
-                        <div className="flex items-center sm:gap-3 gap-1 py-3 sm:px-2">
-                          <FileText className="h-5 w-5 text-amber-600 dark:text-amber-400" />
-                          <div>
-                            <div className="font-semibold">Specific Section</div>
-                            <div className="text-xs text-muted-foreground">Reset section progress</div>
-                          </div>
-                        </div>
-                      </SelectItem>
-                      <SelectItem value="item" className="cursor-pointer" >
-                        <div className="flex items-center sm:gap-3 gap-1 py-3 sm:px-2">
-                          <Play className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-                          <div>
-                            <div className="font-semibold">Specific Item</div>
-                            <div className="text-xs text-muted-foreground">Reset single item</div>
-                          </div>
-                        </div>
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
+          {/* Enhanced Reset Progress Modal */}
+          {isResetDialogOpen && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center mb-0">
+              <div
+                className="absolute inset-0 bg-black/60 backdrop-blur-md cursor-pointer"
+                onClick={() => setIsResetDialogOpen(false)}
+              />
+              <div className="relative bg-card border border-border rounded-2xl shadow-2xl max-w-3xl w-full mx-4 sm:p-8 p-4 space-y-6 max-h-[90vh] overflow-y-auto animate-in fade-in-0 zoom-in-95 duration-300 cursor-default">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xl md:text-2xl font-bold text-card-foreground">Reset Student Progress</h2>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsResetDialogOpen(false)}
+                    className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground rounded-full cursor-pointer"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
                 </div>
 
-                {(resetScope === "module" || resetScope === "section" || resetScope === "item") && (
-                  <div className="space-y-3">
-                    <Label htmlFor="module" className="text-sm font-bold text-foreground">
-                      Module
-                    </Label>
-                    <Select value={selectedModule} onValueChange={setSelectedModule}>
-                      <SelectTrigger className="h-16 border-border bg-card text-card-foreground cursor-pointer">
-                        <SelectValue placeholder="Select module" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-card border-border cursor-pointer">
-                        {getAvailableModules().map((module: any) => (
-                          <SelectItem key={module.moduleId} value={module.moduleId} className="cursor-pointer">
-                            <div className="py-2">
-                              <div className="font-semibold">{module.name}</div>
-                              <div className="text-xs text-muted-foreground">
-                                {module.sections?.length || 0} sections
-                              </div>
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                {selectedUser && (
+                  <div className="flex items-center gap-4 p-6 bg-gradient-to-r from-muted/30 to-muted/10 rounded-xl border border-border">
+                    <Avatar className="h-12 w-12 border-2 border-primary/20 shadow-md">
+                      <AvatarImage src={selectedUser.avatar || "/placeholder.svg"} alt={selectedUser.name} />
+                      <AvatarFallback className="bg-gradient-to-br from-primary to-accent text-primary-foreground font-bold">
+                        {selectedUser.name
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="min-w-0 flex-1">
+                      <p className="font-bold text-card-foreground truncate text-lg">{selectedUser.name}</p>
+                      <p className="text-muted-foreground truncate">{selectedUser.email}</p>
+                    </div>
                   </div>
                 )}
 
-                {(resetScope === "section" || resetScope === "item") && selectedModule && (
-                  <div className="space-y-3">
-                    <Label htmlFor="section" className="text-sm font-bold text-foreground">
-                      Section
-                    </Label>
-                    <Select value={selectedSection} onValueChange={setSelectedSection}>
-                      <SelectTrigger className="h-16 border-border bg-card text-card-foreground cursor-pointer">
-                        <SelectValue placeholder="Select section" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-card border-border cursor-pointer">
-                        {getAvailableSections().map((section: any) => (
-                          <SelectItem key={section.sectionId} value={section.sectionId} className="cursor-pointer">
-                            <div className="py-2">
-                              <div className="font-semibold">{section.name}</div>
-                              <div className="text-xs text-muted-foreground">Section in selected module</div>
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                )}
-
-                {resetScope === "item" && selectedModule && selectedSection && (
-                  <ItemSelector
-                    versionId={versionId!}
-                    moduleId={selectedModule}
-                    sectionId={selectedSection}
-                    selectedItem={selectedItem}
-                    onItemChange={setSelectedItem}
-                  />
-                )}
-
-                <div className="flex gap-4 p-4 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-xl">
-                  <AlertTriangle className="h-6 w-6 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
-                  <div className="text-sm text-amber-800 dark:text-amber-200">
-                    <strong>Warning:</strong> This action cannot be undone. The student's progress will be permanently
-                    reset for the selected scope.
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex justify-end gap-3 pt-4">
-                <Button
-                  variant="outline"
-                  onClick={() => setIsResetDialogOpen(false)}
-                  className="min-w-[100px] cursor-pointer"
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="destructive"
-                  onClick={handleConfirmReset}
-                  disabled={!isFormValid() || resetProgressMutation.isPending}
-                  className="min-w-[120px] shadow-lg cursor-pointer"
-                >
-                  {resetProgressMutation.isPending ? (
-                    <>
-                      <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                      Resetting...
-                    </>
-                  ) : (
-                    "Reset Progress"
-                  )}
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-        {totalPages > 1 && (
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            totalDocuments={totalDocuments}
-            onPageChange={handlePageChange}
-          />
-        )}
-
-        {/* Bulk Unenroll Confirmation Dialog */}
-        {isBulkUnenrollDialogOpen && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center mb-0">
-            <div
-              className="absolute inset-0 bg-black/60 backdrop-blur-md cursor-pointer"
-              onClick={() => setIsBulkUnenrollDialogOpen(false)}
-            />
-            <div className="relative bg-card border border-border rounded-2xl shadow-2xl sm:max-w-lg max-[425px]:w-[90vw] w-full mx-4 sm:p-10 p-5 space-y-8 animate-in fade-in-0 zoom-in-95 duration-300 cursor-default">
-              <div className="flex items-center justify-between">
-                <h2 className="text-xl md:text-2xl font-bold text-card-foreground">Bulk Unenroll</h2>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setIsBulkUnenrollDialogOpen(false)}
-                  className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground rounded-full cursor-pointer"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-
-              <div className="space-y-4">
-                <p className="text-lg text-card-foreground">
-                  Are you sure you want to unenroll <strong>{selectedUsers.size}</strong> students?
+                <p className="text-muted-foreground">
+                  Choose the scope of progress reset for this student in{" "}
+                  <strong>
+                    {course.name} ({version.version})
+                  </strong>
+                  . This action cannot be undone.
                 </p>
-                <div className="flex gap-4 p-6 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl">
-                  <div><AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" /></div>
-                  <div className="text-sm text-red-800 dark:text-red-200">
-                    <strong>Warning:</strong> This action cannot be undone. Selected students will lose access to the course version and all their progress data.
+
+                <div className="space-y-8 flex justify-around flex-wrap">
+                  <div className="space-y-3">
+                    <Label htmlFor="reset-scope" className="text-sm font-bold text-foreground">
+                      Reset Scope
+                    </Label>
+                    <Select value={resetScope} onValueChange={(value: any) => setResetScope(value)}>
+                      <SelectTrigger className="h-16 border-border bg-card text-card-foreground cursor-pointer">
+                        <SelectValue placeholder="Select reset scope" />
+                      </SelectTrigger>
+                      <SelectContent className="bg-card border-border cursor-pointer">
+                        <SelectItem value="course" className="cursor-pointer">
+                          <div className="flex items-center sm:gap-3 gap-1 py-3 sm:px-2">
+                            <BookOpen className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                            <div>
+                              <div className="font-semibold">Entire Course Version</div>
+                              <div className="text-xs text-muted-foreground">Reset all progress in this version</div>
+                            </div>
+                          </div>
+                        </SelectItem>
+                        <SelectItem value="module" className="cursor-pointer" >
+                          <div className="flex items-center sm:gap-3 gap-1 py-3 sm:px-2">
+                            <List className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+                            <div>
+                              <div className="font-semibold">Specific Module</div>
+                              <div className="text-xs text-muted-foreground">Reset module progress</div>
+                            </div>
+                          </div>
+                        </SelectItem>
+                        <SelectItem value="section" className="cursor-pointer" >
+                          <div className="flex items-center sm:gap-3 gap-1 py-3 sm:px-2">
+                            <FileText className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+                            <div>
+                              <div className="font-semibold">Specific Section</div>
+                              <div className="text-xs text-muted-foreground">Reset section progress</div>
+                            </div>
+                          </div>
+                        </SelectItem>
+                        <SelectItem value="item" className="cursor-pointer" >
+                          <div className="flex items-center sm:gap-3 gap-1 py-3 sm:px-2">
+                            <Play className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+                            <div>
+                              <div className="font-semibold">Specific Item</div>
+                              <div className="text-xs text-muted-foreground">Reset single item</div>
+                            </div>
+                          </div>
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  {(resetScope === "module" || resetScope === "section" || resetScope === "item") && (
+                    <div className="space-y-3">
+                      <Label htmlFor="module" className="text-sm font-bold text-foreground">
+                        Module
+                      </Label>
+                      <Select value={selectedModule} onValueChange={setSelectedModule}>
+                        <SelectTrigger className="h-16 border-border bg-card text-card-foreground cursor-pointer">
+                          <SelectValue placeholder="Select module" />
+                        </SelectTrigger>
+                        <SelectContent className="bg-card border-border cursor-pointer">
+                          {getAvailableModules().map((module: any) => (
+                            <SelectItem key={module.moduleId} value={module.moduleId} className="cursor-pointer">
+                              <div className="py-2">
+                                <div className="font-semibold">{module.name}</div>
+                                <div className="text-xs text-muted-foreground">
+                                  {module.sections?.length || 0} sections
+                                </div>
+                              </div>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+
+                  {(resetScope === "section" || resetScope === "item") && selectedModule && (
+                    <div className="space-y-3">
+                      <Label htmlFor="section" className="text-sm font-bold text-foreground">
+                        Section
+                      </Label>
+                      <Select value={selectedSection} onValueChange={setSelectedSection}>
+                        <SelectTrigger className="h-16 border-border bg-card text-card-foreground cursor-pointer">
+                          <SelectValue placeholder="Select section" />
+                        </SelectTrigger>
+                        <SelectContent className="bg-card border-border cursor-pointer">
+                          {getAvailableSections().map((section: any) => (
+                            <SelectItem key={section.sectionId} value={section.sectionId} className="cursor-pointer">
+                              <div className="py-2">
+                                <div className="font-semibold">{section.name}</div>
+                                <div className="text-xs text-muted-foreground">Section in selected module</div>
+                              </div>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+
+                  {resetScope === "item" && selectedModule && selectedSection && (
+                    <ItemSelector
+                      versionId={versionId!}
+                      moduleId={selectedModule}
+                      sectionId={selectedSection}
+                      selectedItem={selectedItem}
+                      onItemChange={setSelectedItem}
+                    />
+                  )}
+
+                  <div className="flex gap-4 p-4 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-xl">
+                    <AlertTriangle className="h-6 w-6 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+                    <div className="text-sm text-amber-800 dark:text-amber-200">
+                      <strong>Warning:</strong> This action cannot be undone. The student's progress will be permanently
+                      reset for the selected scope.
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              <div className="flex justify-end gap-3 pt-4">
-                <Button
-                  variant="outline"
-                  onClick={() => setIsBulkUnenrollDialogOpen(false)}
-                  className="min-w-[100px] cursor-pointer"
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="destructive"
-                  onClick={confirmBulkUnenroll}
-                  className="min-w-[100px] shadow-lg cursor-pointer"
-                >
-                  Unenroll Selected
-                </Button>
+                <div className="flex justify-end gap-3 pt-4">
+                  <Button
+                    variant="outline"
+                    onClick={() => setIsResetDialogOpen(false)}
+                    className="min-w-[100px] cursor-pointer"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={handleConfirmReset}
+                    disabled={!isFormValid() || resetProgressMutation.isPending}
+                    className="min-w-[120px] shadow-lg cursor-pointer"
+                  >
+                    {resetProgressMutation.isPending ? (
+                      <>
+                        <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                        Resetting...
+                      </>
+                    ) : (
+                      "Reset Progress"
+                    )}
+                  </Button>
+                </div>
               </div>
             </div>
-          </div>
-        )}
-      </div>
-    </div>
-    
-    {/* Time Slots Modal */}
-    {courseId && versionId && (
-      <TimeSlotsModal
-        isOpen={isTimeSlotsModalOpen}
-        onClose={() => setIsTimeSlotsModalOpen(false)}
-        courseId={courseId}
-        courseVersionId={versionId}
-      />
-    )}
+          )}
+          {totalPages > 1 && (
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              totalDocuments={totalDocuments}
+              onPageChange={handlePageChange}
+            />
+          )}
+
+          {/* Bulk Unenroll Confirmation Dialog */}
+          {isBulkUnenrollDialogOpen && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center mb-0">
+              <div
+                className="absolute inset-0 bg-black/60 backdrop-blur-md cursor-pointer"
+                onClick={() => setIsBulkUnenrollDialogOpen(false)}
+              />
+              <div className="relative bg-card border border-border rounded-2xl shadow-2xl sm:max-w-lg max-[425px]:w-[90vw] w-full mx-4 sm:p-10 p-5 space-y-8 animate-in fade-in-0 zoom-in-95 duration-300 cursor-default">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xl md:text-2xl font-bold text-card-foreground">Bulk Unenroll</h2>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsBulkUnenrollDialogOpen(false)}
+                    className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground rounded-full cursor-pointer"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+
+                <div className="space-y-4">
+                  <p className="text-lg text-card-foreground">
+                    Are you sure you want to unenroll <strong>{selectedUsers.size}</strong> students?
+                  </p>
+                  <div className="flex gap-4 p-6 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl">
+                    <div><AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" /></div>
+                    <div className="text-sm text-red-800 dark:text-red-200">
+                      <strong>Warning:</strong> This action cannot be undone. Selected students will lose access to the course version and all their progress data.
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex justify-end gap-3 pt-4">
+                  <Button
+                    variant="outline"
+                    onClick={() => setIsBulkUnenrollDialogOpen(false)}
+                    className="min-w-[100px] cursor-pointer"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={confirmBulkUnenroll}
+                    className="min-w-[100px] shadow-lg cursor-pointer"
+                  >
+                    Unenroll Selected
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div >
+
+      {/* Time Slots Modal */}
+      {
+        courseId && versionId && (
+          <TimeSlotsModal
+            isOpen={isTimeSlotsModalOpen}
+            onClose={() => setIsTimeSlotsModalOpen(false)}
+            courseId={courseId}
+            courseVersionId={versionId}
+          />
+        )
+      }
     </>
   )
 }
@@ -1896,20 +1880,6 @@ function ItemSelector({
     )
   }
 
-  const getItemIcon = (type: string) => {
-    switch (type?.toUpperCase()) {
-      case "VIDEO":
-        return "🎥"
-      case "QUIZ":
-        return "❓"
-      case "ARTICLE":
-      case "BLOG":
-        return "📖"
-      default:
-        return "📄"
-    }
-  }
-
   const getItemTypeDisplay = (type: string) => {
     switch (type?.toUpperCase()) {
       case "VIDEO":
@@ -1940,7 +1910,7 @@ function ItemSelector({
           {itemsWithDefaultNames.map((item: any) => (
             <SelectItem key={item._id} value={item._id} className="cursor-pointer">
               <div className="flex items-center gap-3 py-2">
-                <span className="text-lg">{getItemIcon(item.type)}</span>
+                <span className="flex-shrink-0">{getItemIcon(item.type)}</span>
                 <div>
                   <div className="font-semibold">{item.displayName}</div>
                   <div className="text-xs text-muted-foreground">{getItemTypeDisplay(item.type)}</div>
@@ -1961,14 +1931,12 @@ function SectionItems({
   sectionId,
   selectedViewItem,
   onItemSelect,
-  getItemIcon,
 }: {
   versionId: string
   moduleId: string
   sectionId: string
   selectedViewItem: string
   onItemSelect: (itemId: string, itemType: string, itemName: string) => void
-  getItemIcon: (type: string) => string
 }) {
   const { data: itemsResponse, isLoading, error } = useItemsBySectionId(versionId, moduleId, sectionId)
 
@@ -2004,7 +1972,7 @@ function SectionItems({
             }`}
           onClick={() => onItemSelect(item._id, item.type, item.displayName)}
         >
-          <span className="text-lg">{getItemIcon(item.type)}</span>
+          <span className="flex-shrink-0">{getItemIcon(item.type)}</span>
           <span className="text-sm text-foreground">{item.displayName}</span>
           <Badge variant="outline" className="ml-auto text-xs">
             {item.type}
@@ -2016,9 +1984,35 @@ function SectionItems({
 }
 
 
+interface EnrollmentsTableProps {
+  studentEnrollments: any[];
+  enrollmentsLoading: boolean;
+  isSearching: boolean;
+  enrollmentTab: "ACTIVE" | "INACTIVE";
+  searchQuery: string;
+  limit: number;
+  handleLimitChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  handleSort: (column: any) => void;
+  sortBy: string;
+  sortOrder: "asc" | "desc";
+  isLoadingQuizScores: boolean;
+  setIsExporting: (exporting: boolean) => void;
+  unenrollMutation: any;
+  user: any;
+  handleViewProgress: (user: any) => void;
+  handleRemoveStudent: (user: any) => void;
+  isSelectionMode: boolean;
+  selectedUsers: Set<string>;
+  onSelectUser: (userId: string, checked: boolean) => void;
+  onSelectAll: (checked: boolean) => void;
+  toggleSelectionMode: () => void;
+  handleBulkUnenroll: () => void;
+  setIsTimeSlotsModalOpen: (open: boolean) => void;
+  getStudentTimeSlot: (userId: string) => any;
+}
+
 function EnrollmentsTable({
   studentEnrollments,
-  totalDocuments,
   enrollmentsLoading,
   isSearching,
   enrollmentTab,
@@ -2034,7 +2028,6 @@ function EnrollmentsTable({
   user,
   handleViewProgress,
   handleRemoveStudent,
-  getRoleBadge,
   isSelectionMode,
   selectedUsers,
   onSelectUser,
@@ -2042,9 +2035,8 @@ function EnrollmentsTable({
   toggleSelectionMode,
   handleBulkUnenroll,
   setIsTimeSlotsModalOpen,
-  timeSlotsData,
   getStudentTimeSlot,
-}: any) {
+}: EnrollmentsTableProps) {
   const isInactiveTab = enrollmentTab === "INACTIVE"
 
   return (
@@ -2166,14 +2158,12 @@ function EnrollmentsTable({
                         { key: "unenrolledAt", label: "Unenrolled", className: "w-[120px]" },
                         { key: "progress", label: "Completion Percentage", className: "w-[200px]" },
                         { key: "assignedTimeSlot", label: "Assigned Time Slot", className: "w-[200px]" },
-                        { key: "scoreObtained", label: "Score obtained", className: "w-[200px]" },
                       ]
                       : [
                         { key: "name", label: "Student", className: "pl-6 w-[300px]" },
                         { key: "enrollmentDate", label: "Enrolled", className: "w-[120px]" },
                         { key: "progress", label: "Completion Percentage", className: "w-[200px]" },
                         { key: "assignedTimeSlot", label: "Assigned Time Slot", className: "w-[200px]" },
-                        { key: "scoreObtained", label: "Score obtained", className: "w-[200px]" },
                       ];
                     return columns.map(({ key, label, className }) => (
                       <TableHead
@@ -2255,14 +2245,12 @@ function EnrollmentsTable({
                         { key: "unenrolledAt", label: "Unenrolled", className: "w-[120px]" },
                         { key: "progress", label: "Completion Percentage", className: "w-[200px]" },
                         { key: "assignedTimeSlot", label: "Assigned Time Slot", className: "w-[200px]" },
-                        { key: "scoreObtained", label: "Score obtained", className: "w-[200px]" },
                       ]
                       : [
                         { key: "name", label: "Student", className: "pl-6 w-[300px]" },
                         { key: "enrollmentDate", label: "Enrolled", className: "w-[120px]" },
                         { key: "progress", label: "Completion Percentage", className: "w-[200px]" },
                         { key: "assignedTimeSlot", label: "Assigned Time Slot", className: "w-[200px]" },
-                        { key: "scoreObtained", label: "Score obtained", className: "w-[200px]" },
                       ];
                     return columns.map(({ key, label, className }) => (
                       <TableHead
@@ -2419,14 +2407,6 @@ function EnrollmentsTable({
                         </div>
                       </TableCell>
 
-                      {/* Score obtained */}
-                      <TableCell className="py-6">
-                        <div className="text-muted-foreground font-medium">
-                          {enrollment.totalQuizScore !== undefined
-                            ? `${enrollment.totalQuizScore} / ${enrollment.totalQuizMaxScore || 0}`
-                            : "N/A"}
-                        </div>
-                      </TableCell>
 
                       {/* Actions */}
                       <TableCell className="py-6 pr-6">

--- a/frontend/src/app/pages/teacher/course-enrollments.tsx
+++ b/frontend/src/app/pages/teacher/course-enrollments.tsx
@@ -179,6 +179,12 @@ export default function CourseEnrollments() {
     !!(courseId && versionId)
   )
 
+  useEffect(() => {
+    if (enrollmentStats) {
+      console.debug('Enrollment stats received:', enrollmentStats);
+    }
+  }, [enrollmentStats]);
+
   const [selectedUser, setSelectedUser] = useState<EnrollmentDetails | null>(null)
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false)
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
@@ -824,6 +830,18 @@ export default function CourseEnrollments() {
       color: "text-purple-600",
       bgColor: "bg-purple-50",
     },
+    {
+      title: "Avg Watch Hours",
+      value: (() => {
+        const v = enrollmentStats?.averageWatchHoursPerUser ?? 0;
+        if (v <= 0) return `0h`;
+        if (v < 0.005) return `<0.01h`;
+        return `${v.toFixed(2)}h`;
+      })(),
+      icon: Clock,
+      color: "text-orange-600",
+      bgColor: "bg-orange-50",
+    },
   ]
   const {
     data: currentPath,
@@ -846,6 +864,12 @@ export default function CourseEnrollments() {
     versionId,
     isViewProgressDialogOpen
   )
+
+  useEffect(() => {
+    if (progressDetail) {
+      console.debug('Progress detail fetched:', progressDetail);
+    }
+  }, [progressDetail]);
 
   // API 3: Course structure — fetched lazily when View Course Structure is clicked
   const {
@@ -1162,6 +1186,10 @@ export default function CourseEnrollments() {
                           <SummaryRow
                             label="Items Completed"
                             value={`${progressDetail.completedItemsCount ?? 0} / ${progressDetail.contentCounts?.totalItems ?? 0}`}
+                          />
+                          <SummaryRow
+                            label="Watch Hours"
+                            value={`${(progressDetail.watchHours ?? 0).toFixed(2)}h`}
                           />
                         </div>
                       </>

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -609,6 +609,90 @@ export function useStudentCurrentProgressPath(
   };
 }
 
+// GET /:userId/enrollments/courses/:courseId/versions/:versionId/progress-detail (API 2)
+export function useStudentProgressDetail(
+  userId?: string,
+  courseId?: string,
+  versionId?: string,
+  enabled?: boolean
+) {
+  const result = api.useQuery(
+    'get',
+    `/users/${userId}/enrollments/courses/${courseId}/versions/${versionId}/progress-detail` as any,
+    {
+      params: {
+        path: { userId: userId!, courseId: courseId!, versionId: versionId! },
+      },
+    },
+    {
+      enabled: Boolean(enabled && userId && courseId && versionId),
+    }
+  );
+
+  return {
+    data: result.data as {
+      _id: string;
+      userId: string;
+      firstName: string;
+      lastName: string;
+      email: string;
+      avatar?: string;
+      enrollmentDate: string;
+      percentCompleted: number;
+      completedItemsCount: number;
+      assignedTimeSlots?: any[];
+      contentCounts: {
+        totalItems: number;
+        itemCounts: {
+          VIDEO?: number;
+          QUIZ?: number;
+          BLOG?: number;
+          PROJECT?: number;
+        };
+      };
+      totalQuizScore: number;
+      totalQuizMaxScore: number;
+    } | undefined,
+    isLoading: result.isLoading,
+    error: result.error ? (result.error.message || 'Failed to load student progress') : null,
+    refetch: result.refetch
+  };
+}
+
+// GET /:userId/enrollments/courses/:courseId/versions/:versionId/course-structure (API 3)
+export function useStudentCourseStructure(
+  userId?: string,
+  courseId?: string,
+  versionId?: string,
+  enabled?: boolean
+) {
+  const result = api.useQuery(
+    'get',
+    `/users/${userId}/enrollments/courses/${courseId}/versions/${versionId}/course-structure` as any,
+    {
+      params: {
+        path: { userId: userId!, courseId: courseId!, versionId: versionId! },
+      },
+    },
+    {
+      enabled: Boolean(enabled && userId && courseId && versionId),
+    }
+  );
+
+  return {
+    data: result.data as {
+      _id: string;
+      userId: string;
+      courseStructure: any[];
+      totalItems: number;
+      itemCounts: any;
+    } | undefined,
+    isLoading: result.isLoading,
+    error: result.error ? (result.error.message || 'Failed to load course structure') : null,
+    refetch: result.refetch
+  };
+}
+
 // PATCH /courses/{id}
 export function useUpdateCourse(): {
   mutate: (variables: { params: { path: { id: string } }, body: components['schemas']['UpdateCourseBody'] }) => void,
@@ -776,7 +860,7 @@ export function useCourseVersionArchive(): {
   reset: () => void,
   status: 'idle' | 'pending' | 'success' | 'error'
 } {
-  const result = api.useMutation("patch", "/courses/versions/{versionId}/archive" as any );
+  const result = api.useMutation("patch", "/courses/versions/{versionId}/archive" as any);
   return {
     ...result,
     error: result.error
@@ -1229,9 +1313,9 @@ export function useUpdateItem(): {
 }
 
 // DELETE /courses/itemGroups/{itemsGroupId}/items/{itemId}
-export function useDeleteItem(): { 
+export function useDeleteItem(): {
   mutate: (variables: { params: { path: { courseId: string, itemsGroupId: string, itemId: string } } }) => void,
-  mutateAsync: (variables: { params: { path: { courseId : string, itemsGroupId: string, itemId: string } } }) => Promise<components['schemas']['DeletedItemResponse']>,
+  mutateAsync: (variables: { params: { path: { courseId: string, itemsGroupId: string, itemId: string } } }) => Promise<components['schemas']['DeletedItemResponse']>,
   data: components['schemas']['DeletedItemResponse'] | undefined,
   error: string | null,
   isPending: boolean,
@@ -1311,7 +1395,7 @@ export function useUnenrollUser(): {
 }
 
 // GET /users/enrollments
-export function useUserEnrollments(page?: number, limit?: number, enabled: boolean = true, search?: string, role = "STUDENT", tab: 'active'|'archived' = "active" ): {
+export function useUserEnrollments(page?: number, limit?: number, enabled: boolean = true, search?: string, role = "STUDENT", tab: 'active' | 'archived' = "active"): {
   data: components['schemas']['EnrollmentResponse'] | undefined,
   isLoading: boolean,
   error: string | null,
@@ -1661,10 +1745,10 @@ export function useSkipOptionalItem(): {
   return {
     ...result,
     // error: result.error ? (result.error.message || 'Failed to skip item') : null
-   error: rawError
+    error: rawError
       ? rawError.message
-        ?? rawError.response?.data?.message
-        ?? "Failed to skip item"
+      ?? rawError.response?.data?.message
+      ?? "Failed to skip item"
       : null,
   }
 }
@@ -3685,7 +3769,7 @@ export const useAutoApprovalSettings = (
       enabled: !!versionId,
     }
   );
-  
+
   return {
     settings: result.data as { registrationsAutoApproved?: boolean; autoapproval_emails?: string[] } | undefined,
     isLoading: result.isLoading,
@@ -4575,17 +4659,19 @@ export function useChooseTimeSlot(): {
 
 // POST /timeslots/teacher/remove-student
 export function useRemoveStudentFromTimeSlot(): {
-  mutateAsync: (variables:{body: {
-    courseId: string;
-    courseVersionId: string;
-    studentId: string;
-    timeSlot: { from: string; to: string };
-  }}) => Promise<any>;
+  mutateAsync: (variables: {
+    body: {
+      courseId: string;
+      courseVersionId: string;
+      studentId: string;
+      timeSlot: { from: string; to: string };
+    }
+  }) => Promise<any>;
   isPending: boolean;
   error: string | null;
 } {
   const result = api.useMutation("post", "/timeslots/teacher/remove-student");
-  
+
   return {
     ...result,
     error: result.error ? (result.error.message || 'Failed to remove student from time slot') : null

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -652,6 +652,7 @@ export function useStudentProgressDetail(
       };
       totalQuizScore: number;
       totalQuizMaxScore: number;
+      watchHours?: number; // total watch hours for this student in the course
     } | undefined,
     isLoading: result.isLoading,
     error: result.error ? (result.error.message || 'Failed to load student progress') : null,
@@ -1417,12 +1418,19 @@ export function useUserEnrollments(page?: number, limit?: number, enabled: boole
 }
 
 // GET /users/enrollments/courses/{courseId}/versions/{versionId}/statistics
+export interface CourseEnrollmentStats {
+  totalEnrollments: number;
+  completedCount: number;
+  averageProgressPercent: number;
+  averageWatchHoursPerUser?: number;
+}
+
 export function useCourseEnrollmentsStats(
   courseId: string | undefined,
   versionId: string | undefined,
   enabled: boolean = true
 ): {
-  data: any | undefined,
+  data: CourseEnrollmentStats | undefined,
   isLoading: boolean,
   error: string | null,
   refetch: () => void


### PR DESCRIPTION
## Summary
This PR adds instructor‑facing watch‑time analytics to the course enrolments view.

When viewing a course, teachers now see a new “Avg Watch Hours” card next to the existing statistics.
Clicking View Progress for a student displays that user’s total watch hours for the course in the content‑summary panel.

## Key Changes

### Backend
- Extended `EnrollmentStats` & `EnrollmentStatisticsResponse` with `averageWatchHoursPerUser`.
- Added aggregation logic in `EnrollmentRepository.getVersionEnrollmentStats` to compute average watch hours per user (handles both string and ObjectId IDs, ignores null `endTime`).
- Enhanced `getStudentProgressDetail` pipeline to lookup, sum, and project `watchHours` for the selected user.
- Added debug `console.debug` logs to both repository methods for easier testing.
- Updated controller default return for empty stats to include the new field.
- Updated types in `users/types.ts` and validator classes.
- Adjusted OpenAPI descriptions.

### Frontend
- Defined `CourseEnrollmentStats` interface and updated `useCourseEnrollmentsStats` hook typing.
- Added new card to stats grid with smart formatting (`0h`, `<0.01h`, etc.).
- Always display "Watch Hours" row in student progress modal, defaulting to `0.00h`.
- Added debugging logs for enrollment stats and progress detail responses.
- Adjusted related types to include optional `watchHours`.