### PR TITLE
Fix/access stop tx autoscroll

### DIFF
--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -628,10 +628,40 @@ export class ItemService extends BaseService {
     // 1) current item matches => allow
     if (currentItemId === itemId) return response();
 
-    // 2) already completed => allow
+    // 2) item is at-or-before learner's progress pointer => allow re-watch
+    //    without depending on watchTime.endTime for the candidate item.
+    if (currentUserProgress && courseVersion && moduleId && sectionId) {
+      const isAtOrBefore = await this.progressService.isItemAtOrBeforeCurrent(
+        courseVersion,
+        currentUserProgress.currentModule?.toString(),
+        currentUserProgress.currentSection?.toString(),
+        currentUserProgress.currentItem?.toString(),
+        moduleId,
+        sectionId,
+        itemId,
+      );
+      if (isAtOrBefore) return response(isItemAlreadyCompleted);
+      console.warn('[ItemService.readItem] position check returned false', {
+        itemId,
+        moduleId,
+        sectionId,
+        progressModule: currentUserProgress.currentModule?.toString(),
+        progressSection: currentUserProgress.currentSection?.toString(),
+        progressItem: currentUserProgress.currentItem?.toString(),
+      });
+    } else {
+      console.warn('[ItemService.readItem] position check skipped', {
+        hasProgress: !!currentUserProgress,
+        hasCourseVersion: !!courseVersion,
+        moduleId,
+        sectionId,
+      });
+    }
+
+    // 3) already completed => allow
     if (isItemAlreadyCompleted) return response(true);
 
-    // 3) previous item completed => allow
+    // 4) previous item completed => allow
     const previousItemCompleted = await this._isPreviousItemCompleted(
       courseVersion,
       moduleId,
@@ -663,7 +693,23 @@ export class ItemService extends BaseService {
       return response();
     }
 
-    // All checks failed => forbid
+    // All checks failed => forbid. Log the decision context so we can see
+    // why each gate let the request through.
+    console.warn('[ItemService.readItem] Access denied', {
+      userId,
+      versionId,
+      itemId,
+      moduleId,
+      sectionId,
+      cohortId,
+      isItemAlreadyCompleted,
+      isItemAlreadyAttempted,
+      linearProgressionEnabled,
+      currentItemId,
+      progressModule: currentUserProgress?.currentModule?.toString(),
+      progressSection: currentUserProgress?.currentSection?.toString(),
+      progressItem: currentUserProgress?.currentItem?.toString(),
+    });
     throw new ForbiddenError("You don't have permission to watch this item");
     // return {
     //   ...item,

--- a/backend/src/modules/quizzes/services/AttemptService.ts
+++ b/backend/src/modules/quizzes/services/AttemptService.ts
@@ -444,7 +444,11 @@ class AttemptService extends BaseService {
       throw new NotFoundError(`Quiz with ID ${quizId} not found`);
     }
 
-    // 2. Check existing submission (idempotency)
+    // 2. Idempotent re-submit. Common when a slow first request made the
+    // student click submit again, or the page reloaded mid-submit. Return the
+    // prior grading result and reconcile progress (in case the first call
+    // died after creating the submission row but before the progress write
+    // landed) — never throw, since the user already submitted in good faith.
     const existingSubmission = await this.submissionRepository.get(
       quizId,
       userId,
@@ -452,9 +456,48 @@ class AttemptService extends BaseService {
       cohortId
     );
     if (existingSubmission) {
-      throw new BadRequestError(
-        `Attempt with ID ${attemptId} has already been submitted`,
-      );
+      let existingGrading = existingSubmission.gradingResult;
+
+      if (!existingGrading) {
+        // First submit landed the row but never graded it. Grade now and
+        // persist on the existing record so future re-submits are pure reads.
+        const fresh = await this._grade(attemptId, quizId, answers);
+        existingGrading = {
+          ...fresh,
+          overallFeedback: fresh.overallFeedback.map(each => ({
+            ...each,
+            questionId: new ObjectId(each.questionId),
+          })),
+        };
+        await this.submissionRepository.update(
+          existingSubmission._id.toString(),
+          { gradingResult: existingGrading },
+        );
+      }
+
+      if (!isSkipped && courseId && courseVersionId) {
+        const isItemCompleted = await this.progressRepository.isItemCompleted(
+          userId.toString(),
+          courseId,
+          courseVersionId,
+          quizId,
+          cohortId,
+        );
+        if (!isItemCompleted) {
+          const isPassed = existingGrading.gradingStatus === 'PASSED';
+          await this.progressService.handleQuizeProgressAfterSubmission(
+            userId,
+            quizId,
+            courseId,
+            courseVersionId,
+            isPassed,
+            watchItemId,
+            cohortId,
+          );
+        }
+      }
+
+      return this._buildGradingResult(quiz, existingGrading);
     }
 
     /* -------------------- TRANSACTION (STATE MUTATION ONLY) -------------------- */

--- a/backend/src/modules/users/classes/validators/ProgressValidators.ts
+++ b/backend/src/modules/users/classes/validators/ProgressValidators.ts
@@ -322,6 +322,25 @@ export class StopItemBody {
     type: 'string',
   })
   cohortId?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @JSONSchema({
+    description: 'Actual seconds the video was playing in this session (player-tracked, not wall-clock)',
+    example: 342,
+    type: 'number',
+  })
+  watchedSeconds?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  @JSONSchema({
+    description: 'True when this session was closed because the idle timer fired, not normal completion',
+    example: false,
+    type: 'boolean',
+  })
+  isExpired?: boolean;
 }
 
 export class ItemIdparams {

--- a/backend/src/modules/users/controllers/ProgressController.ts
+++ b/backend/src/modules/users/controllers/ProgressController.ts
@@ -295,6 +295,8 @@ class ProgressController {
       seekForwardEnabled,
       nextItemId,
       cohortId,
+      watchedSeconds,
+      isExpired,
     } = body;
 
     const userId = String(user._id);
@@ -322,7 +324,9 @@ class ProgressController {
       isSkipped,
       seekForwardEnabled,
       nextItemId,
-      cohortId
+      cohortId,
+      watchedSeconds,
+      isExpired,
     );
   }
 

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -1361,65 +1361,69 @@ class ProgressService extends BaseService {
     throw new Error('Invalid time format');
   }
 
-  private isValidWatchTime(watchTime: IWatchTime, item: Item) {
-    // Basic sanity checks
+  private async isValidWatchTime(
+    watchTime: IWatchTime,
+    item: Item,
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    itemId: string,
+    cohortId?: string,
+    session?: ClientSession,
+  ): Promise<boolean> {
     if (!watchTime.startTime || !watchTime.endTime || !item.details) {
       return false;
     }
-
-    const watchStartTime = new Date(watchTime.startTime);
-    const watchEndTime = new Date(watchTime.endTime);
-
-    // Server-side measured duration in seconds
-    const serverDuration =
-      Math.abs(watchEndTime.getTime() - watchStartTime.getTime()) / 1000;
-
-    // Buffer for latency/load (add 5 seconds to the server's measured time)
-    // This assumes the user actually watched longer, but the server started late or ended early
-    // Effectively, we are saying If the server saw 5s, maybe they actually watched 10s
-    const adjustedDuration = serverDuration + 5;
+    // Sessions closed by the idle timer never count toward completion
+    if (watchTime.isExpired) {
+      return false;
+    }
 
     switch (item.type) {
-      case 'VIDEO':
+      case 'VIDEO': {
         const videoDetails = item.details as IVideoDetails;
         if (!videoDetails.startTime || !videoDetails.endTime) return false;
 
-        // parse it to seconds through liabrary
-        const videoEndTimeInSeconds = this.parseTimeToSeconds(
-          videoDetails.endTime,
-        );
-        // parseInt(videoDetails.endTime.split(':')[0]) * 3600 +
-        // parseInt(videoDetails.endTime.split(':')[1]) * 60 +
-        // parseInt(videoDetails.endTime.split(':')[2]);
-        const videoStartTimeInSeconds = this.parseTimeToSeconds(
-          videoDetails.startTime,
-        );
-        // parseInt(videoDetails.startTime.split(':')[0]) * 3600 +
-        // parseInt(videoDetails.startTime.split(':')[1]) * 60 +
-        // parseInt(videoDetails.startTime.split(':')[2]);
-
         const totalVideoDuration =
-          videoEndTimeInSeconds - videoStartTimeInSeconds;
+          this.parseTimeToSeconds(videoDetails.endTime) -
+          this.parseTimeToSeconds(videoDetails.startTime);
+        if (totalVideoDuration <= 0) return false;
 
-        // Security Rule
-        // - Must have watched at least 15% of the video
-        // OR
-        // - If the video is long, must have watched at least 30 seconds
-        const minimumRequired = Math.min(totalVideoDuration * 0.15, 30);
+        // Sum play time across all of this user's non-expired sessions for the
+        // item. Each session is capped at the video's own duration so re-watches
+        // can't push a partial viewer across the line. The just-closed session
+        // is included because stopItemTracking ran before this check.
+        const cumulativeWatched =
+          await this.progressRepository.sumWatchSecondsForItem(
+            userId,
+            itemId,
+            courseId,
+            courseVersionId,
+            totalVideoDuration,
+            cohortId,
+            session,
+          );
 
-        return adjustedDuration >= minimumRequired;
+        // 40% covers a student watching at up to 2x speed with normal
+        // seek/pause behavior. Teachers can mark an item isOptional to bypass.
+        return cumulativeWatched >= totalVideoDuration * 0.4;
+      }
 
-      case 'BLOG':
+      case 'BLOG': {
         const blogDetails = item.details as IBlogDetails;
-        // Estimated read time is in minutes
         const readTimeSeconds =
           (blogDetails.estimatedReadTimeInMinutes || 1) * 60;
-
-        // Require at least 10% of estimated time OR 10 seconds
-        // This stops instant click-throughs but doesn't punish fast readers
         const minReadTime = Math.min(readTimeSeconds * 0.1, 10);
 
-        return adjustedDuration >= minReadTime;
+        // Blog has no client-side play tracking — wall-clock with 5s grace.
+        const sessionSeconds = typeof watchTime.duration === 'number'
+          ? watchTime.duration
+          : Math.abs(
+              new Date(watchTime.endTime).getTime() -
+              new Date(watchTime.startTime).getTime(),
+            ) / 1000;
+        return sessionSeconds + 5 >= minReadTime;
+      }
 
       default:
         return true;
@@ -2166,6 +2170,8 @@ class ProgressService extends BaseService {
     seekForwardEnabled?: boolean,
     nextItemId?: string,
     cohortId?: string,
+    watchedSeconds?: number,
+    isExpired?: boolean,
   ): Promise<void> {
     const [courseVersion, progress, item, linearProgressionEnabled] =
       await Promise.all([
@@ -2256,6 +2262,8 @@ class ProgressService extends BaseService {
           stoppedWatchTime = await this.progressRepository.stopItemTracking(
             watchItemId,
             session,
+            watchedSeconds,
+            isExpired,
           );
 
           if (stoppedWatchTime) {
@@ -2269,6 +2277,7 @@ class ProgressService extends BaseService {
               isSkipped,
               stoppedWatchTime,
               cohortId,
+              session,
             );
           } else {
             // watchTimeId not found or soft-deleted — treat as already-stopped (idempotent).
@@ -2558,12 +2567,22 @@ class ProgressService extends BaseService {
     isSkipped?: boolean,
     stoppedWatchTime?: IWatchTime,
     cohortId?: string,
+    session?: ClientSession,
   ): Promise<void> {
     const WATCH_TIME_REQUIRED_ITEMS = new Set<string>(['VIDEO', 'BLOG']);
 
     // 1 Watch-time based items
     if (WATCH_TIME_REQUIRED_ITEMS.has(item.type)) {
-      this.validateWatchTime(item, stoppedWatchTime);
+      await this.validateWatchTime(
+        item,
+        userId,
+        courseId,
+        courseVersionId,
+        itemId,
+        stoppedWatchTime,
+        cohortId,
+        session,
+      );
       return;
     }
 
@@ -2581,12 +2600,31 @@ class ProgressService extends BaseService {
     }
   }
 
-  private validateWatchTime(item: Item, stoppedWatchTime?: IWatchTime): void {
+  private async validateWatchTime(
+    item: Item,
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    itemId: string,
+    stoppedWatchTime?: IWatchTime,
+    cohortId?: string,
+    session?: ClientSession,
+  ): Promise<void> {
     if (!stoppedWatchTime) {
       throw new BadRequestError('Watch time not found');
     }
 
-    if (!this.isValidWatchTime(stoppedWatchTime, item)) {
+    const ok = await this.isValidWatchTime(
+      stoppedWatchTime,
+      item,
+      userId,
+      courseId,
+      courseVersionId,
+      itemId,
+      cohortId,
+      session,
+    );
+    if (!ok) {
       throw new BadRequestError('Invalid watch time');
     }
   }
@@ -2683,7 +2721,17 @@ class ProgressService extends BaseService {
         if (!watchTime) {
           throw new NotFoundError('Watch time not found');
         }
-        if (!this.isValidWatchTime(watchTime, item)) {
+        const ok = await this.isValidWatchTime(
+          watchTime,
+          item,
+          userId,
+          courseId,
+          courseVersionId,
+          itemId,
+          cohort,
+          session,
+        );
+        if (!ok) {
           throw new BadRequestError(
             'Watch time is not valid, the user did not watch the item long enough',
           );
@@ -3495,9 +3543,9 @@ class ProgressService extends BaseService {
       throw new NotFoundError(`Item ${itemId} not found`);
     }
 
-    // if (item.isOptional !== true) {
-    //   throw new BadRequestError('Item is not marked as optional');
-    // }
+    if (item.isOptional !== true) {
+      throw new BadRequestError('Item is not marked as optional');
+    }
 
     // Get or create progress
 

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -1374,10 +1374,6 @@ class ProgressService extends BaseService {
     if (!watchTime.startTime || !watchTime.endTime || !item.details) {
       return false;
     }
-    // Sessions closed by the idle timer never count toward completion
-    if (watchTime.isExpired) {
-      return false;
-    }
 
     switch (item.type) {
       case 'VIDEO': {
@@ -1389,10 +1385,12 @@ class ProgressService extends BaseService {
           this.parseTimeToSeconds(videoDetails.startTime);
         if (totalVideoDuration <= 0) return false;
 
-        // Sum play time across all of this user's non-expired sessions for the
-        // item. Each session is capped at the video's own duration so re-watches
-        // can't push a partial viewer across the line. The just-closed session
-        // is included because stopItemTracking ran before this check.
+        // Sum play time across all of this user's sessions for the item
+        // (including idle-expired ones — those seconds are still honest
+        // engagement). Each session is capped at the video's own duration so
+        // re-watches and background-playback abuse can't push a partial viewer
+        // across the line. The just-closed session is included because
+        // stopItemTracking ran before this check.
         const cumulativeWatched =
           await this.progressRepository.sumWatchSecondsForItem(
             userId,

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -627,6 +627,24 @@ class ProgressService extends BaseService {
       return;
     }
 
+    // Re-opening an item the learner has already passed in sequence is allowed
+    // even if its watchTime row never recorded a clean completion.
+    const courseVersion = await this.courseRepo.readVersion(courseVersionId);
+    if (
+      courseVersion &&
+      (await this.isItemAtOrBeforeCurrent(
+        courseVersion,
+        progress.currentModule?.toString(),
+        progress.currentSection?.toString(),
+        progress.currentItem?.toString(),
+        moduleId,
+        sectionId,
+        itemId,
+      ))
+    ) {
+      return;
+    }
+
     if (
       progress.currentModule.toString() !== moduleId ||
       progress.currentSection.toString() !== sectionId ||
@@ -946,6 +964,74 @@ class ProgressService extends BaseService {
     }
 
     return null;
+  }
+
+  /**
+   * Returns true if the candidate (item) sits at-or-before the learner's
+   * current progress pointer in the course's declared module/section/item
+   * order. Used to let learners freely re-open any item they've already
+   * passed without depending on watchTime.endTime — the access predicate
+   * for completed/earlier items is positional, not watch-history-based.
+   */
+  public async isItemAtOrBeforeCurrent(
+    courseVersion: ICourseVersion,
+    currentModuleId: string,
+    currentSectionId: string,
+    currentItemId: string,
+    itemModuleId: string,
+    itemSectionId: string,
+    itemId: string,
+  ): Promise<boolean> {
+    if (!currentModuleId || !currentSectionId || !currentItemId) return false;
+    if (!itemModuleId || !itemSectionId || !itemId) return false;
+
+    if (
+      itemModuleId === currentModuleId &&
+      itemSectionId === currentSectionId &&
+      itemId === currentItemId
+    ) {
+      return true;
+    }
+
+    const sortedModules = [...courseVersion.modules].sort((a, b) =>
+      a.order.localeCompare(b.order),
+    );
+    const currentModuleIdx = sortedModules.findIndex(
+      m => m.moduleId?.toString() === currentModuleId,
+    );
+    const itemModuleIdx = sortedModules.findIndex(
+      m => m.moduleId?.toString() === itemModuleId,
+    );
+    if (currentModuleIdx === -1 || itemModuleIdx === -1) return false;
+    if (itemModuleIdx < currentModuleIdx) return true;
+    if (itemModuleIdx > currentModuleIdx) return false;
+
+    const sortedSections = [...sortedModules[currentModuleIdx].sections].sort(
+      (a, b) => a.order.localeCompare(b.order),
+    );
+    const currentSectionIdx = sortedSections.findIndex(
+      s => s.sectionId?.toString() === currentSectionId,
+    );
+    const itemSectionIdx = sortedSections.findIndex(
+      s => s.sectionId?.toString() === itemSectionId,
+    );
+    if (currentSectionIdx === -1 || itemSectionIdx === -1) return false;
+    if (itemSectionIdx < currentSectionIdx) return true;
+    if (itemSectionIdx > currentSectionIdx) return false;
+
+    const itemsGroup = await this.itemRepo.readItemsGroup(
+      sortedSections[currentSectionIdx].itemsGroupId?.toString(),
+    );
+    if (!itemsGroup?.items) return false;
+    const sortedItems = [...itemsGroup.items].sort((a, b) =>
+      a.order.localeCompare(b.order),
+    );
+    const currentItemIdx = sortedItems.findIndex(
+      i => i._id.toString() === currentItemId,
+    );
+    const itemIdx = sortedItems.findIndex(i => i._id.toString() === itemId);
+    if (currentItemIdx === -1 || itemIdx === -1) return false;
+    return itemIdx <= currentItemIdx;
   }
 
   public async getPreviousVideoItem(
@@ -2036,6 +2122,21 @@ class ProgressService extends BaseService {
       progress.currentItem?.toString() === itemId;
 
     if (isExactCurrentItem) {
+      return;
+    }
+
+    // Re-watching an earlier item in sequence is allowed without requiring its
+    // own or its predecessor's watchTime row to look clean.
+    const isAtOrBefore = await this.isItemAtOrBeforeCurrent(
+      courseVersion,
+      progress.currentModule?.toString(),
+      progress.currentSection?.toString(),
+      progress.currentItem?.toString(),
+      moduleId,
+      sectionId,
+      itemId,
+    );
+    if (isAtOrBefore) {
       return;
     }
 

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -2349,6 +2349,18 @@ class ProgressService extends BaseService {
       }
     }
 
+    // Captured inside the transaction, applied after commit. Enrollment
+    // percent + recalculate-on-completion are derived/eventually-consistent
+    // metrics that don't need the same atomicity as currentItem advancement.
+    // Keeping them outside the transaction shrinks the lock-hold window —
+    // the captured 64s stop in production logs traced to these RTTs running
+    // before the final updateProgress committed.
+    let postTxEnrollmentId: string | null = null;
+    let postTxPercentCompleted: number | null = null;
+    let postTxCompletedCount: number | null = null;
+    let postTxGuruProgress: { percentCompleted: number; completedItemsCount: number } | null = null;
+    let postTxShouldRecalc = false;
+
     await this._withTransaction(async session => {
       let shouldCountCurrentItemAsCompleted = false;
       let stoppedWatchTime: any = null;
@@ -2578,43 +2590,25 @@ class ProgressService extends BaseService {
       );
 
       // ----------------------------------------------------
-      // 9. GURU SETU OVERRIDE
+      // 9. GURU SETU OVERRIDE — capture for post-commit
       // ----------------------------------------------------
       if (
         courseId?.toString() === GURU_SETU_COURSE_ID &&
         courseVersionId?.toString() === GURU_SETU_VERSION_ID
       ) {
-        const guruProgress = await this.calculateGuruSetuProgress(
+        postTxGuruProgress = await this.calculateGuruSetuProgress(
           userId,
           courseVersionId,
-        );
-
-        await this.enrollmentRepo.updateProgressPercentById(
-          enrollment._id.toString(),
-          guruProgress.percentCompleted,
-          guruProgress.completedItemsCount,
-          cohortId,
         );
       }
 
       // ----------------------------------------------------
-      // 10. NORMAL ENROLLMENT PROGRESS UPDATE
+      // 10. NORMAL ENROLLMENT PROGRESS — capture for post-commit
       // ----------------------------------------------------
-      await this.enrollmentRepo.updateProgressPercentById(
-        enrollment._id.toString(),
-        percentCompleted,
-        completedCourseItemsCount,
-        cohortId,
-      );
-
-      if (percentCompleted > 99) {
-        await this.recalculateStudentProgress(
-          userId,
-          courseId,
-          courseVersionId,
-          cohortId,
-        );
-      }
+      postTxEnrollmentId = enrollment._id.toString();
+      postTxPercentCompleted = percentCompleted;
+      postTxCompletedCount = completedCourseItemsCount;
+      postTxShouldRecalc = percentCompleted > 99;
 
       // ----------------------------------------------------
       // 11. FINAL PROGRESS UPDATE
@@ -2628,6 +2622,45 @@ class ProgressService extends BaseService {
         session,
       );
     });
+
+    // Post-commit, best-effort. A failure here leaves the canonical progress
+    // row intact; the next stop recomputes percent from `getCompletedItems`
+    // and self-heals. Never rethrown so an enrollment-percent hiccup can't
+    // appear to the client as a stop failure.
+    if (postTxEnrollmentId !== null) {
+      try {
+        if (postTxGuruProgress) {
+          await this.enrollmentRepo.updateProgressPercentById(
+            postTxEnrollmentId,
+            postTxGuruProgress.percentCompleted,
+            postTxGuruProgress.completedItemsCount,
+            cohortId,
+          );
+        }
+        await this.enrollmentRepo.updateProgressPercentById(
+          postTxEnrollmentId,
+          postTxPercentCompleted!,
+          postTxCompletedCount!,
+          cohortId,
+        );
+        if (postTxShouldRecalc) {
+          await this.recalculateStudentProgress(
+            userId,
+            courseId,
+            courseVersionId,
+            cohortId,
+          );
+        }
+      } catch (err) {
+        console.warn('[stopItem] post-commit enrollment percent update failed', {
+          userId,
+          courseId,
+          courseVersionId,
+          itemId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 
   private validateProgressPosition(

--- a/backend/src/shared/classes/BaseService.ts
+++ b/backend/src/shared/classes/BaseService.ts
@@ -13,7 +13,14 @@ export abstract class BaseService {
     operation: (session: ClientSession) => Promise<T>,
   ): Promise<T> {
     const client = await this.db.getClient();
-    const MAX_RETRIES = 3;
+    // Five attempts with exponential backoff + jitter. The previous budget (3
+    // attempts, fixed 50/100ms) was too tight under concurrent writes from the
+    // student flow (stop + start of next item, double-clicked submit, nested
+    // save() transaction inside submit()) — competing transactions kept losing
+    // in lockstep and surfacing as 500s. Jitter breaks the lockstep; the
+    // longer total budget (~1s worst case) is invisible to the user but covers
+    // the window where contending writers finish and clear the conflict.
+    const MAX_RETRIES = 5;
     const txOptions = {
       readPreference: ReadPreference.primary,
       readConcern: new ReadConcern('snapshot'),
@@ -40,7 +47,10 @@ export abstract class BaseService {
           error?.code === 112 ||
           (typeof error?.message === 'string' && error.message.includes('Write conflict'));
         if (isTransient && attempt < MAX_RETRIES - 1) {
-          await new Promise(resolve => setTimeout(resolve, 50 * (attempt + 1)));
+          // 50, 100, 200, 400 ms base + 0–50 ms jitter.
+          const baseMs = 50 * Math.pow(2, attempt);
+          const jitterMs = Math.floor(Math.random() * 50);
+          await new Promise(resolve => setTimeout(resolve, baseMs + jitterMs));
           continue;
         }
         throw error;

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -639,13 +639,16 @@ class ProgressRepository {
     await this.init();
     const capMs = Math.max(0, capSeconds) * 1000;
 
+    // isExpired sessions (idle-timer-closed) still count: the seconds the
+    // student actually watched before stepping away are honest engagement.
+    // The cap-per-session below already prevents a "leave it playing in the
+    // background" abuse from inflating the total beyond the video's duration.
     const match: any = {
       userId: new ObjectId(userId),
       itemId: new ObjectId(itemId),
       courseId: new ObjectId(courseId),
       courseVersionId: new ObjectId(courseVersionId),
       isDeleted: { $ne: true },
-      isExpired: { $ne: true },
       startTime: { $ne: null },
     };
     if (cohortId) {

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -565,6 +565,18 @@ class ProgressRepository {
     session?: ClientSession,
   ): Promise<string | null> {
     await this.init();
+    // Close any orphaned open sessions for this (user, item) so concurrent tabs
+    // can't double-count toward the cumulative completion threshold.
+    await this.watchTimeCollection.updateMany(
+      {
+        userId: new ObjectId(userId),
+        itemId: new ObjectId(itemId),
+        endTime: { $exists: false },
+        isDeleted: { $ne: true },
+      },
+      { $set: { endTime: new Date(), isExpired: true } },
+      { session },
+    );
     const watchTime: IWatchTime = {
       userId: new ObjectId(userId),
       courseId: new ObjectId(courseId),
@@ -586,17 +598,112 @@ class ProgressRepository {
   async stopItemTracking(
     watchTimeId: string,
     session?: ClientSession,
+    watchedSeconds?: number,
+    isExpired?: boolean,
   ): Promise<IWatchTime | null> {
     await this.init();
+    const updateFields: Partial<IWatchTime> = { endTime: new Date() };
+    if (typeof watchedSeconds === 'number' && watchedSeconds >= 0) {
+      updateFields.duration = watchedSeconds;
+    }
+    if (isExpired === true) {
+      updateFields.isExpired = true;
+    }
     const result = await this.watchTimeCollection.findOneAndUpdate(
       {
         _id: new ObjectId(watchTimeId),
         isDeleted: { $ne: true },
       },
-      { $set: { endTime: new Date() } },
+      { $set: updateFields },
       { returnDocument: 'after', session },
     );
     return result;
+  }
+
+  /**
+   * Sum the cumulative play seconds for an item across all of a user's
+   * non-expired, soft-undeleted watch records. Each record contributes
+   * `min(record_seconds, capSeconds)` so re-watches don't inflate the total
+   * past the video's own duration. Prefers the client-reported `duration`
+   * field; falls back to wall-clock (endTime − startTime) for legacy records.
+   */
+  async sumWatchSecondsForItem(
+    userId: string | ObjectId,
+    itemId: string,
+    courseId: string,
+    courseVersionId: string,
+    capSeconds: number,
+    cohortId?: string,
+    session?: ClientSession,
+  ): Promise<number> {
+    await this.init();
+    const capMs = Math.max(0, capSeconds) * 1000;
+
+    const match: any = {
+      userId: new ObjectId(userId),
+      itemId: new ObjectId(itemId),
+      courseId: new ObjectId(courseId),
+      courseVersionId: new ObjectId(courseVersionId),
+      isDeleted: { $ne: true },
+      isExpired: { $ne: true },
+      startTime: { $ne: null },
+    };
+    if (cohortId) {
+      match.cohortId = new ObjectId(cohortId);
+    } else {
+      match.$or = [
+        { cohortId: null },
+        { cohortId: { $exists: false } },
+      ];
+    }
+
+    const result = await this.watchTimeCollection
+      .aggregate<{ totalMs: number }>(
+        [
+          { $match: match },
+          {
+            $project: {
+              effectiveMs: {
+                $let: {
+                  vars: {
+                    raw: {
+                      $cond: [
+                        { $and: [{ $ne: ['$duration', null] }, { $gte: ['$duration', 0] }] },
+                        { $multiply: ['$duration', 1000] },
+                        {
+                          $cond: [
+                            { $ne: ['$endTime', null] },
+                            { $subtract: ['$endTime', '$startTime'] },
+                            0,
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                  in: {
+                    $cond: [
+                      { $gt: ['$$raw', 0] },
+                      { $min: ['$$raw', capMs] },
+                      0,
+                    ],
+                  },
+                },
+              },
+            },
+          },
+          {
+            $group: {
+              _id: null,
+              totalMs: { $sum: '$effectiveMs' },
+            },
+          },
+        ],
+        { session },
+      )
+      .toArray();
+
+    const totalMs = result[0]?.totalMs ?? 0;
+    return totalMs / 1000;
   }
 
   async getWatchTime(

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -458,6 +458,11 @@ export interface IWatchTime {
   startTime: Date;
   endTime?: Date;
   cohortId?: ID;
+  /** Actual seconds the video was playing in this session (set at stop time) */
+  duration?: number;
+  /** True when the session was closed because the idle timer fired, not normal stop */
+  isExpired?: boolean;
+  isDeleted?: boolean;
 }
 
 export interface ICohort {

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -2145,37 +2145,52 @@ useEffect(() => {
 
                 {/* Notification Stack */}
                 <div className="fixed top-6 right-6 z-50 flex flex-col gap-2 w-90 ">
-                  {/* ✅ Item Access Error Notification */}
-                  {isItemForbidden && (
-                    <Card className="border border-red-400/40 bg-red-600/95 text-red-50 shadow-lg backdrop-blur-md animate-in slide-in-from-right-3 duration-300">
-                      <CardContent className="flex items-center gap-3 px-4 py-0">
-                        <div className="flex h-22 w-22 items-center justify-center rounded-l border-red-50/30 bg-red-50/10 text-4xl p-4">
-                          <AlertCircle className="h-16 w-16" />
-                        </div>
-                        <div className="flex-1 space-y-1">
-                          <Badge variant="outline" className="border-red-50/30 bg-red-50/10 text-red-50 text-lg font-bold">
-                            Access Restricted
-                          </Badge>
-                          <p className="text-md font-medium leading-relaxed">
-                            {itemError && itemErrorName === "ForbiddenError"
-                              ? itemError
-                              : previousValidItem
-                                ? "Returning to previous valid content."
-                                : "Complete current item first to access this content."
-                            }
-                          </p>
-                        </div>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setIsItemForbidden(false)}
-                          className="h-6 w-6 p-0 text-red-50 hover:bg-red-50/10"
-                        >
-                          ×
-                        </Button>
-                      </CardContent>
-                    </Card>
-                  )}
+                  {/* Item Not Completed Notification.
+                      currentItem still points at the previous (incomplete) item here:
+                      a 403 leaves itemData undefined, so setCurrentItem() doesn't run. */}
+                  {isItemForbidden && (() => {
+                    const itemKind =
+                      currentItem?.type === 'VIDEO' ? 'video'
+                      : currentItem?.type === 'QUIZ' ? 'quiz'
+                      : currentItem?.type === 'BLOG' ? 'reading'
+                      : currentItem?.type === 'PROJECT' ? 'project'
+                      : 'item';
+                    const isPrerequisiteBlock =
+                      itemErrorName === 'ForbiddenError' &&
+                      typeof itemError === 'string' &&
+                      itemError.toLowerCase().includes("don't have permission to watch");
+                    const heading = isPrerequisiteBlock
+                      ? `${itemKind.charAt(0).toUpperCase() + itemKind.slice(1)} not completed`
+                      : 'Cannot open this item';
+                    const body = isPrerequisiteBlock
+                      ? `Please complete the current ${itemKind} item before moving to the next one.`
+                      : (itemError || `Please complete the current ${itemKind} item before moving to the next one.`);
+                    return (
+                      <Card className="border border-amber-400/40 bg-amber-600/95 text-amber-50 shadow-lg backdrop-blur-md animate-in slide-in-from-right-3 duration-300">
+                        <CardContent className="flex items-center gap-3 px-4 py-0">
+                          <div className="flex h-22 w-22 items-center justify-center rounded-l border-amber-50/30 bg-amber-50/10 text-4xl p-4">
+                            <AlertCircle className="h-16 w-16" />
+                          </div>
+                          <div className="flex-1 space-y-1">
+                            <Badge variant="outline" className="border-amber-50/30 bg-amber-50/10 text-amber-50 text-lg font-bold">
+                              {heading}
+                            </Badge>
+                            <p className="text-md font-medium leading-relaxed">
+                              {body}
+                            </p>
+                          </div>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setIsItemForbidden(false)}
+                            className="h-6 w-6 p-0 text-amber-50 hover:bg-amber-50/10"
+                          >
+                            ×
+                          </Button>
+                        </CardContent>
+                      </Card>
+                    );
+                  })()}
 
                   {/* Gesture Notification */}
                   {doGesture && currentItem?.type !== 'VIDEO' && (

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -187,8 +187,24 @@ export default function CoursePage() {
   // ✅ Add the missing ref declaration
   const itemContainerRef = useRef<ItemContainerRef>(null);
 
-  // Ref for autoscroll to selected sidebar item
+  // Ref for autoscroll to selected sidebar item. Uses a callback ref so we
+  // scroll the moment the active row mounts — selectedItemId often updates
+  // before its section items have been fetched/rendered, so a useEffect on
+  // [selectedItemId] runs while the ref is still null.
   const selectedItemRef = useRef<HTMLButtonElement | null>(null);
+  const lastScrolledItemIdRef = useRef<string | null>(null);
+  const setSelectedItemRef = useCallback((node: HTMLButtonElement | null) => {
+    selectedItemRef.current = node;
+    if (!node) return;
+    const itemId = node.dataset.itemId;
+    if (!itemId || lastScrolledItemIdRef.current === itemId) return;
+    lastScrolledItemIdRef.current = itemId;
+    // One frame of slack lets the surrounding collapsibles finish painting
+    // before we ask the browser to scroll the row into view.
+    requestAnimationFrame(() => {
+      node.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+  }, []);
 
   // Helper function to update course store navigation state
   const updateCourseNavigation = useCallback((moduleId: string, sectionId: string, itemId: string) => {
@@ -1659,13 +1675,6 @@ useEffect(() => {
 
 
 
-  // Autoscroll to selected sidebar item when selectedItemId changes
-  useEffect(() => {
-    if (selectedItemRef.current) {
-      selectedItemRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
-  }, [selectedItemId]);
-
   useEffect(() => {
     refetchVersion();
   }, [courseVersionData]);
@@ -1914,8 +1923,10 @@ useEffect(() => {
                                                     onClick={() => handleSelectItem(moduleId, sectionId, itemId)}
                                                     isActive={isCurrentItem}
                                                     className="group relative h-8 px-3 w-full rounded-md transition-all duration-200 hover:bg-accent/10 dark:data-[state=active]:bg-primary/10 data-[state=active]:bg-primary/10 data-[state=active]:text-primary justify-start"
-                                                    // Assign ref only to the selected item for autoscroll
-                                                    ref={isCurrentItem ? selectedItemRef : undefined}
+                                                    data-item-id={itemId}
+                                                    // Callback ref scrolls when the active row mounts, regardless of
+                                                    // when selectedItemId vs. items-list arrival happens.
+                                                    ref={isCurrentItem ? setSelectedItemRef : undefined}
                                                   >
                                                     <div className="flex items-center gap-2 w-full min-w-0">
                                                       <div className={`p-0.5 rounded transition-colors flex-shrink-0 ${isCurrentItem

--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -196,6 +196,37 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
 
   const wasPlayingBeforeTabSwitch = useRef(false);
 
+  // Tracks actual seconds the video was playing in the current watch session,
+  // not wall-clock. Backend uses this (capped per session at video duration)
+  // to compute cumulative engagement vs. the 40% completion threshold.
+  const playedSecondsRef = useRef(0);
+  const playStartTimestampRef = useRef<number | null>(null);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+  const onPlayStart = () => {
+    playStartTimestampRef.current = Date.now();
+    if (idleTimerRef.current) {
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = null;
+    }
+  };
+
+  const onPlayPause = () => {
+    if (playStartTimestampRef.current !== null) {
+      playedSecondsRef.current += (Date.now() - playStartTimestampRef.current) / 1000;
+      playStartTimestampRef.current = null;
+    }
+  };
+
+  const getPlayedSeconds = () => {
+    let total = playedSecondsRef.current;
+    if (playStartTimestampRef.current !== null) {
+      total += (Date.now() - playStartTimestampRef.current) / 1000;
+    }
+    return Math.round(total);
+  };
+
 
   useEffect(() => {
     watchTimeTrackRef.current = watchTimeTrack;
@@ -444,7 +475,7 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
   };
 
   //  function to handle stop with debouncing and retry logic
-  const handleStopItem = useCallback(async (watchItemId: string | null, debounceMs: number = 0): Promise<boolean> => {
+  const handleStopItem = useCallback(async (watchItemId: string | null, debounceMs: number = 0, isExpired: boolean = false): Promise<boolean> => {
     // Clear any pending stop request
     if (stopTimeoutRef.current) {
       clearTimeout(stopTimeoutRef.current);
@@ -491,6 +522,8 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
                     seekForwardEnabled,
                     nextItemId,
                     cohortId: currentCourse!.cohortId ?? '',
+                    watchedSeconds: getPlayedSeconds(),
+                    isExpired,
                   },
                   signal: abortController.signal,
                 } as any);
@@ -770,6 +803,9 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
   function handleSendStartItem() {
 
     if (!currentCourse?.itemId) return;
+    // Reset the play-time counter for this fresh session
+    playedSecondsRef.current = 0;
+    playStartTimestampRef.current = null;
     if (!isAlreadyWatched && !completedItemIdsRef.current.has(currentCourse!.itemId) && !isCompleted) {
       startItem.mutate({
         params: {
@@ -859,6 +895,7 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
           onStateChange: async (event: { data: number; target: YTPlayerInstance }) => {
             if (window.YT && event.data === window.YT.PlayerState.PLAYING) {
               setPlaying(true);
+              onPlayStart();
               if (!progressStartedRef.current) {
                 handleSendStartItem();
                 setVideoEnded(false);
@@ -870,6 +907,8 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
               }, 500);
             } else if (window.YT && event.data === window.YT.PlayerState.ENDED) {
               setPlaying(false);
+              onPlayPause();
+              if (idleTimerRef.current) { clearTimeout(idleTimerRef.current); idleTimerRef.current = null; }
               setVideoEnded(true);
               if (!progressStoppedRef.current && currentCourse) {
                 const watchItemId = watchItemIdRef.current || currentCourse.watchItemId;
@@ -895,6 +934,23 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
               }
             } else {
               setPlaying(false);
+              onPlayPause();
+              // Start idle expiry countdown — if the user pauses and walks away,
+              // we close the session as expired so it doesn't count toward completion.
+              if (!progressStoppedRef.current) {
+                if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+                idleTimerRef.current = setTimeout(async () => {
+                  const watchItemId = watchItemIdRef.current || currentCourse?.watchItemId;
+                  if (watchItemId && !progressStoppedRef.current) {
+                    await handleStopItem(watchItemId, 0, true /* isExpired */);
+                    progressStartedRef.current = false;
+                    progressStoppedRef.current = false;
+                    watchItemIdRef.current = null;
+                    playedSecondsRef.current = 0;
+                    playStartTimestampRef.current = null;
+                  }
+                }, IDLE_TIMEOUT_MS);
+              }
             }
           },
         },
@@ -915,6 +971,11 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
   if (stopTimeoutRef.current) {
     clearTimeout(stopTimeoutRef.current);
     stopTimeoutRef.current = null;
+  }
+  // Clear pending idle expiry timer so it doesn't fire after unmount
+  if (idleTimerRef.current) {
+    clearTimeout(idleTimerRef.current);
+    idleTimerRef.current = null;
   }
     // Stop if started but not yet stopped (immediate on unmount, no debounce)
   // if (!progressStoppedRef.current && !stopInFlightRef.current && watchItemIdRef.current && currentCourse) {


### PR DESCRIPTION
Three independent fixes for the student course player.

## Commits

- **Sidebar autoscroll** — replace `useRef + useEffect([selectedItemId])` with a callback ref so the active row scrolls into view the moment its DOM node mounts (the effect was firing before section items had been fetched, so the ref was still null).
- **Positional access bypass** — new `isItemAtOrBeforeCurrent` helper walks the course's declared module → section → item order. Wired into `ItemService.readItem`, `verifyProgress`, and `validateProgressPositionOrPreviousCompleted` as a bypass: any item at-or-before `progress.currentItem` is freely accessible regardless of `watchTime.endTime`. Forward-jump path unchanged.
- **stopItem transaction shrink** — move the two `enrollmentRepo.updateProgressPercentById` writes (which never passed `session` anyway) and the conditional `recalculateStudentProgress` out of `_withTransaction`, run them post-commit in a `try/catch + warn-log`. Production logs showed a 64s stop holding the session lock because of these RTTs to Atlas, opening a race with concurrent `GET /item/...`. Enrollment percent is now eventually consistent (writes are absolute, self-heal on next stop).

## Test required

- [ ] Sidebar auto-centers the active item on course load.
- [ ] Click an earlier completed video → loads without 403.
- [ ] Stop a video → no `WriteConflict` surfaces; latency well under prior 64s.
- [ ] Quiz pass and quiz fail reattempt flows still work.
- [ ] GURU_SETU course percent still updates (now post-commit, best-effort).
