### PR TITLE
fix: sort items according to order field before traversing.

### DIFF
--- a/backend/src/modules/courses/services/CourseVersionService.ts
+++ b/backend/src/modules/courses/services/CourseVersionService.ts
@@ -143,6 +143,14 @@ export class CourseVersionService extends BaseService {
     return session ? run(session) : this._withTransaction(run);
   }
 
+  sortItemsByOrder(items: any[]) {
+    return [...items].sort((a, b) => {
+      const orderA = a.order || '';
+      const orderB = b.order || '';
+      return orderA.localeCompare(orderB);
+    });
+  }
+
   public async readCourseVersion(
     courseVersionId: string,
     userId: string,
@@ -204,10 +212,17 @@ export class CourseVersionService extends BaseService {
           });
       }
 
+      readVersion.modules = this.sortItemsByOrder(readVersion.modules).map(module => ({
+        ...module,
+        sections: this.sortItemsByOrder(module.sections || []).map(section => ({
+          ...section,
+          items: this.sortItemsByOrder(section.items || [])
+        }))
+      }));
+
       const version = instanceToPlain(
         Object.assign(new CourseVersion(), readVersion),
       ) as CourseVersion;
-
       return version;
     });
   }
@@ -646,7 +661,13 @@ export class CourseVersionService extends BaseService {
           updatedAt: cohort.updatedAt
         }));
       }
-
+      readVersion.modules = this.sortItemsByOrder(readVersion.modules).map(module => ({
+        ...module,
+        sections: this.sortItemsByOrder(module.sections || []).map(section => ({
+          ...section,
+          items: this.sortItemsByOrder(section.items || [])
+        }))
+      }));
       const version = instanceToPlain(
         Object.assign(new CourseVersion(), readVersion),
       ) as CourseVersion;

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -3374,13 +3374,6 @@ class ProgressService extends BaseService {
     };
   }
 
-  sortItemsByOrder(items: any[]) {
-    return [...items].sort((a, b) => {
-      const orderA = a.order || '';
-      const orderB = b.order || '';
-      return orderA.localeCompare(orderB);
-    });
-  }
 
   async getItemIdsUntilItem(
     courseVersionId: string,
@@ -3399,13 +3392,6 @@ class ProgressService extends BaseService {
       throw new NotFoundError(`Course version ${courseVersionId} not found`);
     }
 
-    courseVersion.modules = this.sortItemsByOrder(courseVersion.modules).map(module => ({
-      ...module,
-      sections: this.sortItemsByOrder(module.sections || []).map(section => ({
-        ...section,
-        items: this.sortItemsByOrder(section.items || [])
-      }))
-    }));
 
     const collectedItemIds: string[] = [];
     let isItemFound = false;
@@ -3500,13 +3486,6 @@ class ProgressService extends BaseService {
       throw new NotFoundError('Course version not found');
     }
 
-    courseVersion.modules = this.sortItemsByOrder(courseVersion.modules).map(module => ({
-      ...module,
-      sections: this.sortItemsByOrder(module.sections || []).map(section => ({
-        ...section,
-        items: this.sortItemsByOrder(section.items || [])
-      }))
-    }));
 
     const completedSet = new Set(completedItemIds.map(id => id.toString()));
 

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -3374,6 +3374,14 @@ class ProgressService extends BaseService {
     };
   }
 
+  sortItemsByOrder(items: any[]) {
+    return [...items].sort((a, b) => {
+      const orderA = a.order || '';
+      const orderB = b.order || '';
+      return orderA.localeCompare(orderB);
+    });
+  }
+
   async getItemIdsUntilItem(
     courseVersionId: string,
     itemId: string,
@@ -3390,6 +3398,14 @@ class ProgressService extends BaseService {
     if (!courseVersion) {
       throw new NotFoundError(`Course version ${courseVersionId} not found`);
     }
+
+    courseVersion.modules = this.sortItemsByOrder(courseVersion.modules).map(module => ({
+      ...module,
+      sections: this.sortItemsByOrder(module.sections || []).map(section => ({
+        ...section,
+        items: this.sortItemsByOrder(section.items || [])
+      }))
+    }));
 
     const collectedItemIds: string[] = [];
     let isItemFound = false;
@@ -3484,6 +3500,14 @@ class ProgressService extends BaseService {
       throw new NotFoundError('Course version not found');
     }
 
+    courseVersion.modules = this.sortItemsByOrder(courseVersion.modules).map(module => ({
+      ...module,
+      sections: this.sortItemsByOrder(module.sections || []).map(section => ({
+        ...section,
+        items: this.sortItemsByOrder(section.items || [])
+      }))
+    }));
+
     const completedSet = new Set(completedItemIds.map(id => id.toString()));
 
     const moduleStats: Array<{
@@ -3527,7 +3551,7 @@ class ProgressService extends BaseService {
     return moduleStats;
   }
 
-  async recalculateStudentProgress( // changes pending according to cohort
+  async recalculateStudentProgress(
     userId: string,
     courseId: string,
     versionId: string,


### PR DESCRIPTION
Issue: https://sprints.zoho.in/workspace/annamai#P10/itemdetails/I187

Solution: Sort items in modules according to the order field before traversing.

