### PR TITLE
chore(backend): add json5 dependency and lockfile entry

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -113,6 +113,7 @@
     "fluent-ffmpeg": "^2.1.3",
     "graphql": "~16.10.0",
     "inversify": "^7.5.2",
+    "json5": "^2.2.3",
     "lexorank": "^1.0.5",
     "mathjs": "^14.5.2",
     "mongodb": "^6.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       inversify:
         specifier: ^7.5.2
         version: 7.5.4(reflect-metadata@0.2.2)
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
       lexorank:
         specifier: ^1.0.5
         version: 1.0.5


### PR DESCRIPTION
Adds json5 as an explicit backend dependency to match its existing usage in QuestionService.ts.


**Why:** json5 was already imported in backend/src/modules/quizzes/services/QuestionService.ts but was not declared in package.json, making the dependency