### PR TITLE
fix(video): remove manual iframe removeChild that crashed React on ac…

### DIFF
--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -954,21 +954,6 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
       if (playerRef.current) {
         try {
           playerRef.current.stopVideo?.();
-          // ✅ Remove iframe BEFORE destroy to prevent React reconciliation conflict
-          try {
-            if (iframeRef.current) {
-              // Case 1: YouTube replaced the div with an iframe
-              if (iframeRef.current.tagName === 'IFRAME') {
-                iframeRef.current.parentNode?.removeChild(iframeRef.current);
-              } else {
-                // Case 2: YouTube inserted iframe inside our div
-                const iframe = iframeRef.current.querySelector('iframe');
-                iframe?.parentNode?.removeChild(iframe);
-              }
-            }
-          } catch (e) {
-            // Ignore — node may already be detached
-          }
           playerRef.current.destroy?.();
         } catch (error) {
           console.warn('Player cleanup error:', error);


### PR DESCRIPTION
- Diagnosed the "Something went wrong" / insertBefore crash — traced it to PR #985's manual removeChild in the YT player cleanup, which conflicts with React's reconciliation when readyToDetect (the proctoring access gate) flips.
- Applied the fix — removed the manual removeChild block from [frontend/src/components/video.tsx:949-959](vscode-webview://15u1p08kufncbla14ivr45d4t5nd4kcsob2935o0kuf5q09gbvou/frontend/src/components/video.tsx#L949-L959), leaving stopVideo() + destroy(). TypeScript compile passes.