### PR TITLE
ci: isolate e2e dependency install in nightly workflow

### DIFF
--- a/.github/workflows/nightly-staging-e2e.yml
+++ b/.github/workflows/nightly-staging-e2e.yml
@@ -27,7 +27,7 @@ jobs:
           version: 8
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --dir e2e
 
       - name: Install Playwright Browsers
         run: pnpm --dir e2e exec playwright install --with-deps

--- a/.github/workflows/nightly-staging-e2e.yml
+++ b/.github/workflows/nightly-staging-e2e.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10.12.1
 
       - name: Install Dependencies
         run: pnpm install --dir e2e


### PR DESCRIPTION
Isolate E2E dependency installation in nightly workflow to prevent errors from unrelated packages. Only e2e dependencies are installed during nightly E2E runs, ensuring Playwright tests are unaffected by issues in other parts of the monorepo.