### PR TITLE
Fix Quiz Evaluation Logic - Value-Based ID Comparison

### DIFF
--- a/backend/src/modules/quizzes/services/AttemptService.ts
+++ b/backend/src/modules/quizzes/services/AttemptService.ts
@@ -208,7 +208,7 @@ class AttemptService extends BaseService {
 
       //Find parameter map for the question
       const questionDetail = attempt.questionDetails.find(
-        qd => qd.questionId === answer.questionId,
+        qd => qd.questionId.toString() === answer.questionId.toString(),
       );
       const parameterMap = questionDetail?.parameterMap;
       // answer.lotItemId.toString()

--- a/backend/src/modules/quizzes/utils/functions/getSelectedItemTexts.ts
+++ b/backend/src/modules/quizzes/utils/functions/getSelectedItemTexts.ts
@@ -39,9 +39,11 @@ export const getSelectedItemTexts = (
         ? [answer.lotItemId]
         : [];
 
+    const selectedLotIdsStr = selectedLotId.map(id => id.toString());
+
     // Map selected IDs to texts
     questionLotItems.forEach(lot => {
-      if (selectedLotId.includes(lot._id.toString())) {
+      if (selectedLotIdsStr.includes(lot._id.toString())) {
         selectedAnswerTexts.push(lot.text);
       }
     });


### PR DESCRIPTION
## Description
This PR resolves a persistent issue where correct quiz answers (especially in parameterized and numeric questions) were incorrectly marked as wrong. The root cause was identified as strict reference equality checks (`===`) between MongoDB `ObjectId` instances. Since these IDs are recreated from the database during each submission, they have different memory addresses, causing comparisons to fail.

### Key Fixes:
1.  **AttemptService.ts**: Updated the `questionDetail` lookup in the grading method to use stringified comparison (`.toString()`). This ensures that the system correctly retrieves the `parameterMap` needed for grading.
2.  **getSelectedItemTexts.ts**: Fixed the option selection lookup to properly handle `ObjectId` arrays, ensuring that user-selected text is correctly matched and displayed in feedback.
3.  **Grader Audits**: Verified that `SOLQuestionGrader`, `SMLQuestionGrader`, and `OTLQuestionGrader` were already using robust comparison methods or were unaffected.

## Implementation Details
-   Changed `qd.questionId === answer.questionId` to `qd.questionId.toString() === answer.questionId.toString()`.
-   Modified `getSelectedItemTexts` to map choice lists to strings before performing `includes()` checks.

## Verification
-   **Simulation**: Created and ran a simulation script (`test_id_comparison.ts`) that confirmed `ObjectId` strictly comparing as `false` but string-comparing as `true`.
-   **Logic Check**: Verified that the lookup now correctly finds the corresponding `questionDetail` when IDs have the same value.