### PR TITLE
Update Course Progression UI & Lock Configuration

### DIFF
--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -399,7 +399,7 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
 
     if (itemError && selectedItemId && itemErrorName === "ForbiddenError") {
 
-      toast.error(itemError);
+      // toast.error(itemError);
       // Clear loading state on error
       setIsNavigatingToNext(false);
       setIsItemForbidden(true);
@@ -2028,6 +2028,7 @@ useEffect(() => {
                           <AlertCircle className="h-16 w-16" />
                         </div>
                         <div className="flex-1 space-y-1">
+                          {/* 
                           <Badge variant="outline" className="border-red-50/30 bg-red-50/10 text-red-50 text-lg font-bold">
                             Access Restricted
                           </Badge>
@@ -2038,6 +2039,13 @@ useEffect(() => {
                                 ? "Returning to previous valid content."
                                 : "Complete current item first to access this content."
                             }
+                          </p>
+                          */}
+                          <Badge variant="outline" className="border-red-50/30 bg-red-50/10 text-red-50 text-lg font-bold">
+                            Lesson Locked
+                          </Badge>
+                          <p className="text-md font-medium leading-relaxed">
+                            ViBe lessons unlock in order, so you build each concept on the previous one. Please finish your current lesson to continue.
                           </p>
                         </div>
                         <Button

--- a/frontend/src/components/EditProctoringModal.tsx
+++ b/frontend/src/components/EditProctoringModal.tsx
@@ -219,7 +219,7 @@ export function ProctoringModal({
                     </div>
                     <Switch checked={linearProgressionEnabled}
                      onCheckedChange={()=>setLinearProgressionEnabled(prev=>!prev)}
-                    //  disabled 
+                     disabled 
                      />
                   </div>
 


### PR DESCRIPTION
# Pull Request: Update Course Progression UI & Lock Configuration

## 🎯 What this PR does
This PR updates the student experience when interacting with locked course items and strictly enforces linear progression on the instructor side by locking the configuration toggle.

## 🛠️ Changes Made
1. **Locked "Linear Course Progression" Toggle (`EditProctoringModal.tsx`)**
   - Disabled the toggle switch on the instructor configuration screen (`disabled={true}`) so that instructors can no longer accidentally turn off linear progression for a course.

2. **Improved Student "Lesson Locked" Notification (`course-page.tsx`)**
   - Removed the generic duplicate toast notification (`toast.error`) that was firing alongside the custom top-right alert.
   - Replaced the generic "Access Restricted" UI with a more informative message: 
     > **Lesson Locked**
     > *ViBe lessons unlock in order, so you build each concept on the previous one. Please finish your current lesson to continue.*
   - **Note:** The previous alert template and logic were kept in the file as comments for reference.

## 🧪 How to Test
1. **Instructor Dashboard:** Go to a course's Additional Settings and verify that the "Linear Course Progression" toggle is visible but unclickable.
2. **Student Player:** Enter a course as a student, ensure Linear Progression is on, and attempt to click a future, uncompleted item in the sidebar. Verify that only the custom top-right "Lesson Locked" alert appears with the new instructional text.
