### PR TITLE
Hide 'Preparing Environment' when proctors are disabled

### DIFF
--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -415,6 +415,7 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
       if (allProctorsDisabled) {
         setShowProctorDialog(false);
         setAllProctorsDisabled(true);
+        setReadyToDetect(true);
       }
     }
     fetch();


### PR DESCRIPTION
## Summary
This PR improves the student learning experience by bypassing the "Preparing environment..." screen when all course proctors are disabled. Previously, the system would wait for AI models to initialize even if they were not needed, causing unnecessary delays (especially on mobile devices where AI proctoring is generally restricted).

### Key Changes
-   **Student Course Page**: Updated `course-page.tsx` to set the `readyToDetect` state to `true` immediately upon loading proctoring settings if all proctors are disabled.
-   **Video Component**: By setting `readyToDetect` to `true`, the `video.tsx` component can now skip the preparation UI and start loading the YouTube player immediately.
-   **Mobile Support**: Students can now view course content on mobile devices without being blocked by the "Preparing environment" screen when proctors are turned off.
