### PR TITLE
Fix/access restricted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Thumbs.db
 .idea/
 .vscode/
 !.vscode/settings.json
+
+# Local agent customizations (personal, not for repo)
+.github/agents/debugger.agent.md
 *.swp
 *.swo
 

--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -521,14 +521,15 @@ export class ItemService extends BaseService {
     itemId: string,
     userId: string,
     courseId: string,
-    versionId: string
+    versionId: string,
+    cohortId?: string
   ): Promise<boolean> {
     const previousItem = await this.progressService.getPreviousItemInSequence(courseVersion, moduleId, sectionId, itemId);
     // First item ? 
     if (!previousItem) {
       return true;
     }
-    const previousItemCompleted = await this.progressRepo.isItemCompleted(userId, courseId, versionId, previousItem.itemId);
+    const previousItemCompleted = await this.progressRepo.isItemCompleted(userId, courseId, versionId, previousItem.itemId, cohortId);
     return previousItemCompleted;
   }
 
@@ -639,6 +640,7 @@ export class ItemService extends BaseService {
       userId,
       courseId,
       versionId,
+      cohortId,
     );
 
     if (previousItemCompleted) {


### PR DESCRIPTION
**Problem**
In courses with Linear Progression enabled, cohort-enrolled students were incorrectly shown "Access Restricted" after completing the previous item.

**Root Cause**
_isPreviousItemCompleted called isItemCompleted without cohortId, so the repo queried cohortId: null — missing the actual completion record — and falsely blocked access.

**Fix**
Threaded cohortId through _isPreviousItemCompleted so the completion check queries the correct cohort scope.