### PR TITLE
fix(gurusetu): export every (enrolled student × video) row with watch %

### DIFF
--- a/backend/src/modules/users/controllers/EnrollmentController.ts
+++ b/backend/src/modules/users/controllers/EnrollmentController.ts
@@ -956,7 +956,7 @@ export class EnrollmentController {
   @OpenAPI({
     summary: 'Export Gurusetu feedback rows',
     description:
-      'Returns Gurusetu Pilot(FDP for Faculty) feedback rows for students who watched more than 50% of each video. Optional cohort filter via cohortId query parameter.',
+      'Returns one row per (enrolled student, video) for Gurusetu Pilot(FDP for Faculty), including watch time, watch percentage, and feedback when submitted. Optional cohort filter via cohortId query parameter.',
   })
   async exportGuruSetuFeedback(
     @Param('courseId') courseId: string,

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -3752,15 +3752,13 @@ export class EnrollmentRepository {
       ? new ObjectId(cohortId)
       : null;
 
-    const watchTimeCollection = await this.db.getCollection<any>('watchTime');
-
     const pipeline = buildGuruSetuFeedbackExportPipeline(
       guruSetuCourseId,
       guruSetuVersionId,
       parsedCohortId,
     );
 
-    return watchTimeCollection
+    return this.enrollmentCollection
       .aggregate(pipeline, { allowDiskUse: true })
       .toArray();
   }

--- a/backend/src/shared/database/providers/mongo/repositories/queries/guruSetuFeedbackExportPipeline.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/queries/guruSetuFeedbackExportPipeline.ts
@@ -1,5 +1,51 @@
 import { ObjectId } from 'mongodb';
 
+const HHMMSS_TO_SECONDS = (path: string) => ({
+  $let: {
+    vars: {
+      parts: { $split: [{ $ifNull: [path, '00:00:00'] }, ':'] },
+    },
+    in: {
+      $add: [
+        {
+          $multiply: [
+            {
+              $convert: {
+                input: { $arrayElemAt: ['$$parts', 0] },
+                to: 'int',
+                onError: 0,
+                onNull: 0,
+              },
+            },
+            3600,
+          ],
+        },
+        {
+          $multiply: [
+            {
+              $convert: {
+                input: { $arrayElemAt: ['$$parts', 1] },
+                to: 'int',
+                onError: 0,
+                onNull: 0,
+              },
+            },
+            60,
+          ],
+        },
+        {
+          $convert: {
+            input: { $arrayElemAt: ['$$parts', 2] },
+            to: 'int',
+            onError: 0,
+            onNull: 0,
+          },
+        },
+      ],
+    },
+  },
+});
+
 export function buildGuruSetuFeedbackExportPipeline(
   guruSetuCourseId: ObjectId,
   guruSetuVersionId: ObjectId,
@@ -10,190 +56,9 @@ export function buildGuruSetuFeedbackExportPipeline(
       $match: {
         courseId: guruSetuCourseId,
         courseVersionId: guruSetuVersionId,
-        endTime: { $ne: null },
-        isNotPure: { $ne: true },
-      },
-    },
-    {
-      $addFields: {
-        itemObjId: {
-          $cond: [
-            { $eq: [{ $type: '$itemId' }, 'string'] },
-            {
-              $convert: {
-                input: '$itemId',
-                to: 'objectId',
-                onError: null,
-                onNull: null,
-              },
-            },
-            '$itemId',
-          ],
-        },
-      },
-    },
-    {
-      $match: {
-        itemObjId: { $ne: null },
-      },
-    },
-    {
-      $group: {
-        _id: {
-          userId: '$userId',
-          videoId: '$itemObjId',
-        },
-        rawWatchedMs: { $sum: { $subtract: ['$endTime', '$startTime'] } },
-        watchSessionCount: { $sum: 1 },
-        firstWatchAt: { $min: '$startTime' },
-        lastWatchAt: { $max: '$startTime' },
-      },
-    },
-    {
-      $addFields: {
-        userId: '$_id.userId',
-        videoId: '$_id.videoId',
-        rawWatchedSeconds: {
-          $round: [{ $divide: ['$rawWatchedMs', 1000] }, 2],
-        },
-      },
-    },
-    {
-      $lookup: {
-        from: 'videos',
-        localField: 'videoId',
-        foreignField: '_id',
-        as: 'video',
-      },
-    },
-    {
-      $unwind: {
-        path: '$video',
-        preserveNullAndEmptyArrays: false,
-      },
-    },
-    {
-      $addFields: {
-        videoName: { $ifNull: ['$video.name', '$video.title'] },
-        videoDurationSeconds: {
-          $let: {
-            vars: {
-              startParts: {
-                $split: [{ $ifNull: ['$video.details.startTime', '00:00:00'] }, ':'],
-              },
-              endParts: {
-                $split: [{ $ifNull: ['$video.details.endTime', '00:00:00'] }, ':'],
-              },
-            },
-            in: {
-              $max: [
-                0,
-                {
-                  $subtract: [
-                    {
-                      $add: [
-                        {
-                          $multiply: [
-                            {
-                              $convert: {
-                                input: { $arrayElemAt: ['$$endParts', 0] },
-                                to: 'int',
-                                onError: 0,
-                                onNull: 0,
-                              },
-                            },
-                            3600,
-                          ],
-                        },
-                        {
-                          $multiply: [
-                            {
-                              $convert: {
-                                input: { $arrayElemAt: ['$$endParts', 1] },
-                                to: 'int',
-                                onError: 0,
-                                onNull: 0,
-                              },
-                            },
-                            60,
-                          ],
-                        },
-                        {
-                          $convert: {
-                            input: { $arrayElemAt: ['$$endParts', 2] },
-                            to: 'int',
-                            onError: 0,
-                            onNull: 0,
-                          },
-                        },
-                      ],
-                    },
-                    {
-                      $add: [
-                        {
-                          $multiply: [
-                            {
-                              $convert: {
-                                input: { $arrayElemAt: ['$$startParts', 0] },
-                                to: 'int',
-                                onError: 0,
-                                onNull: 0,
-                              },
-                            },
-                            3600,
-                          ],
-                        },
-                        {
-                          $multiply: [
-                            {
-                              $convert: {
-                                input: { $arrayElemAt: ['$$startParts', 1] },
-                                to: 'int',
-                                onError: 0,
-                                onNull: 0,
-                              },
-                            },
-                            60,
-                          ],
-                        },
-                        {
-                          $convert: {
-                            input: { $arrayElemAt: ['$$startParts', 2] },
-                            to: 'int',
-                            onError: 0,
-                            onNull: 0,
-                          },
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
-    {
-      $addFields: {
-        rawWatchedSeconds: {
-          $min: ['$rawWatchedSeconds', '$videoDurationSeconds'],
-        },
-      },
-    },
-    {
-      $match: {
-        $expr: {
-          $and: [
-            { $gt: ['$videoDurationSeconds', 0] },
-            {
-              $gt: [
-                '$rawWatchedSeconds',
-                { $multiply: ['$videoDurationSeconds', 0.5] },
-              ],
-            },
-          ],
-        },
+        role: 'STUDENT',
+        isDeleted: { $ne: true },
+        ...(parsedCohortId ? { cohortId: parsedCohortId } : {}),
       },
     },
     {
@@ -205,15 +70,89 @@ export function buildGuruSetuFeedbackExportPipeline(
       },
     },
     {
-      $unwind: {
-        path: '$user',
-        preserveNullAndEmptyArrays: false,
+      $unwind: { path: '$user', preserveNullAndEmptyArrays: true },
+    },
+    {
+      $lookup: {
+        from: 'newCourseVersion',
+        let: { cvid: '$courseVersionId' },
+        pipeline: [
+          { $match: { $expr: { $eq: ['$_id', '$$cvid'] } } },
+          { $unwind: '$modules' },
+          { $match: { 'modules.isDeleted': { $ne: true } } },
+          { $unwind: '$modules.sections' },
+          { $match: { 'modules.sections.isDeleted': { $ne: true } } },
+          {
+            $lookup: {
+              from: 'itemsGroup',
+              let: { igId: '$modules.sections.itemsGroupId' },
+              pipeline: [
+                {
+                  $match: {
+                    $expr: { $eq: ['$_id', { $toObjectId: '$$igId' }] },
+                  },
+                },
+              ],
+              as: 'itemGroup',
+            },
+          },
+          { $unwind: '$itemGroup' },
+          { $unwind: '$itemGroup.items' },
+          {
+            $match: {
+              'itemGroup.items.type': 'VIDEO',
+              'itemGroup.items.isHidden': { $ne: true },
+              'itemGroup.items.isDeleted': { $ne: true },
+            },
+          },
+          {
+            $lookup: {
+              from: 'videos',
+              let: { itemId: '$itemGroup.items._id' },
+              pipeline: [
+                {
+                  $match: {
+                    $expr: {
+                      $and: [
+                        { $eq: ['$_id', { $toObjectId: '$$itemId' }] },
+                        { $ne: ['$isDeleted', true] },
+                        { $ne: ['$isHidden', true] },
+                      ],
+                    },
+                  },
+                },
+              ],
+              as: 'video',
+            },
+          },
+          { $unwind: '$video' },
+          { $replaceRoot: { newRoot: '$video' } },
+        ],
+        as: 'videos',
+      },
+    },
+    { $unwind: '$videos' },
+    {
+      $addFields: {
+        videoId: '$videos._id',
+        videoName: { $ifNull: ['$videos.name', '$videos.title'] },
+        videoDurationSeconds: {
+          $max: [
+            0,
+            {
+              $subtract: [
+                HHMMSS_TO_SECONDS('$videos.details.endTime'),
+                HHMMSS_TO_SECONDS('$videos.details.startTime'),
+              ],
+            },
+          ],
+        },
       },
     },
     {
       $lookup: {
-        from: 'enrollment',
-        let: { uid: '$userId' },
+        from: 'watchTime',
+        let: { uid: '$userId', vid: '$videoId' },
         pipeline: [
           {
             $match: {
@@ -222,30 +161,97 @@ export function buildGuruSetuFeedbackExportPipeline(
                   { $eq: ['$userId', '$$uid'] },
                   { $eq: ['$courseId', guruSetuCourseId] },
                   { $eq: ['$courseVersionId', guruSetuVersionId] },
-                  { $eq: ['$role', 'STUDENT'] },
-                  { $ne: ['$isDeleted', true] },
+                  { $ne: ['$endTime', null] },
+                  { $ne: ['$isNotPure', true] },
                 ],
               },
-              ...(parsedCohortId ? { cohortId: parsedCohortId } : {}),
             },
           },
-          { $limit: 1 },
+          {
+            $addFields: {
+              itemObjId: {
+                $cond: [
+                  { $eq: [{ $type: '$itemId' }, 'string'] },
+                  {
+                    $convert: {
+                      input: '$itemId',
+                      to: 'objectId',
+                      onError: null,
+                      onNull: null,
+                    },
+                  },
+                  '$itemId',
+                ],
+              },
+            },
+          },
+          { $match: { $expr: { $eq: ['$itemObjId', '$$vid'] } } },
+          {
+            $group: {
+              _id: null,
+              rawWatchedMs: { $sum: { $subtract: ['$endTime', '$startTime'] } },
+              watchSessionCount: { $sum: 1 },
+              firstWatchAt: { $min: '$startTime' },
+              lastWatchAt: { $max: '$startTime' },
+            },
+          },
         ],
-        as: 'enrollment',
+        as: 'watch',
       },
     },
     {
-      $match: {
-        'enrollment.0': { $exists: true },
+      $unwind: { path: '$watch', preserveNullAndEmptyArrays: true },
+    },
+    {
+      $addFields: {
+        rawWatchedSeconds: {
+          $let: {
+            vars: {
+              raw: {
+                $round: [
+                  {
+                    $divide: [{ $ifNull: ['$watch.rawWatchedMs', 0] }, 1000],
+                  },
+                  2,
+                ],
+              },
+            },
+            in: {
+              $cond: [
+                { $gt: ['$videoDurationSeconds', 0] },
+                { $min: ['$$raw', '$videoDurationSeconds'] },
+                '$$raw',
+              ],
+            },
+          },
+        },
+      },
+    },
+    {
+      $addFields: {
+        watchPercentage: {
+          $cond: [
+            { $gt: ['$videoDurationSeconds', 0] },
+            {
+              $round: [
+                {
+                  $multiply: [
+                    { $divide: ['$rawWatchedSeconds', '$videoDurationSeconds'] },
+                    100,
+                  ],
+                },
+                2,
+              ],
+            },
+            0,
+          ],
+        },
       },
     },
     {
       $lookup: {
         from: 'feedback_submission',
-        let: {
-          uid: '$userId',
-          vid: '$videoId',
-        },
+        let: { uid: '$userId', vid: '$videoId' },
         pipeline: [
           {
             $match: {
@@ -261,17 +267,7 @@ export function buildGuruSetuFeedbackExportPipeline(
             },
           },
           { $sort: { updatedAt: -1, createdAt: -1, _id: -1 } },
-          {
-            $group: {
-              _id: {
-                userId: '$userId',
-                feedbackFormId: '$feedbackFormId',
-                previousItemId: '$previousItemId',
-              },
-              doc: { $first: '$$ROOT' },
-            },
-          },
-          { $replaceRoot: { newRoot: '$doc' } },
+          { $limit: 1 },
         ],
         as: 'feedbackSubmission',
       },
@@ -279,7 +275,7 @@ export function buildGuruSetuFeedbackExportPipeline(
     {
       $unwind: {
         path: '$feedbackSubmission',
-        preserveNullAndEmptyArrays: false,
+        preserveNullAndEmptyArrays: true,
       },
     },
     {
@@ -301,65 +297,66 @@ export function buildGuruSetuFeedbackExportPipeline(
         _id: 0,
         userId: { $toString: '$userId' },
         userEmail: '$user.email',
+        userFirstName: '$user.firstName',
+        userLastName: '$user.lastName',
         videoName: 1,
         videoDurationSeconds: 1,
         rawWatchedSeconds: 1,
-        watchSessionCount: 1,
-        firstWatchAt: 1,
-        lastWatchAt: 1,
-        details: '$feedbackSubmission.details',
+        watchPercentage: 1,
+        watchSessionCount: { $ifNull: ['$watch.watchSessionCount', 0] },
+        firstWatchAt: '$watch.firstWatchAt',
+        lastWatchAt: '$watch.lastWatchAt',
         feedbackFormName: '$feedbackForm.name',
         'Was the explanation in the video clear?': {
           $getField: {
             field: 'Was the explanation in the video clear?',
-            input: '$feedbackSubmission.details',
+            input: { $ifNull: ['$feedbackSubmission.details', {}] },
           },
         },
         'How would you rate the Audio & Visual quality?': {
           $getField: {
             field: 'How would you rate the Audio & Visual quality?',
-            input: '$feedbackSubmission.details',
+            input: { $ifNull: ['$feedbackSubmission.details', {}] },
           },
         },
         'How was the pacing of the content in the video?': {
           $getField: {
             field: 'How was the pacing of the content in the video?',
-            input: '$feedbackSubmission.details',
+            input: { $ifNull: ['$feedbackSubmission.details', {}] },
           },
         },
         'Did the video hold your attention?': {
           $getField: {
             field: 'Did the video hold your attention?',
-            input: '$feedbackSubmission.details',
+            input: { $ifNull: ['$feedbackSubmission.details', {}] },
           },
         },
         'How useful do you find this content ?': {
           $getField: {
             field: 'How useful do you find this content ?',
-            input: '$feedbackSubmission.details',
+            input: { $ifNull: ['$feedbackSubmission.details', {}] },
           },
         },
         'How confident do you feel applying this concept in your daily/ professional life?': {
           $getField: {
             field:
               'How confident do you feel applying this concept in your daily/ professional life?',
-            input: '$feedbackSubmission.details',
+            input: { $ifNull: ['$feedbackSubmission.details', {}] },
           },
         },
         'Please share your feedback here': {
           $getField: {
             field: 'Please share your feedback here',
-            input: '$feedbackSubmission.details',
+            input: { $ifNull: ['$feedbackSubmission.details', {}] },
           },
         },
-        createdAt: '$feedbackSubmission.createdAt',
+        feedbackSubmittedAt: '$feedbackSubmission.createdAt',
       },
     },
     {
       $sort: {
         userEmail: 1,
         videoName: 1,
-        createdAt: -1,
       },
     },
   ];


### PR DESCRIPTION
Pipeline previously started from watchTime and required a feedback submission, so users who never watched and users who watched without submitting feedback were missing from the export. Restructure to start from enrollment, cross-join with all videos in the course version, and left-join watchTime + feedback so every student-video pair appears. Adds a watchPercentage column.

