### PR TITLE
UX Issue

### DIFF
--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -53,9 +53,9 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
   const [playing, setPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
-  const [volume, setVolume] = useState(100);
+  // const [volume, setVolume] = useState(100);
   // Use the stored playback rate from the player store
-  const { playbackRate, setPlaybackRate } = usePlayerStore();
+  const { playbackRate, setPlaybackRate,volume, setVolume } = usePlayerStore();
   const [maxTime, setMaxTime] = useState(0);
   const [, setIsHovering] = useState(false);
   const [videoEnded, setVideoEnded] = useState(false);
@@ -652,7 +652,8 @@ const handleStopItem = useCallback(async (watchItemId: string | null, debounceMs
             const dur = event.target.getDuration();
             setPlayerReady(true);
             setDuration(dur);
-            setVolume(event.target.getVolume());
+            // setVolume(event.target.getVolume());
+            event.target.setVolume(volume); 
             setMaxTime(startTimeSeconds);
             event.target.seekTo(startTimeSeconds, true);
             onDurationChange?.(dur);
@@ -796,7 +797,7 @@ const handleStopItem = useCallback(async (watchItemId: string | null, debounceMs
           const time = player.getCurrentTime();
           setCurrentTime(time);
           setDuration(player.getDuration());
-          setVolume(player.getVolume());
+          // setVolume(player.getVolume());
 
           // Enforce startTime constraint
           if (time < startTimeSeconds) {

--- a/frontend/src/store/player-store.ts
+++ b/frontend/src/store/player-store.ts
@@ -3,14 +3,18 @@ import { persist } from 'zustand/middleware';
 
 interface PlayerState {
   playbackRate: number;
+  volume: number;
   setPlaybackRate: (rate: number) => void;
+  setVolume: (volume: number) => void;
 }
 
 export const usePlayerStore = create<PlayerState>()(
   persist(
     (set) => ({
       playbackRate: 1.0, // Default playback rate
+      volume: 100,
       setPlaybackRate: (rate: number) => set({ playbackRate: rate }),
+      setVolume: (volume) => set({ volume }),
     }),
     {
       name: 'player-storage', // unique name for localStorage


### PR DESCRIPTION
## UX Issue
When viewing a video, if the volume was reduced, it resets to 100 whenever new video loads. 

#### Steps to reproduce:
1. View any video content in the course and decrease the volume. 
2. Watch the video, let it move to next video.
3. Volume for the video will become 100 again.

## What was done
- added volume and setVolume to zustand to perist volume
- called it in the video.tsx to keep it in sync
- removed unnecessary getVolume() calls


