### PR TITLE
feat: add profile picture upload and update functionality

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -63,6 +63,7 @@
         "@swc/cli": "^0.7.7",
         "@swc/core": "^1.12.0",
         "@swc/helpers": "^0.5.17",
+        "@types/archiver": "^7.0.0",
         "@types/bcrypt": "^5.0.2",
         "@types/body-parser": "^1.19.5",
         "@types/config": "^3.3.5",
@@ -7239,6 +7240,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/archiver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
+      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -7874,6 +7885,16 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/request": {
       "version": "2.48.13",

--- a/backend/src/modules/anomalies/services/CloudStorageService.ts
+++ b/backend/src/modules/anomalies/services/CloudStorageService.ts
@@ -43,6 +43,22 @@ export class CloudStorageService {
     return filename;
   }
 
+  async uploadAvatar(
+    file: Express.Multer.File,
+    userId: string,
+  ): Promise<string> {
+    const ext = file.mimetype.split('/')[1];
+    const filename = `avatars/${userId}.${ext}`;
+    const bucket = this.googleStorage.bucket(this.anomalyBucketName);
+    const gcsFile = bucket.file(filename);
+    await gcsFile.save(file.buffer, {
+      metadata: {contentType: file.mimetype},
+      public: true,
+    });
+    return `https://storage.googleapis.com/${this.anomalyBucketName}/${filename}`;
+  }
+
+
   /**
    * Delete anomaly from cloud storage
    */

--- a/backend/src/modules/auth/services/FirebaseAuthService.ts
+++ b/backend/src/modules/auth/services/FirebaseAuthService.ts
@@ -331,9 +331,12 @@ export class FirebaseAuthService extends BaseService implements IAuthService {
     firebaseUID: string,
     body: Partial<IUser>,
   ): Promise<void> {
-    // Update user in Firebase Auth
-    await this.auth.updateUser(firebaseUID, {
+    const update: Record<string, string> = {
       displayName: `${body.firstName} ${body.lastName}`,
-    });
+    };
+    if (body.avatar) {
+      update.photoURL = body.avatar;
+    }
+    await this.auth.updateUser(firebaseUID, update);
   }
 }

--- a/backend/src/modules/users/classes/validators/UserValidators.ts
+++ b/backend/src/modules/users/classes/validators/UserValidators.ts
@@ -88,21 +88,19 @@ export class EditUserBody{
     description: "User's first name",
     example: 'John',
     type: 'string',
-    readOnly: true,
   })
   @IsString()
-  @IsNotEmpty()
-  firstName: string;
+  @IsOptional()
+  firstName?: string;
 
   @JSONSchema({
     description: "User's last name",
     example: 'Smith',
     type: 'string',
-    readOnly: true,
   })
   @IsString()
-  @IsNotEmpty()
-  lastName: string;
+  @IsOptional()
+  lastName?: string;
 }
 
 /**

--- a/backend/src/modules/users/controllers/UserController.ts
+++ b/backend/src/modules/users/controllers/UserController.ts
@@ -13,11 +13,13 @@ import {
   Post,
   Patch,
   Authorized,
+  UploadedFile,
 } from 'routing-controllers';
 import {OpenAPI, ResponseSchema} from 'routing-controllers-openapi';
-import {EditUserBody, GetUserParams, GetUserResponse, UserNotFoundErrorResponse } from '../classes/validators/UserValidators.js';
-import { AUTH_TYPES } from '#root/modules/auth/types.js';
-import { IAuthService } from '#root/modules/auth/interfaces/IAuthService.js';
+import {EditUserBody, GetUserParams, GetUserResponse, UserNotFoundErrorResponse} from '../classes/validators/UserValidators.js';
+import {AUTH_TYPES} from '#root/modules/auth/types.js';
+import {IAuthService} from '#root/modules/auth/interfaces/IAuthService.js';
+import {imageUploadOptions} from '#root/modules/anomalies/classes/validators/fileUploadOptions.js';
 
 @OpenAPI({
   tags: ['Users'],
@@ -28,7 +30,6 @@ export class UserController {
   constructor(
     @inject(USERS_TYPES.UserService)
     private readonly userService: UserService,
-    
     @inject(AUTH_TYPES.AuthService)
     private readonly authService: IAuthService,
   ) {}
@@ -50,13 +51,13 @@ export class UserController {
   async getUserById(
     @Params() params: GetUserParams,
   ): Promise<GetUserResponse> {
-    const { userId } = params;
+    const {userId} = params;
     return await this.userService.getUserById(userId);
   }
 
   @OpenAPI({
     summary: 'Edit user information',
-    description: `Edit user information like first and last name.<br/>
+    description: `Edit user information like first name, last name, and avatar.<br/>
     It returns an empty body with a 200 status code.`,
   })
   @Authorized()
@@ -69,13 +70,20 @@ export class UserController {
   async editUser(
     @Req() req: any,
     @Body() body: EditUserBody,
+    @UploadedFile('avatar', {required: false, options: imageUploadOptions})
+    file?: Express.Multer.File,
   ): Promise<void> {
     const token = req.headers.authorization?.split(' ')[1];
     const user = await this.authService.getCurrentUserFromToken(token);
     const userId = user._id.toString();
     const firebaseUID = user.firebaseUID;
-    await this.userService.editUser(userId, body);
-    await this.authService.updateFirebaseUser(firebaseUID, body);
+    await this.userService.editUser(userId, body, file);
+    if (body.firstName || body.lastName) {
+      await this.authService.updateFirebaseUser(firebaseUID, {
+        firstName: body.firstName ?? user.firstName,
+        lastName: body.lastName ?? user.lastName,
+      });
+    }
   }
 
   @OpenAPI({
@@ -92,9 +100,9 @@ export class UserController {
   })
   async makeAdmin(
     @Params() params: GetUserParams,
-    @Body() body: { password: string }
+    @Body() body: {password: string},
   ): Promise<void> {
-    const { userId } = params;
+    const {userId} = params;
     await this.userService.makeAdmin(userId, body.password);
   }
 }

--- a/backend/src/modules/users/services/UserService.ts
+++ b/backend/src/modules/users/services/UserService.ts
@@ -1,14 +1,17 @@
-import { appConfig } from '#root/config/app.js';
+import {appConfig} from '#root/config/app.js';
 import {BaseService} from '#root/shared/classes/BaseService.js';
 import {IUserRepository} from '#root/shared/database/interfaces/IUserRepository.js';
 import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
-import { IUser } from '#root/shared/index.js';
+import {IUser} from '#root/shared/index.js';
 import {GLOBAL_TYPES} from '#root/types.js';
 import {injectable, inject} from 'inversify';
 import {BadRequestError, NotFoundError} from 'routing-controllers';
+import {CloudStorageService} from '#root/modules/anomalies/services/CloudStorageService.js';
 
 @injectable()
 export class UserService extends BaseService {
+  private cloudStorageService = new CloudStorageService();
+
   constructor(
     @inject(GLOBAL_TYPES.UserRepo) private readonly userRepo: IUserRepository,
     @inject(GLOBAL_TYPES.Database)
@@ -22,25 +25,33 @@ export class UserService extends BaseService {
     if (!user) {
       throw new NotFoundError(`User with ID ${userId} not found`);
     }
-    user._id = user._id.toString(); // Ensure id is a string
+    user._id = user._id.toString();
     return user;
   }
 
   async editUser(
     userId: string,
-    userData: Partial<IUser>
+    userData: Partial<IUser>,
+    file?: Express.Multer.File,
   ): Promise<void> {
-    return this._withTransaction(async (session) => {
-    const user = await this.userRepo.findById(userId);
-    if (!user) {
-      throw new NotFoundError(`User with ID ${userId} not found`);
-    }
-    await this.userRepo.edit(userId, userData, session);
-  });
+    return this._withTransaction(async session => {
+      const user = await this.userRepo.findById(userId);
+      if (!user) {
+        throw new NotFoundError(`User with ID ${userId} not found`);
+      }
+
+      const updateData: Partial<IUser> = {...userData};
+
+      if (file) {
+        updateData.avatar = await this.cloudStorageService.uploadAvatar(file, userId);
+      }
+
+      await this.userRepo.edit(userId, updateData, session);
+    });
   }
 
   async makeAdmin(userId: string, password: string): Promise<void> {
-    return this._withTransaction(async (session) => {
+    return this._withTransaction(async session => {
       if (appConfig.adminPassword !== password) {
         throw new BadRequestError('Invalid admin password');
       }

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -20,6 +20,7 @@ export interface IUser {
   firstName: string;
   lastName?: string;
   roles: 'admin' | 'user';
+  avatar?: string;
 }
 
 export type Versions = {

--- a/frontend/src/components/profile.tsx
+++ b/frontend/src/components/profile.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import React, { useState } from "react"
-import { Mail, User, Shield, Pencil, BookOpen, Clock, Award } from "lucide-react"
+import React, { useState, useRef } from "react"
+import { Mail, User, Shield, Pencil, BookOpen, Award, Camera } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -18,41 +18,31 @@ import ConfirmationModal from "@/app/pages/teacher/components/confirmation-modal
 import { Skeleton } from "@/components/ui/skeleton"
 
 export default function UserProfile({ role = "student" }: { role?: "student" | "teacher" | "admin" }) {
-  const { user, setUser } = useAuthStore()
+  const { user, setUser, token } = useAuthStore()
   const navigate = useNavigate()
   const handleLogout = () => {
     logout();
     navigate({ to: "/auth" });
   };
 
-  // Fetch user data and statistics
-  const { token } = useAuthStore();
   const { data: enrollmentsData, isLoading: enrollmentsLoading } = useUserEnrollments(1, 100, !!token);
 
-  // Calculate statistics
   const totalEnrollments = enrollmentsData?.totalDocuments || 0;
-
   const enrollments = enrollmentsData?.enrollments || [];
 
-  // Calculate progress including all enrolled courses
   const totalProgress = React.useMemo(() => {
     if (enrollments.length === 0) return 0;
-
-    // Calculate total completed items and total items across all enrollments
     const { totalCompleted, totalItems } = enrollments.reduce((acc, enrollment) => {
       const completed = typeof enrollment.completedItems === 'number' ? enrollment.completedItems : 0;
       const total = enrollment.contentCounts?.totalItems || 0;
       return {
         totalCompleted: acc.totalCompleted + completed,
-        totalItems: acc.totalItems + (total > 0 ? total : 1) // Avoid division by zero
+        totalItems: acc.totalItems + (total > 0 ? total : 1)
       };
     }, { totalCompleted: 0, totalItems: 0 });
-
-    // Calculate overall progress percentage
     return Number(((totalCompleted / totalItems) * 100).toFixed(2)) || 0;
   }, [enrollments]);
 
-  // Fallback data if user is not available
   const firstName = user?.name?.split(" ")[0] || ""
   const lastName = user?.name?.split(" ")[1] || ""
   const displayName = user?.name || `${firstName || ""} ${lastName || ""}`.trim() || (role === "teacher" ? "Teacher" : "Student")
@@ -65,6 +55,9 @@ export default function UserProfile({ role = "student" }: { role?: "student" | "
   const [newFirstName, setNewFirstName] = useState(firstName || "")
   const [newLastName, setNewLastName] = useState(lastName || "")
   const [confirmLogout, setConfirmLogout] = useState(false);
+  const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
+
+  const avatarInputRef = useRef<HTMLInputElement>(null);
 
   const { mutateAsync: editUser } = useEditUser();
 
@@ -97,6 +90,37 @@ export default function UserProfile({ role = "student" }: { role?: "student" | "
     }
   }
 
+  const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setIsUploadingAvatar(true);
+    try {
+      const formData = new FormData();
+      formData.append("avatar", file);
+
+      const res = await fetch(`${import.meta.env.VITE_BASE_URL}/users/edit`, {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        body: formData,
+      });
+
+      if (!res.ok) throw new Error("Upload failed");
+
+      const objectUrl = URL.createObjectURL(file);
+      if (user && user.uid) {
+        setUser({ ...user, avatar: objectUrl, uid: user.uid });
+      }
+      toast.success("Profile picture updated");
+    } catch {
+      toast.error("Failed to update profile picture");
+    } finally {
+      setIsUploadingAvatar(false);
+      if (avatarInputRef.current) avatarInputRef.current.value = "";
+    }
+  };
 
   return (
     <div className="flex flex-1 flex-col gap-4 md:p-4 pt-0">
@@ -117,13 +141,40 @@ export default function UserProfile({ role = "student" }: { role?: "student" | "
             <div className="absolute inset-0 bg-card text-card-foreground" />
             <CardContent className="relative xl:p-6 lg:p-2 p-6">
               <div className="flex flex-col items-center space-y-6">
-                <div className="relative">
+                <div className="relative group">
                   <Avatar className="h-28 w-28 ring-4 ring-white dark:ring-gray-800 shadow-xl">
                     <AvatarImage src={user?.avatar || "/placeholder.svg"} alt="Profile" />
                     <AvatarFallback className="text-lg md:text-xl font-semibold bg-gradient-to-br from-blue-500 to-indigo-600 text-white">
                       {avatarFallback.toUpperCase()}
                     </AvatarFallback>
                   </Avatar>
+
+                  {/* Loading overlay */}
+                  {isUploadingAvatar && (
+                    <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40">
+                      <div className="h-6 w-6 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                    </div>
+                  )}
+
+                  {/* Edit overlay on hover */}
+                  {!isUploadingAvatar && (
+                    <button
+                      onClick={() => avatarInputRef.current?.click()}
+                      className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+                      aria-label="Change profile picture"
+                    >
+                      <Camera className="h-6 w-6 text-white" />
+                    </button>
+                  )}
+
+                  <input
+                    ref={avatarInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleAvatarChange}
+                  />
+
                   <div className="absolute -bottom-2 right-4">
                     <Badge variant="secondary" className="text-xs px-3 py-1 bg-white dark:bg-gray-800 shadow-lg border">
                       {displayRole}
@@ -166,17 +217,6 @@ export default function UserProfile({ role = "student" }: { role?: "student" | "
                     </Badge>
                   </div>
 
-                  {/* <div className="text-center pt-4">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={handleLogout}
-                      className="relative h-9 px-4 text-sm font-medium transition-all duration-300 hover:bg-gradient-to-r hover:from-red-500/10 hover:to-red-400/5 hover:text-red-600 dark:hover:text-red-400 hover:shadow-lg hover:shadow-red-500/10"
-                    >
-                      <LogOut className="h-4 w-4 mr-2" />
-                      Logout
-                    </Button>
-                  </div> */}
                   <div className="text-center pt-4">
                     <Button
                       variant="ghost"
@@ -257,7 +297,6 @@ export default function UserProfile({ role = "student" }: { role?: "student" | "
         </div>
 
         {/* Learning Stats */}
-
         {role === "student" && (
           <Card>
             <CardHeader>
@@ -267,7 +306,6 @@ export default function UserProfile({ role = "student" }: { role?: "student" | "
             <CardContent>
               <div className="grid gap-4 md:grid-cols-3">
                 <div className="text-center">
-                  {/* Enrolled Courses */}
                   {enrollmentsLoading ? (
                     <Skeleton className="h-8 w-12 mx-auto mb-1" />
                   ) : (
@@ -279,7 +317,6 @@ export default function UserProfile({ role = "student" }: { role?: "student" | "
                   <p className="text-sm text-muted-foreground">Enrolled Courses</p>
                 </div>
 
-                {/* Overall Progress */}
                 <div className="text-center">
                   {enrollmentsLoading ? (
                     <Skeleton className="h-8 w-16 mx-auto mb-1" />
@@ -291,43 +328,10 @@ export default function UserProfile({ role = "student" }: { role?: "student" | "
                   )}
                   <p className="text-sm text-muted-foreground">Overall Progress</p>
                 </div>
-                {/* <div className="text-center">
-                  <div className="text-2xl font-bold text-primary">7</div>
-                  <p className="text-sm text-muted-foreground">Day Streak</p>
-                </div> */}
               </div>
             </CardContent>
           </Card>
-        )
-        }
-        {/* : (
-          <Card>
-            <CardHeader>
-              <CardTitle>Teaching Statistics</CardTitle>
-              <CardDescription>Your contributions and activities</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-4 md:grid-cols-4">
-                <div className="text-center">
-                  <div className="text-2xl font-bold text-primary">3</div>
-                  <p className="text-sm text-muted-foreground">Courses Created</p>
-                </div>
-                <div className="text-center">
-                  <div className="text-2xl font-bold text-primary">10</div>
-                  <p className="text-sm text-muted-foreground">Articles</p>
-                </div>
-                <div className="text-center">
-                  <div className="text-2xl font-bold text-primary">19</div>
-                  <p className="text-sm text-muted-foreground">Blogs</p>
-                </div>
-                <div className="text-center">
-                  <div className="text-2xl font-bold text-primary">100</div>
-                  <p className="text-sm text-muted-foreground">Assignments Given</p>
-                </div>
-                
-              </div>
-            </CardContent>
-          </Card> */}
+        )}
 
       </div>
     </div>


### PR DESCRIPTION
## Description

Adds support for updating profile picture on the user profile page.

This extends the existing profile edit functionality to allow users to upload and update their avatar without affecting current name update behavior.

---

## Changes Made

### Backend

* Added optional `avatar` field to user model
* Extended `/users/edit` to accept multipart form data
* Integrated avatar upload using existing CloudStorageService
* Stored avatar URL in MongoDB and synced with Firebase `photoURL`
* Made `firstName` and `lastName` optional in edit validator

### Frontend

* Added hover-based avatar edit UI with camera overlay
* Implemented file input + FormData upload
* Added loading state for avatar upload
* Updated Zustand store for immediate UI feedback

---

## Behavior

* Users can update profile picture independently
* Existing name update functionality remains unchanged
* Supports:

  * avatar-only updates
  * name-only updates
  * combined updates

---

## Testing

* Verified image upload flow (UI → API → DB → Firebase)
* Confirmed avatar persists after refresh
* Verified backward compatibility for name updates
* Tested error handling for failed uploads

---

## Related Issue

Closes #596
