### PR TITLE
fix(progress): don't rewind currentItem when rewatching a completed v…

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -2238,8 +2238,9 @@ class ProgressService extends BaseService {
      * - skipped items
      * - rewatch of already-completed items
      */
+    let alreadyCompleted = false;
     if (item.type !== 'QUIZ' && !isSkipped) {
-      const alreadyCompleted = await this.progressRepository.isItemCompleted(
+      alreadyCompleted = await this.progressRepository.isItemCompleted(
         userId,
         courseId,
         courseVersionId,
@@ -2528,14 +2529,18 @@ class ProgressService extends BaseService {
       // ----------------------------------------------------
       // 11. FINAL PROGRESS UPDATE
       // ----------------------------------------------------
-      await this.progressRepository.updateProgress(
-        userId,
-        courseId,
-        courseVersionId,
-        newProgress,
-        cohortId,
-        session,
-      );
+      // On rewatch of an already-completed item, skip the pointer write so
+      // currentItem isn't rewound from the student's real forward position.
+      if (!alreadyCompleted) {
+        await this.progressRepository.updateProgress(
+          userId,
+          courseId,
+          courseVersionId,
+          newProgress,
+          cohortId,
+          session,
+        );
+      }
     });
   }
 


### PR DESCRIPTION
Re-playing a completed video silently rewinds progress.currentItem to the next-after-the-rewatched item, so the student opens the course on an already-finished video. Hoists alreadyCompleted out of the validation block and skips the pointer write on rewatch. Quiz reattempt and skip flows are unaffected.