### PR TITLE
Fix/duplicate settings menu item

### DIFF
--- a/frontend/src/app/pages/teacher/course-page.tsx
+++ b/frontend/src/app/pages/teacher/course-page.tsx
@@ -1730,6 +1730,7 @@ function VersionCard({
                           setShowProctoringModal(true);
                         }}
                         disabled={isArchived}
+                        title={isArchived ? "Cannot open settings for archived version" : undefined}
                       >
                         <Settings2 className="mr-2 h-4 w-4" />
                         Settings
@@ -1737,17 +1738,6 @@ function VersionCard({
                       <DropdownMenuItem onClick={configureCohorts}>
                         <Layers className="mr-2 h-4 w-4" />
                         Configure Cohorts
-                      </DropdownMenuItem>
-
-                      <DropdownMenuItem onClick={(e) => {
-                        e.stopPropagation()
-                        setShowProctoringModal(true)
-                      }}
-                        disabled={isArchived}
-                        title={isArchived ? "Cannot open settings for archived version" : undefined}
-                      >
-                        <Settings2 className="h-4 w-4 mr-2" />
-                        Settings
                       </DropdownMenuItem>
 
                       <DropdownMenuItem onClick={viewAnomalies}>


### PR DESCRIPTION
## Summary
- The Manage section of the course version card's three-dots menu rendered the **Settings** (Proctoring Settings) item twice
- Removed the duplicate; kept the entry in its natural position next to **Ejection Policies** and **Configure Cohorts**
- Carried over the archived-state tooltip (`"Cannot open settings for archived version"`) from the deleted duplicate so no behavior is lost

## Before / After
**Before** — Manage section: Ejection Policies → Settings → Configure Cohorts → **Settings** → View Anomalies
**After**  — Manage section: Ejection Policies → Settings → Configure Cohorts → View Anomalies

## Files changed
- `frontend/src/app/pages/teacher/course-page.tsx`

