### PR TITLE
Fix/watchtime session hardening

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -1407,6 +1407,17 @@ class ProgressService extends BaseService {
         // - If the video is long, must have watched at least 30 seconds
         const minimumRequired = Math.min(totalVideoDuration * 0.15, 30);
 
+        // Upper-bound sanity check.
+        // A single uninterrupted watch span should not exceed a reasonable
+        // multiple of the video duration. If it does, the most likely cause
+        // is that the learner left the tab/player open without calling stop
+        // (paused video, hidden tab, sleeping laptop). Reject the span so
+        // the item is not marked completed off an inflated wall-clock delta.
+        const maxAllowedVideoDuration = totalVideoDuration * 3 + 60;
+        if (serverDuration > maxAllowedVideoDuration) {
+          return false;
+        }
+
         return adjustedDuration >= minimumRequired;
 
       case 'BLOG':
@@ -1418,6 +1429,12 @@ class ProgressService extends BaseService {
         // Require at least 10% of estimated time OR 10 seconds
         // This stops instant click-throughs but doesn't punish fast readers
         const minReadTime = Math.min(readTimeSeconds * 0.1, 10);
+
+        // Upper-bound sanity check (see VIDEO branch for rationale).
+        const maxAllowedReadTime = readTimeSeconds * 5 + 60;
+        if (serverDuration > maxAllowedReadTime) {
+          return false;
+        }
 
         return adjustedDuration >= minReadTime;
 

--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -293,8 +293,69 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
     onNext?.();
   }, [onNext]);
 
-  // Pause video when user switches browser tabs
+  // Pause video AND close the open WatchTime row when the learner hides the tab.
+  //
+  // Why we close the row (not just pause):
+  // The backend computes engagement as endTime - startTime on the WatchTime
+  // record opened by startItemTracking. If we only pause the player, the
+  // record stays open while the tab is hidden; whenever stopItem eventually
+  // fires (sometimes hours later) the recorded duration is wall-clock time,
+  // which trivially passes isValidWatchTime's minimum-watch threshold and
+  // marks the item as legitimately watched. Closing the row on hide bounds
+  // each WatchTime span to actual foreground time.
+  //
+  // Why we do NOT call handleStopItem here:
+  // handleStopItem treats a successful stop as item completion (sets
+  // progressStoppedRef, adds to completedItemIdsRef, and may navigate). On
+  // tab hide we explicitly do not want to mark the item completed — we just
+  // want to close the open span. So we fire the underlying mutation
+  // directly and re-open a fresh span via handleSendStartItem on return.
   useEffect(() => {
+    const closeOpenWatchTimeForHide = async () => {
+      const watchItemId = watchItemIdRef.current;
+      if (!watchItemId) return;
+      if (!currentCourse?.itemId) return;
+      // Already navigating away or already stopped — nothing to close.
+      if (progressStoppedRef.current || stopInFlightRef.current) return;
+      // Item is already complete — backend will reject anyway, skip.
+      if (
+        isAlreadyWatched ||
+        isCompleted ||
+        completedItemIdsRef.current.has(currentCourse.itemId)
+      ) {
+        return;
+      }
+      try {
+        await stopItem.mutateAsync({
+          params: {
+            path: {
+              courseId: currentCourse.courseId,
+              courseVersionId: currentCourse.versionId ?? '',
+            },
+          },
+          body: {
+            watchItemId,
+            itemId: currentCourse.itemId,
+            moduleId: currentCourse.moduleId ?? '',
+            sectionId: currentCourse.sectionId ?? '',
+            seekForwardEnabled,
+            nextItemId,
+            cohortId: currentCourse.cohortId ?? '',
+          },
+        } as any);
+        // Clear the local watchItemId so a fresh one is opened on return.
+        watchItemIdRef.current = null;
+        setWatchItemId('');
+        // Allow the player-state PLAYING handler to fire startItem again
+        // when playback resumes after the tab becomes visible.
+        progressStartedRef.current = false;
+      } catch (err) {
+        // Best-effort: if the close fails the server-side cap in
+        // isValidWatchTime is the safety net.
+        console.warn('[Visibility] stopItem on hide failed:', err);
+      }
+    };
+
     const handleVisibilityChange = () => {
       const player = playerRef.current;
       if (!player) return;
@@ -306,20 +367,82 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
         } else {
           wasPlayingBeforeTabSwitch.current = false;
         }
+        // Close the open WatchTime regardless of play state, because the
+        // row was opened the moment playback first started and would
+        // otherwise keep accruing wall-clock time while hidden.
+        void closeOpenWatchTimeForHide();
       } else {
         if (wasPlayingBeforeTabSwitch.current && playerReady) {
           player.playVideo();
           setTimeout(() => { playerRef.current?.setPlaybackRate?.(playbackRate); }, 50);
           wasPlayingBeforeTabSwitch.current = false;
         }
+        // Re-open a fresh WatchTime so the resumed playback is tracked.
+        // handleSendStartItem itself guards against already-completed items.
+        if (!watchItemIdRef.current) {
+          handleSendStartItem();
+        }
+      }
+    };
+
+    // On pagehide / unload we cannot await a network round-trip, so enqueue
+    // the close into the existing failedStopQueue. The next page load's
+    // queue-flush effect will send it, ensuring the WatchTime row is
+    // closed even if the user navigates away or kills the tab.
+    const handlePageHide = () => {
+      const watchItemId = watchItemIdRef.current;
+      if (!watchItemId || !currentCourse?.itemId) return;
+      if (progressStoppedRef.current) return;
+      if (
+        isAlreadyWatched ||
+        isCompleted ||
+        completedItemIdsRef.current.has(currentCourse.itemId)
+      ) {
+        return;
+      }
+      try {
+        const QUEUE_KEY = 'vibe.failedStopQueue';
+        const raw = localStorage.getItem(QUEUE_KEY);
+        const queue: any[] = raw ? JSON.parse(raw) : [];
+        const payload = {
+          params: {
+            path: {
+              courseId: currentCourse.courseId,
+              courseVersionId: currentCourse.versionId ?? '',
+            },
+          },
+          body: {
+            watchItemId,
+            itemId: currentCourse.itemId,
+            moduleId: currentCourse.moduleId ?? '',
+            sectionId: currentCourse.sectionId ?? '',
+            seekForwardEnabled,
+            nextItemId,
+            cohortId: currentCourse.cohortId ?? '',
+          },
+          queuedAt: Date.now(),
+        };
+        const dedupKey = `${payload.body.itemId}:${payload.body.watchItemId}`;
+        const exists = queue.some(
+          (q: any) => `${q?.body?.itemId}:${q?.body?.watchItemId}` === dedupKey,
+        );
+        if (!exists) {
+          queue.push(payload);
+          localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+        }
+      } catch (err) {
+        console.warn('[Visibility] failed to enqueue stop on pagehide:', err);
       }
     };
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', handlePageHide);
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', handlePageHide);
     };
-  }, [playing, playerReady, playbackRate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playing, playerReady, playbackRate, currentCourse?.itemId, currentCourse?.courseId, currentCourse?.versionId, currentCourse?.moduleId, currentCourse?.sectionId, currentCourse?.cohortId, isAlreadyWatched, isCompleted, seekForwardEnabled, nextItemId]);
 
   // Wait 10 seconds after readyToDetect becomes true (to match FloatingVideo's grace period)
   useEffect(() => {

--- a/frontend/src/store/context/auth.tsx
+++ b/frontend/src/store/context/auth.tsx
@@ -4,8 +4,16 @@ import { auth } from '@/lib/firebase';
 import { useAuthStore } from '@/store/auth-store';
 import { logout, loginWithGoogle, loginWithEmail, refreshFirebaseToken } from '@/utils/auth';
 import { setTokenRefreshFunction } from '@/lib/openapi';
+import { toast } from 'sonner';
 
 import type { Role, AuthContextType } from '@/types/auth.types';
+
+// Auto-logout after this many milliseconds of user inactivity. Activity is
+// detected from pointer/keyboard/touch events and from the tab becoming
+// visible after being hidden. The threshold is intentionally generous so
+// learners watching long videos (where the tab is visible but they aren't
+// touching anything) are not booted out unfairly.
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
 
 // Create a context with default values
@@ -57,21 +65,27 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               await refreshFirebaseToken();
             } catch (error) {
               console.error('Failed to refresh token:', error);
-              // If refresh fails, sign out user
-              // handleLogout();
-
-              // Retry token refresh 
+              // First retry: try once more before giving up. A transient
+              // network blip or a brief Firebase hiccup should not log
+              // the learner out.
               try {
                 console.log('Retrying token refresh...');
                 const firebaseUser = auth.currentUser;
                 if (firebaseUser) {
                   const newToken = await firebaseUser.getIdToken(true);
                   setToken(newToken);
+                  return;
                 }
               } catch (retryError) {
                 console.error('Token refresh retry failed:', retryError);
-
               }
+              // Both attempts failed. The token cannot be renewed, which
+              // means subsequent API calls will return 401. Sign the user
+              // out cleanly so they re-authenticate, instead of leaving
+              // the UI in a "logged in" state that silently 401s on
+              // every request and can mask account revocation.
+              toast.error('Your session has expired. Please sign in again.');
+              handleLogout();
             }
           }, 50 * 60 * 1000); // 50 minutes in milliseconds
 
@@ -83,7 +97,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             setToken(retryToken);
           } catch (retryError) {
             console.error('Token refresh on page load failed:', retryError);
-
+            // The initial token fetch and its retry both failed. Treat
+            // this as an unrecoverable auth error and force re-login,
+            // rather than leaving the app in an authReady=false limbo.
+            toast.error('Unable to verify your session. Please sign in again.');
+            handleLogout();
           }
         }
       } else {
@@ -105,6 +123,63 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
     };
   }, [setToken, clearUser, handleLogout]);
+
+  // Idle auto-logout.
+  //
+  // The Firebase token-refresh loop above keeps the session alive
+  // indefinitely as long as the tab is open. Without an idle bound, a
+  // learner who walks away from a shared/public machine leaves an
+  // authenticated session running, and any cached watch-time / progress
+  // session ticks against their account. This effect logs the user out
+  // after IDLE_TIMEOUT_MS of no detectable interaction.
+  //
+  // We deliberately count tab visibility as activity (not just pointer /
+  // keyboard input) so a learner who is actively watching a long video
+  // with the tab focused is not logged out, while a backgrounded tab
+  // counts only its last visibility transition as activity.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const triggerIdleLogout = () => {
+      console.warn('[Auth] Idle timeout reached — logging out');
+      toast.info('You were signed out after a period of inactivity.');
+      handleLogout();
+    };
+
+    const resetIdleTimer = () => {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(triggerIdleLogout, IDLE_TIMEOUT_MS);
+    };
+
+    const onVisibility = () => {
+      if (!document.hidden) resetIdleTimer();
+    };
+
+    const activityEvents: Array<keyof DocumentEventMap> = [
+      'mousemove',
+      'mousedown',
+      'keydown',
+      'touchstart',
+      'scroll',
+      'wheel',
+    ];
+    activityEvents.forEach(evt =>
+      document.addEventListener(evt, resetIdleTimer, { passive: true }),
+    );
+    document.addEventListener('visibilitychange', onVisibility);
+
+    resetIdleTimer();
+
+    return () => {
+      if (idleTimer) clearTimeout(idleTimer);
+      activityEvents.forEach(evt =>
+        document.removeEventListener(evt, resetIdleTimer),
+      );
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [isAuthenticated, handleLogout]);
 
   // Login function that sets the user in the store
   const login = (selectedRole: Role, uid: string, email: string, name?: string) => {


### PR DESCRIPTION

Learners who hide a tab, pause a video, or close the laptop without clicking stop leave an open `WatchTime` row that keeps accruing wall-clock time. When stop eventually fires (or never does), the inflated duration trivially passes the lower-bound watch-time check and the item is marked complete. Auth sessions also persisted indefinitely, since token-refresh failures were silently swallowed.

This PR addresses both:

- **Backend — server-side cap** (`ProgressService.isValidWatchTime`): reject any single watch span exceeding `contentDuration × 3 + 60s` for videos and `readTime × 5 + 60s` for blogs. A legitimate viewer cannot exceed this; an idle tab will.
- **Frontend — close watch span on tab hide** (`components/video.tsx`): on `visibilitychange → hidden`, fire `stopItem` directly (bypassing `handleStopItem` to avoid auto-completing) and clear the local watch-id refs; on `pagehide`, enqueue the stop into the existing `vibe.failedStopQueue` localStorage drain. On return-to-visible, start a fresh span.
- **Frontend — idle + auth hardening** (`store/context/auth.tsx`): force `handleLogout()` after token-refresh exhaustion (was silent); add a 30-minute idle timer driven by mouse/keyboard/touch/scroll/visibility events.

---

