### PR TITLE
Policy modal issues

### DIFF
--- a/frontend/src/app/pages/student/components/policies/PolicyAcknowledgementModal.tsx
+++ b/frontend/src/app/pages/student/components/policies/PolicyAcknowledgementModal.tsx
@@ -93,18 +93,18 @@ export function PolicyAcknowledgementModal({
       }}
     >
       <DialogContent
-        className="max-w-4xl max-h-[90vh]"
+        className=""
         onInteractOutside={(e) => e.preventDefault()}
       >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Shield className="h-5 w-5 text-primary" />
+            <Shield className="h-5 w-5 text-primary " />
             {isInviteMode
               ? "Accept Course Invite"
               : "Course Policy — Acknowledgement Required"}
           </DialogTitle>
 
-          <DialogDescription>
+          <DialogDescription className="mb-2 ml-1">
             {isInviteMode
               ? "Please review and accept the policies before continuing."
               : "A policy has been added or updated for your cohort. You must review and acknowledge it before you can continue accessing this course. Your progress has not been affected."}

--- a/frontend/src/app/pages/student/components/policies/PolicyReacknowledgementModal.tsx
+++ b/frontend/src/app/pages/student/components/policies/PolicyReacknowledgementModal.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Shield } from "lucide-react";
@@ -38,18 +38,19 @@ export function PolicyReacknowledgementModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
-      <DialogContent className="max-w-4xl max-h-[90vh]" onClick={(e) => e.stopPropagation()} onInteractOutside={(e) => e.preventDefault()}>
+    <Dialog open={open} 
+    onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent className="max-w-xl" onClick={(e) => e.stopPropagation()} onInteractOutside={(e) => e.preventDefault()}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Shield className="h-5 w-5 text-blue-600" />
+            <Shield className="h-5 w-5 text-primary" />
             Policy Updated — Re-acknowledgement Required
           </DialogTitle>
         </DialogHeader>
-
-        <p className="text-sm text-muted-foreground">
+        <DialogDescription className="my-2 ml-1">
           The ejection policy for this course has been updated. Please review and acknowledge the new policy to continue accessing the course.
-        </p>
+        </DialogDescription>
+        
 
         <div className="max-h-[50vh] overflow-y-auto pr-2">
           {isLoading ? <div className="text-center py-6">Loading policies...</div> : <StudentPolicyList policies={policies} />}

--- a/frontend/src/app/pages/teacher/components/ejection-policies/SystemNotificationDropdown.tsx
+++ b/frontend/src/app/pages/teacher/components/ejection-policies/SystemNotificationDropdown.tsx
@@ -15,6 +15,19 @@ type Props = {
   onApproveRegistration?: (reg: PendingRegistrationNotification) => void;
   onInviteAction?: () => void;
 };
+const canSeeInvite = (inviteRole: string, userRole?: string|null) => {
+  if (!userRole) return false;
+
+  if (inviteRole === "INSTRUCTOR") {
+    return userRole === "teacher" || userRole === "admin";
+  }
+
+  if (inviteRole === "STUDENT") {
+    return userRole === "student";
+  }
+
+  return false;
+};
 
 export function UnifiedNotificationDropdown({
   notifications,
@@ -29,6 +42,9 @@ export function UnifiedNotificationDropdown({
   
 
 const user = useAuthStore((state) => state.user);
+const filteredInvites = pendingInvites.filter((invite) =>
+  canSeeInvite(invite.role, user?.role)
+);
 const isTeacher = user?.role === "teacher";
   const unreadSystem = notifications.filter(n => !n.read);
   const totalCount = unreadSystem.length + pendingInvites.length + pendingRegistrations.length;
@@ -66,13 +82,13 @@ const isTeacher = user?.role === "teacher";
         <ul className="divide-y divide-gray-100 dark:divide-zinc-800 p-1">
           
           {/* ── Pending Invites ── */}
-          {pendingInvites.length > 0 && (
+          {filteredInvites.length > 0 && (
             <li className="px-2 py-1.5">
               <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest mb-1 px-1">
                 Course Invites
               </p>
               <div className="space-y-1">
-                {pendingInvites.map((invite, idx) => (
+                {filteredInvites.map((invite, idx) => (
                   <div key={`invite-${idx}`} className="p-2 rounded hover:bg-primary/5 dark:hover:bg-primary/10 transition-colors border border-transparent hover:border-primary/20 dark:hover:border-primary/30">
                     <div className="flex items-start gap-2">
                       <div className="mt-0.5 rounded-full bg-primary/10 dark:bg-primary/20 p-1">

--- a/frontend/src/app/pages/teacher/components/ejection-policies/SystemNotificationDropdown.tsx
+++ b/frontend/src/app/pages/teacher/components/ejection-policies/SystemNotificationDropdown.tsx
@@ -2,6 +2,8 @@ import { Mail, UserCheck, Bell, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import SystemNotificationItem from "./SystemNotificationItem";
 import { SystemNotification, PendingRegistrationNotification } from "@/types/notification.types";
+import { useAuthStore } from "@/store/auth-store";
+import { processInviteApi } from "@/hooks/hooks";
 
 type Props = {
   notifications: SystemNotification[];
@@ -11,6 +13,7 @@ type Props = {
   onMarkAllRead: () => void;
   onAcceptInvite?: (invite: any) => void;
   onApproveRegistration?: (reg: PendingRegistrationNotification) => void;
+  onInviteAction?: () => void;
 };
 
 export function UnifiedNotificationDropdown({
@@ -21,9 +24,16 @@ export function UnifiedNotificationDropdown({
   onMarkAllRead,
   onAcceptInvite,
   onApproveRegistration,
+  onInviteAction,
 }: Props) {
+  
+
+const user = useAuthStore((state) => state.user);
+const isTeacher = user?.role === "teacher";
   const unreadSystem = notifications.filter(n => !n.read);
   const totalCount = unreadSystem.length + pendingInvites.length + pendingRegistrations.length;
+  console.log('pending invites:', pendingInvites);
+  
 
   return (
     <div className="absolute right-0 top-full mt-1 w-80 bg-white dark:bg-black rounded-lg shadow-lg border border-border dark:border-zinc-700 z-50 overflow-hidden flex flex-col max-h-[32rem]">
@@ -73,14 +83,42 @@ export function UnifiedNotificationDropdown({
                           {invite?.course?.name || "New Invite"}
                         </p>
                         <p className="text-[10px] text-muted-foreground">Course Invitation</p>
-                        <Button 
-                          size="sm" 
-                          variant="outline" 
-                          onClick={() => onAcceptInvite?.(invite)}
-                          className="mt-2 h-7 text-[10px] px-2 w-full border-primary/20 hover:bg-primary/5 hover:text-primary"
-                        >
-                          Check Course
-                        </Button>
+                        {isTeacher ? (
+                          <div className="-ml-2 flex gap-1 mt-2 max-w-min">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="w-full text-[10px]"
+                              onClick={async () => {
+                                await processInviteApi(invite.inviteId, "REJECTED");
+                                 onInviteAction?.(); 
+                                
+                              }}
+                            >
+                              Reject
+                            </Button>
+
+                            <Button
+                              size="sm"
+                              className="w-full text-[10px]"
+                              onClick={async () => {
+                                await processInviteApi(invite.inviteId, "ACCEPT", false);
+                                 onInviteAction?.(); 
+                              }}
+                            >
+                              Accept
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button 
+                            size="sm" 
+                            variant="outline" 
+                            onClick={() => onAcceptInvite?.(invite)}
+                            className="mt-2 h-7 text-[10px] px-2 w-full"
+                          >
+                            Check Course
+                          </Button>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/frontend/src/components/InviteItem.tsx
+++ b/frontend/src/components/InviteItem.tsx
@@ -17,7 +17,7 @@ const InviteItem = ({ invite, onAcceptClick, onRejectClick , hasPolicies}) => {
 
   return (
     <li
-      className={`p-2 rounded transition-colors cursor-pointer hover:bg-blue-50 dark:hover:bg-blue-950/30`}
+      className={`p-2 rounded hover:bg-primary/5 dark:hover:bg-primary/10 transition-colors border border-transparent hover:border-primary/20 dark:hover:border-primary/30`}
       onClick={handleToggle}
     >
       <div className="flex items-start gap-2">
@@ -62,7 +62,7 @@ const InviteItem = ({ invite, onAcceptClick, onRejectClick , hasPolicies}) => {
 
          
 {isExpanded && status === "PENDING" && (
-  <div className="mt-2 flex gap-1">
+  <div className="-ml-2 flex gap-1 mt-2 max-w-min">
     
     {/* ✅ NO POLICIES → direct actions */}
     {hasPolicies === false ? (
@@ -70,22 +70,24 @@ const InviteItem = ({ invite, onAcceptClick, onRejectClick , hasPolicies}) => {
         <Button
           size="sm"
           variant="outline"
+          className="w-full text-[10px]"
           onClick={(e) => {
             e.stopPropagation();
             onRejectClick(invite);
           }}
-          className="h-6 px-2 text-xs"
+          
         >
           Reject
         </Button>
 
         <Button
-          size="sm"
+         size="sm"
+         className="w-full text-[10px]"
           onClick={(e) => {
             e.stopPropagation();
             onAcceptClick(invite);
           }}
-          className="h-6 px-2 text-xs"
+          
         >
           Accept
         </Button>

--- a/frontend/src/components/InviteItem.tsx
+++ b/frontend/src/components/InviteItem.tsx
@@ -1,9 +1,10 @@
 
 import { useState } from "react";
 import { Button } from "./ui/button";
-import { Mail, CheckCircle, XCircle } from "lucide-react";
+import { Mail } from "lucide-react";
 
-const InviteItem = ({ invite, onAcceptClick, onRejectClick }) => {
+
+const InviteItem = ({ invite, onAcceptClick, onRejectClick , hasPolicies}) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [status, setStatus] = useState(invite.inviteStatus);
 
@@ -59,20 +60,50 @@ const InviteItem = ({ invite, onAcceptClick, onRejectClick }) => {
             </span>
           </p>
 
-          {/* ACTIONS */}
-          {isExpanded && status === "PENDING" && (
-  <div className="mt-2">
-    <Button
-      size="sm"
-      variant="outline"
-      onClick={(e) => {
-        e.stopPropagation();
-        onAcceptClick(invite);
-      }}
-      className="h-6 px-2 text-xs hover:bg-yellow-50 hover:border-yellow-600 hover:text-yellow-600 dark:hover:border-yellow-400 dark:hover:text-yellow-400 "
-    >
-      Check Course
-    </Button>
+         
+{isExpanded && status === "PENDING" && (
+  <div className="mt-2 flex gap-1">
+    
+    {/* ✅ NO POLICIES → direct actions */}
+    {hasPolicies === false ? (
+      <>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRejectClick(invite);
+          }}
+          className="h-6 px-2 text-xs"
+        >
+          Reject
+        </Button>
+
+        <Button
+          size="sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAcceptClick(invite);
+          }}
+          className="h-6 px-2 text-xs"
+        >
+          Accept
+        </Button>
+      </>
+    ) : (
+      /* ✅ HAS POLICIES → modal */
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={(e) => {
+          e.stopPropagation();
+          onAcceptClick(invite);
+        }}
+        className="h-6 px-2 text-xs"
+      >
+        Check Course
+      </Button>
+    )}
   </div>
 )}
         </div>

--- a/frontend/src/components/InviteItem.tsx
+++ b/frontend/src/components/InviteItem.tsx
@@ -1,15 +1,4 @@
 
-
-    // const onAccept = async (invite) => {
-    //     const { data, isLoading, error } = await useProcessInvites(invite.inviteId, 'ACCEPT');
-    //     if (!isLoading && !error) {
-    //         setStatus("ACCEPTED");
-    //         setIsExpanded(false);
-    //         window.location.reload();
-    //     }
-    // };
-    
-
 import { useState } from "react";
 import { Button } from "./ui/button";
 import { Mail, CheckCircle, XCircle } from "lucide-react";

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -67,11 +67,11 @@ export function AppSidebar() {
         url: "/teacher/hp-system",
         icon: SquareTerminal,
       },
-      {
-        title: "Notifications",
-        url: "/teacher/notifications",
-        icon: Bell,
-      },
+      // {
+      //   title: "Notifications",
+      //   url: "/teacher/notifications",
+      //   icon: Bell,
+      // },
     ],
   }
 

--- a/frontend/src/components/inviteDropDown.tsx
+++ b/frontend/src/components/inviteDropDown.tsx
@@ -27,7 +27,7 @@ import { useInvites } from "@/hooks/hooks";
 import { PolicyReacknowledgementModal } from '@/app/pages/student/components/policies/PolicyReacknowledgementModal';
 import { queryClient } from '@/lib/client';
 import { hasActivePolicies } from '@/utils/ejectionPolicyUtils';
-
+import { useAuthStore } from '@/store/auth-store';
 type InviteDropdownProps = {
   setShowInvites?: React.Dispatch<React.SetStateAction<boolean>>;
   onRejectClick?: (invite: any) => void;
@@ -98,7 +98,18 @@ const getSystemNotificationColors = (type: SystemNotification['type']) => {
       };
   }
 };
+const ROLE_MAP = {
+  INSTRUCTOR: ["teacher", "admin"],
+  STUDENT: ["student"],
+};
 
+const canSeeInvite = (
+  inviteRole: string,
+  userRole?: string | null
+) => {
+  if (!userRole) return false;
+  return ROLE_MAP[inviteRole]?.includes(userRole) ?? false;
+};
 const InviteDropdown = ({
   selectedInvite,
   setSelectedInvite,
@@ -120,6 +131,7 @@ const InviteDropdown = ({
   const {mutate: markAsRead, isPending} = useMarkNotificationAsRead();
   const [showPolicyModal, setShowPolicyModal] = useState(false);
   const [selectedPolicyNotification, setSelectedPolicyNotification] = useState<SystemNotification | null>(null);
+  const user = useAuthStore((state) => state.user);
   
   const [submittedAppeals, setSubmittedAppeals] = useState<Set<string>>(new Set());
   const appealKey = (n: SystemNotification) =>
@@ -142,6 +154,8 @@ const InviteDropdown = ({
 const submitAppeal = useSubmitAppeal();
 const [localInvites, setLocalInvites] = useState<any[]>([]);
 const { getInvites } = useInvites();
+const invitesToShow = (pendingInvites.length ? pendingInvites : localInvites)
+  .filter((invite) => canSeeInvite(invite.role, user?.role));
 
 useEffect(() => {
   if (localInvites.length === 0) {
@@ -271,7 +285,7 @@ useEffect(() => {
           ) : (
             <>
              {/* ── Invites ── */}
-             {(pendingInvites.length ? pendingInvites : localInvites).map((invite, idx) => (
+             {invitesToShow.map((invite, idx) => (
                 <InviteItem
   invite={invite}
   hasPolicies={invitePoliciesMap[invite.inviteId]}

--- a/frontend/src/components/inviteDropDown.tsx
+++ b/frontend/src/components/inviteDropDown.tsx
@@ -283,24 +283,43 @@ useEffect(() => {
     );
 
     if (!hasPolicies) {
-      await processInviteApi(invite.inviteId, "ACCEPT", false);
+  await processInviteApi(invite.inviteId, "ACCEPT", false);
 
-      setPendingInvites((prev) =>
-        prev.filter((i) => i.inviteId !== invite.inviteId)
-      );
-      return;
-    }
+  setPendingInvites((prev) =>
+    prev.filter((i) => i.inviteId !== invite.inviteId)
+  );
+
+  setLocalInvites((prev) =>
+    prev.filter((i) => i.inviteId !== invite.inviteId)
+  );
+
+  queryClient.invalidateQueries({
+    queryKey: ["get", "/notifications/user"],
+  });
+
+  return;
+}
 
     setSelectedInvite(invite);
     setShowPolicyModal(true);
   }}
   onRejectClick={async (invite) => {
-    await processInviteApi(invite.inviteId, "REJECTED");
+  await processInviteApi(invite.inviteId, "REJECTED");
 
-    setPendingInvites((prev) =>
-      prev.filter((i) => i.inviteId !== invite.inviteId)
-    );
-  }}
+  
+  setPendingInvites((prev) =>
+    prev.filter((i) => i.inviteId !== invite.inviteId)
+  );
+
+  setLocalInvites((prev) =>
+    prev.filter((i) => i.inviteId !== invite.inviteId)
+  );
+
+  
+  queryClient.invalidateQueries({
+    queryKey: ["get", "/notifications/user"],
+  });
+}}
 />
               ))}
 

--- a/frontend/src/components/inviteDropDown.tsx
+++ b/frontend/src/components/inviteDropDown.tsx
@@ -10,7 +10,7 @@ import {
   Check,
 } from 'lucide-react';
 import {Button} from '@/components/ui/button';
-import {useMarkNotificationAsRead} from '@/hooks/hooks';
+import {processInviteApi, useMarkNotificationAsRead} from '@/hooks/hooks';
 import {
   useSubmitAppeal,
 } from '@/hooks/system-notification-hooks';
@@ -26,6 +26,7 @@ import { AppealModal } from '@/app/pages/student/components/policies/AppealModal
 import { useInvites } from "@/hooks/hooks";
 import { PolicyReacknowledgementModal } from '@/app/pages/student/components/policies/PolicyReacknowledgementModal';
 import { queryClient } from '@/lib/client';
+import { hasActivePolicies } from '@/utils/ejectionPolicyUtils';
 
 type InviteDropdownProps = {
   setShowInvites?: React.Dispatch<React.SetStateAction<boolean>>;
@@ -119,18 +120,19 @@ const InviteDropdown = ({
   const {mutate: markAsRead, isPending} = useMarkNotificationAsRead();
   const [showPolicyModal, setShowPolicyModal] = useState(false);
   const [selectedPolicyNotification, setSelectedPolicyNotification] = useState<SystemNotification | null>(null);
-
+  
   const [submittedAppeals, setSubmittedAppeals] = useState<Set<string>>(new Set());
-const appealKey = (n: SystemNotification) =>
-  `${n.courseId}-${n.courseVersionId}-${n.cohortId}`;
-
+  const appealKey = (n: SystemNotification) =>
+    `${n.courseId}-${n.courseVersionId}-${n.cohortId}`;
+  
   const unreadSystemNotifications = systemNotifications.filter(n => !n.read);
+  const [invitePoliciesMap, setInvitePoliciesMap] = useState<Record<string, boolean>>({});
   const hasAnyContent =
-    pendingInvites.length > 0 ||
-    approvedNotifications.length > 0 ||
-    pendingStudentRegistrations.length > 0 ||
-    rejectedStudentRegistrations.length > 0 ||
-    systemNotifications.length > 0;
+  pendingInvites.length > 0 ||
+  approvedNotifications.length > 0 ||
+  pendingStudentRegistrations.length > 0 ||
+  rejectedStudentRegistrations.length > 0 ||
+  systemNotifications.length > 0;
   
     const [selectedAppeal, setSelectedAppeal] = useState<{
   courseId: string;
@@ -214,6 +216,31 @@ const mostRecentPolicyIds = useMemo(() => {
 
   return new Set(map.values());
 }, [systemNotifications]);
+useEffect(() => {
+  const fetchPolicies = async () => {
+    const results: Record<string, boolean> = {};
+
+    const invites = pendingInvites.length ? pendingInvites : localInvites;
+
+    await Promise.all(
+      invites.map(async (invite) => {
+        const hasPolicies = await hasActivePolicies(
+          invite.courseId,
+          invite.courseVersionId,
+          invite.cohortId
+        );
+
+        results[invite.inviteId] = hasPolicies;
+      })
+    );
+
+    setInvitePoliciesMap(results);
+  };
+
+  if (pendingInvites.length || localInvites.length) {
+    fetchPolicies();
+  }
+}, [pendingInvites, localInvites]);
 
   return (
     <>
@@ -246,14 +273,35 @@ const mostRecentPolicyIds = useMemo(() => {
              {/* ── Invites ── */}
              {(pendingInvites.length ? pendingInvites : localInvites).map((invite, idx) => (
                 <InviteItem
-                  key={`invite-${idx}`}
-                  invite={invite}
-                  onRejectClick={onRejectClick ?? (() => {})}
-                  onAcceptClick={invite => {
-                    setSelectedInvite(invite);
-                    setShowPolicyModal(true);
-                  }}
-                />
+  invite={invite}
+  hasPolicies={invitePoliciesMap[invite.inviteId]}
+  onAcceptClick={async (invite) => {
+    const hasPolicies = await hasActivePolicies(
+      invite.courseId,
+      invite.courseVersionId,
+      invite.cohortId
+    );
+
+    if (!hasPolicies) {
+      await processInviteApi(invite.inviteId, "ACCEPT", false);
+
+      setPendingInvites((prev) =>
+        prev.filter((i) => i.inviteId !== invite.inviteId)
+      );
+      return;
+    }
+
+    setSelectedInvite(invite);
+    setShowPolicyModal(true);
+  }}
+  onRejectClick={async (invite) => {
+    await processInviteApi(invite.inviteId, "REJECTED");
+
+    setPendingInvites((prev) =>
+      prev.filter((i) => i.inviteId !== invite.inviteId)
+    );
+  }}
+/>
               ))}
 
               {/* ── System Notifications (ejection, reinstatement, policy) ── */}

--- a/frontend/src/layouts/teacher-layout.tsx
+++ b/frontend/src/layouts/teacher-layout.tsx
@@ -176,6 +176,11 @@ const { mutate: markAllSystemRead } = useMarkAllSystemNotificationsAsRead();
   }, [user, isAuthReady, pendingRegistrations?.length])
 
   const totalUnreadCount = (systemUnreadCount || 0) + pendingInvites.length + pendingRegistrationsList.length;
+  const handleInviteAction = async () => {
+  const result = await getInvites();
+  setPendingInvites(result.invites || []);
+  
+};
 
   return (
     <SidebarProvider>
@@ -259,6 +264,7 @@ const { mutate: markAllSystemRead } = useMarkAllSystemNotificationsAsRead();
                       navigate({ to: "/teacher/courses/registration-requests" as any });
                       setShowSystemNotifications(false);
                     }}
+                    onInviteAction={handleInviteAction}
                   />
                 )}
               </div>

--- a/frontend/src/utils/ejectionPolicyUtils.ts
+++ b/frontend/src/utils/ejectionPolicyUtils.ts
@@ -1,0 +1,36 @@
+
+import { queryClient } from "@/lib/client";
+import { fetchClient } from "@/lib/openapi";
+
+export async function hasActivePolicies(
+  courseId: string,
+  courseVersionId: string,
+  cohortId: string
+): Promise<boolean> {
+  try {
+    const data: any = await queryClient.fetchQuery({
+      queryKey: [
+        "get",
+        "/ejection-policies/courses/{courseId}/versions/{courseVersionId}/cohorts/{cohortId}/active",
+        courseId,
+        courseVersionId,
+        cohortId,
+      ],
+      queryFn: async () => {
+        const res = await fetchClient.GET(
+          "/ejection-policies/courses/{courseId}/versions/{courseVersionId}/cohorts/{cohortId}/active",
+          {
+            params: {
+              path: { courseId, courseVersionId, cohortId },
+            },
+          }
+        );
+        return res.data;
+      },
+    });
+
+    return (data?.policies || []).length > 0;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION

- Policy Acknowledgement and Re-acknowledgement modal compacted in size
- Removed Notifications from sidebar on instructor side
- Now when a course with no ejection policies is sent as an invitation to a student, the student is directly able to accept or reject the course without acknowledgement from an empty policy modal.
- Policy acknowledgement modal was being shown in teacher's invite flow, removed it. Teachers can directly accept or reject a course invitation.
- Refetching the notification on accepting or rejecting a course by student so that the reject and accept buttons do not keep showing. Also, worked on making the UI consistent with the teacher's notification buttons.