### PR TITLE
Fix/gs registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Thumbs.db
 .idea/
 .vscode/
 !.vscode/settings.json
+
+# Local agent customizations (personal, not for repo)
+.github/agents/debugger.agent.md
 *.swp
 *.swo
 

--- a/backend/src/modules/courseRegistration/controllers/CourseRegistrationController.ts
+++ b/backend/src/modules/courseRegistration/controllers/CourseRegistrationController.ts
@@ -143,28 +143,6 @@ class CourseRegistrationController {
     const userId = user._id;
     const { versionId } = params;
 
-    // Extract and verify reCAPTCHA token
-    const recaptchaToken = body.recaptchaToken;
-
-    if (!recaptchaToken) {
-      throw new BadRequestError('reCAPTCHA verification is required');
-    }
-
-    // Import and verify reCAPTCHA
-    const { verifyRecaptcha } = await import('#root/shared/functions/verifyRecaptcha.js');
-
-    try {
-      const isValidRecaptcha = await verifyRecaptcha(recaptchaToken);
-      if (!isValidRecaptcha) {
-        throw new BadRequestError('reCAPTCHA verification failed. Please try again.');
-      }
-    } catch (error) {
-      if (error instanceof BadRequestError) {
-        throw error;
-      }
-      throw new BadRequestError('Failed to verify reCAPTCHA. Please try again.');
-    }
-
     // Remove recaptchaToken from body before processing
     const { recaptchaToken: _, ...registrationBody } = body;
 

--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -521,14 +521,15 @@ export class ItemService extends BaseService {
     itemId: string,
     userId: string,
     courseId: string,
-    versionId: string
+    versionId: string,
+    cohortId?: string
   ): Promise<boolean> {
     const previousItem = await this.progressService.getPreviousItemInSequence(courseVersion, moduleId, sectionId, itemId);
     // First item ? 
     if (!previousItem) {
       return true;
     }
-    const previousItemCompleted = await this.progressRepo.isItemCompleted(userId, courseId, versionId, previousItem.itemId);
+    const previousItemCompleted = await this.progressRepo.isItemCompleted(userId, courseId, versionId, previousItem.itemId, cohortId);
     return previousItemCompleted;
   }
 
@@ -639,6 +640,7 @@ export class ItemService extends BaseService {
       userId,
       courseId,
       versionId,
+      cohortId,
     );
 
     if (previousItemCompleted) {

--- a/frontend/src/app/pages/student/CourseRegistration.tsx
+++ b/frontend/src/app/pages/student/CourseRegistration.tsx
@@ -647,7 +647,7 @@ const CourseRegistration: React.FC = () => {
                             )}
                             <Button
                               type="submit"
-                              disabled={isSubmitting || (!recaptchaToken && isRecaptchaEnabled) || ((formFieldData as any)?.isActive === false) || (versionData && (versionData as any).cohorts?.find((c: any) => c.cohortId === cohort)?.isActive === false)}
+                              disabled={isSubmitting || ((formFieldData as any)?.isActive === false) || (versionData && (versionData as any).cohorts?.find((c: any) => c.cohortId === cohort)?.isActive === false)}
                             >
                               {isSubmitting ? (
                                 <>


### PR DESCRIPTION
**Summary**

Learners were blocked from submitting course registration because the course registration flow still enforced reCAPTCHA validation even when the captcha widget was not loading in the frontend.

This change removes the reCAPTCHA validation gate specifically from the GS course registration flow, while leaving the existing reCAPTCHA integration code otherwise intact.

**What changed**

- Removed backend reCAPTCHA verification enforcement from the course registration endpoint.
- Removed the frontend submit-button blocking condition that required a reCAPTCHA token before registration could be submitted.
- Kept the existing reCAPTCHA-related plumbing and UI code in place so this is a minimal unblock rather than a broader reCAPTCHA refactor.

**Why**
The current learner experience fails at registration because:

- the captcha widget is not reliably loading in the frontend
- the frontend prevented submission without a captcha token
- the backend also rejected requests when the token was missing or invalid
- That combination meant learners could not complete registration even when the issue was with captcha rendering, not with the registration form itself.