### PR TITLE
feat: add progress validation to quiz submission flow

### DIFF
--- a/backend/src/modules/quizzes/classes/validators/QuizValidator.ts
+++ b/backend/src/modules/quizzes/classes/validators/QuizValidator.ts
@@ -1627,8 +1627,9 @@ export interface QuestionAnswersBodydto {
   courseVersionId?: string;
   watchItemId?: string;
   cohortId?: string;
+  moduleId?: string;
+  sectionId?: string;
 }
-
 
 export {
   CreateAttemptParams,

--- a/backend/src/modules/quizzes/controllers/AttemptController.ts
+++ b/backend/src/modules/quizzes/controllers/AttemptController.ts
@@ -224,7 +224,7 @@ class AttemptController {
         req.on('error', err => reject(err));
       },
     );
-    const {isSkipped, answers, courseId, courseVersionId, watchItemId, cohortId} = body;
+    const { isSkipped, answers, courseId, courseVersionId, watchItemId, cohortId, moduleId, sectionId } = body;
     const userId = user._id.toString();
     // Build subject context first
     const attemptSubject = subject('Attempt', {quizId});
@@ -245,6 +245,8 @@ class AttemptController {
         courseVersionId,
         watchItemId,
         cohortId,
+        moduleId,
+        sectionId,
       );
       return result as SubmitAttemptResponse;
     } catch (error: any) {

--- a/backend/src/modules/quizzes/services/AttemptService.ts
+++ b/backend/src/modules/quizzes/services/AttemptService.ts
@@ -425,7 +425,9 @@ class AttemptService extends BaseService {
     courseId?: string,
     courseVersionId?: string,
     watchItemId?: string,
-    cohortId?: string
+    cohortId?: string,
+    moduleId?: string,
+    sectionId?: string,
   ): Promise<Partial<IGradingResult> | null> {
     /* -------------------- READS OUTSIDE TRANSACTION -------------------- */
 
@@ -455,6 +457,33 @@ class AttemptService extends BaseService {
       throw new BadRequestError(
         `Attempt with ID ${attemptId} has already been submitted`,
       );
+    }
+
+    // 3. Progress validation - check if current item matches progress or previous item is completed
+    if (courseId && courseVersionId && moduleId && sectionId) {
+      const [progress, courseVersion] = await Promise.all([
+        this.progressRepository.findProgress(
+          userId.toString(),
+          courseId,
+          courseVersionId,
+          cohortId,
+        ),
+        this.courseRepo.readVersion(courseVersionId),
+      ]);
+
+      if (progress && courseVersion) {
+        await this.progressService.validateItemAccess(
+          progress,
+          courseVersion,
+          userId.toString(),
+          courseId,
+          courseVersionId,
+          moduleId,
+          sectionId,
+          quizId,
+          cohortId,
+        );
+      }
     }
 
     /* -------------------- TRANSACTION (STATE MUTATION ONLY) -------------------- */

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -2033,6 +2033,30 @@ class ProgressService extends BaseService {
   //   }
   // }
 
+  public async validateItemAccess(
+    progress: IProgress,
+    courseVersion: any,
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    moduleId: string,
+    sectionId: string,
+    itemId: string,
+    cohortId?: string,
+  ): Promise<void> {
+    await this.validateProgressPositionOrPreviousCompleted(
+      progress,
+      courseVersion,
+      userId,
+      courseId,
+      courseVersionId,
+      moduleId,
+      sectionId,
+      itemId,
+      cohortId,
+    );
+  }
+  
   private async validateProgressPositionOrPreviousCompleted(
     progress: IProgress,
     courseVersion: any,

--- a/frontend/src/components/quiz.tsx
+++ b/frontend/src/components/quiz.tsx
@@ -713,7 +713,9 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
           answers: answersForSubmission, isSkipped, courseId: currentCourse?.courseId,
           courseVersionId: currentCourse?.versionId,
           watchItemId: currentCourse?.watchItemId ?? undefined,
-          cohortId: currentCourse?.cohortId??''
+          cohortId: currentCourse?.cohortId??'',
+          moduleId: currentCourse?.moduleId ?? '',
+          sectionId: currentCourse?.sectionId ?? '',
         }
       };
 


### PR DESCRIPTION
Changes:
Added moduleId and sectionId to QuestionAnswersBodydto
Updated frontend submit payload in quiz.tsx to send moduleId and sectionId
Updated AttemptController to extract and pass these fields to the service
Added moduleId and sectionId to AttemptService.submit method signature
Added progress validation block in AttemptService.submit before the transaction
Created public wrapper method validateItemAccess in ProgressService to expose the existing private validateProgressPositionOrPreviousCompleted method
