### PR TITLE
fix(progression): allow next-after-current in CASL when current is co…

### DIFF
--- a/backend/src/modules/courses/abilities/itemAbilities.ts
+++ b/backend/src/modules/courses/abilities/itemAbilities.ts
@@ -125,6 +125,24 @@ export async function setupItemAbilities(
             allowedItemIds.push(currentItemId);
           }
 
+          // If the learner has actually completed the current item, allow the
+          // immediate next visible item too — mirrors the linear-progression
+          // intent of "complete current → unlock next" at the CASL layer, so
+          // the controller doesn't 403 a forward-by-one navigation that
+          // ItemService.readItem path 4 (previousItemCompleted) would itself
+          // grant.
+          if (completedItemsStr.includes(currentItemId)) {
+            const nextId = await progressService.getNextItemIdAfterCurrent(
+              enrollment.versionId,
+              progress.currentModule?.toString?.(),
+              progress.currentSection?.toString?.(),
+              currentItemId,
+            );
+            if (nextId && !allowedItemIds.includes(nextId)) {
+              allowedItemIds.push(nextId);
+            }
+          }
+
           // Mirror ItemService.readItem's position-walk bypass at the CASL
           // layer: every item positionally at-or-before the learner's pointer
           // is freely accessible, regardless of whether its watchTime row

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -4061,6 +4061,33 @@ class ProgressService extends BaseService {
   }
 
   /**
+   * Convenience wrapper around getNextItemInSequence that loads the course
+   * version itself. Returns the next visible item ID (or null), so callers
+   * that don't already have the courseVersion object — like the CASL ability
+   * builder — can ask "what's the natural next item after this pointer?"
+   * without duplicating the load.
+   */
+  async getNextItemIdAfterCurrent(
+    courseVersionId: string,
+    currentModuleId: string,
+    currentSectionId: string,
+    currentItemId: string,
+  ): Promise<string | null> {
+    if (!courseVersionId || !currentModuleId || !currentSectionId || !currentItemId) {
+      return null;
+    }
+    const courseVersion = await this.courseRepo.readVersion(courseVersionId);
+    if (!courseVersion) return null;
+    const next = await this.getNextItemInSequence(
+      courseVersion,
+      currentModuleId,
+      currentSectionId,
+      currentItemId,
+    );
+    return next?.itemId ?? null;
+  }
+
+  /**
    * Returns every item ID positionally at-or-before (currentModuleId,
    * currentSectionId, currentItemId) in the course version's declared
    * module → section → item order. Used by the CASL ability builder to


### PR DESCRIPTION
The CASL allow-list returns only items at-or-before the learner's pointer (plus completedItems). When the frontend auto-advances after a completed video to the next quiz, the next item sits forward of the pointer → CASL rejects with "view this item" before ItemService.readItem can run path 4 (previousItemCompleted), which would have granted access and advanced the pointer.

Fix: when currentItem is in completedItems, also add getNextItemIdAfterCurrent to the allow-list. Mirrors the linear-progression intent of "complete current → unlock next" at the CASL layer. Hidden items are skipped via getNextItemInSequence's existing filter.

Adds a small wrapper getNextItemIdAfterCurrent on ProgressService so the ability builder doesn't have to load the courseVersion itself.

Surgically reapplies the backend-only portion of the reverted PR #998 — specifically the sub-commit "fix(progression): allow next-after-current in CASL when current is completed". Frontend stop-tx wiring from #998 is intentionally NOT included; this commit isolates the access fix.

