### PR TITLE
Resolve Lesson Locked Edge Cases for Standard Courses

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -766,6 +766,9 @@ class ProgressService extends BaseService {
     const itemsGroup = await this.itemRepo.readItemsGroup(
       itemsGroupId?.toString(),
     );
+    if (itemsGroup && itemsGroup.items) {
+      itemsGroup.items = itemsGroup.items.filter((i: any) => !i.isHidden && !i.isDeleted);
+    }
     const sortedItems = itemsGroup.items.sort((a, b) =>
       a.order.localeCompare(b.order),
     );
@@ -791,6 +794,9 @@ class ProgressService extends BaseService {
       const itemsGroup = await this.itemRepo.readItemsGroup(
         firstSection?.itemsGroupId.toString(),
       );
+      if (itemsGroup && itemsGroup.items) {
+        itemsGroup.items = itemsGroup.items.filter((i: any) => !i.isHidden && !i.isDeleted);
+      }
       const firstItem = itemsGroup.items.sort((a, b) =>
         a.order.localeCompare(b.order),
       )[0];
@@ -812,6 +818,9 @@ class ProgressService extends BaseService {
       const itemsGroup = await this.itemRepo.readItemsGroup(
         nextSection?.itemsGroupId.toString(),
       );
+      if (itemsGroup && itemsGroup.items) {
+        itemsGroup.items = itemsGroup.items.filter((i: any) => !i.isHidden && !i.isDeleted);
+      }
       const firstItem = itemsGroup.items.sort((a, b) =>
         a.order.localeCompare(b.order),
       )[0];
@@ -879,6 +888,9 @@ class ProgressService extends BaseService {
     const itemsGroup = await this.itemRepo.readItemsGroup(
       itemsGroupId?.toString(),
     );
+    if (itemsGroup && itemsGroup.items) {
+      itemsGroup.items = itemsGroup.items.filter((i: any) => !i.isHidden && !i.isDeleted);
+    }
     const sortedItems = itemsGroup.items.sort((a, b) =>
       a.order.localeCompare(b.order),
     );
@@ -902,6 +914,9 @@ class ProgressService extends BaseService {
       const itemsGroup = await this.itemRepo.readItemsGroup(
         lastSection?.itemsGroupId.toString(),
       );
+      if (itemsGroup && itemsGroup.items) {
+        itemsGroup.items = itemsGroup.items.filter((i: any) => !i.isHidden && !i.isDeleted);
+      }
       const lastItem = itemsGroup.items.sort((a, b) =>
         a.order.localeCompare(b.order),
       )[itemsGroup.items.length - 1];
@@ -921,6 +936,9 @@ class ProgressService extends BaseService {
       const itemsGroup = await this.itemRepo.readItemsGroup(
         prevSection?.itemsGroupId?.toString(),
       );
+      if (itemsGroup && itemsGroup.items) {
+        itemsGroup.items = itemsGroup.items.filter((i: any) => !i.isHidden && !i.isDeleted);
+      }
       const lastItem = itemsGroup?.items?.sort((a, b) =>
         a.order.localeCompare(b.order),
       )[itemsGroup.items.length - 1];
@@ -1015,6 +1033,8 @@ class ProgressService extends BaseService {
     );
 
     if (!itemsGroup?.items?.length) return null;
+    itemsGroup.items = itemsGroup.items.filter((i: any) => !i.isHidden && !i.isDeleted);
+    if (!itemsGroup.items.length) return null;
 
     const sortedItems = [...itemsGroup.items].sort((a, b) =>
       a.order.localeCompare(b.order),
@@ -2993,13 +3013,40 @@ class ProgressService extends BaseService {
     //  and as the stop item is not called for that quiz endtime will never be created
     // Only mark quiz as completed (set endTime) if it was actually passed
     if (isPassed) {
-      if (!watchItemId) {
-        throw new BadRequestError('Watch item ID is required to stop tracking');
+      let resolvedWatchItemId = watchItemId;
+
+      if (!resolvedWatchItemId) {
+        // Look up the most recent active watch time for this user and item
+        const activeWatchTimes = await this.progressRepository.getWatchTime(
+          userId.toString(),
+          quizId,
+          courseId,
+          courseVersionId,
+          cohortId,
+        );
+        
+        if (activeWatchTimes && activeWatchTimes.length > 0) {
+          // Find one that doesn't have an endTime
+          const active = activeWatchTimes.find(wt => !wt.endTime);
+          if (active) {
+            resolvedWatchItemId = active._id?.toString();
+          } else {
+             // If all are stopped, fallback to the latest one
+            resolvedWatchItemId = activeWatchTimes[activeWatchTimes.length - 1]._id?.toString();
+          }
+        }
       }
+
+      if (!resolvedWatchItemId) {
+        console.warn(`[handleQuizeProgressAfterSubmission] Could not resolve watchItemId for user ${userId} and quiz ${quizId}.`);
+        // If we really can't find it, we skip stopping the item.
+        return;
+      }
+
       const watchTime = await this.progressRepository.findWatchTimeById(
-        watchItemId
+        resolvedWatchItemId
       );
-      if (watchTime.itemId.toString() !== quizId) {
+      if (watchTime && watchTime.itemId.toString() !== quizId) {
         throw new BadRequestError('Watch item does not correspond to the quiz');
       }
       const isItemCompleted = await this.progressRepository.isItemCompleted(
@@ -3010,9 +3057,9 @@ class ProgressService extends BaseService {
         cohortId,
       )
 
-      if (!isItemCompleted && watchItemId) {
+      if (!isItemCompleted && resolvedWatchItemId) {
         await this.progressRepository.stopItemTracking(
-          watchItemId,
+          resolvedWatchItemId,
         );
       }
     }

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -168,19 +168,37 @@ class ProgressRepository {
     //   { session, limit: 1 },
     // );
     // } else{
-    const  existing = await this.watchTimeCollection.findOne(
+    let existing = await this.watchTimeCollection.findOne(
         {
           userId: new ObjectId(userId),
           courseId: new ObjectId(courseId),
           courseVersionId: new ObjectId(courseVersionId),
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
+          ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
           itemId: new ObjectId(itemId),
           endTime: { $exists: true, $ne: null },
           isDeleted: { $ne: true },
         },
         { session, limit: 1 },
       );
-    // }
+
+    // Fallback: If not found with cohortId, try without cohortId in case of legacy progress
+    if (!existing && cohortId) {
+      existing = await this.watchTimeCollection.findOne(
+        {
+          userId: new ObjectId(userId),
+          courseId: new ObjectId(courseId),
+          courseVersionId: new ObjectId(courseVersionId),
+          $or: [
+            { cohortId: null },
+            { cohortId: { $exists: false } }
+          ],
+          itemId: new ObjectId(itemId),
+          endTime: { $exists: true, $ne: null },
+          isDeleted: { $ne: true },
+        },
+        { session, limit: 1 },
+      );
+    }
 
     return existing !== null;
   }

--- a/frontend/src/components/article.tsx
+++ b/frontend/src/components/article.tsx
@@ -155,8 +155,9 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
             }
 
             onNext?.(); //  only after stop succeeds
-        } catch (err) {
-            toast.error('Unable to save progress. Please try again.');
+        } catch (err: any) {
+            // toast.error('Unable to save progress. Please try again.');
+            toast.warning(err.response?.data?.message || 'You must spend more time reading this article to proceed.');
             console.error('Stop item failed:', err);
         } finally {
             setIsStopping(false);

--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -404,7 +404,8 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
         } catch (err: any) {
           console.error('Stop item failed:', err);
           progressStoppedRef.current = true; // Prevent infinite retries
-          toast.warning('Unable to save progress.');
+          // toast.warning('Unable to save progress.');
+          toast.warning(err.response?.data?.message || 'You must watch at least 30 seconds of this video to proceed.');
           setIsStopFailed(true);
           resolve(false);
 


### PR DESCRIPTION
# Pull Request: Resolve Lesson Locked Edge Cases for Standard Courses

## Description
This PR addresses several critical edge cases that caused students to be incorrectly blocked by the "Lesson Locked" error in courses that have linear progression enabled. It improves system resilience against lost frontend state, legacy data formats, extreme fast-forwarding behaviors, and corrupted course sequences.

## Root Causes & Fixes

### 1. Corrupted Sequence Traversal (Hidden/Deleted Items)
**Issue:** When a student completed a lesson, the backend attempted to unlock the next item in the sequence. However, if the "next" item was logically hidden or deleted from the course, the system would still consider it the required next step. Because the student couldn't access or complete the ghost item, the subsequent visible lesson would remain perpetually locked.
**Fix:** In `ProgressService.ts`, the sequence traversal methods (`getNextItemInSequence`, `getPreviousItemInSequence`, and `getFirstItemInSequence`) were updated to proactively filter out any items where `isDeleted === true` or `isHidden === true`. The system now correctly bridges the gap over invisible items, allowing seamless linear progression.

### 2. Watch Time Validation Failures (Frontend Warning)
**Issue:** If a student finishes an article in less than 10 seconds or skips through a video so quickly that the total elapsed time is under 30 seconds (or 15%), the backend accurately throws a `400 Bad Request` to prevent sequence progression. However, the frontend simply showed an ambiguous "Unable to save progress" message, causing confusion.
**Fix:** The backend validation remains intact to ensure academic integrity. The frontend (`video.tsx` and `article.tsx`) has been updated to explicitly capture the 400 response message and inform the user why they cannot proceed (e.g., "You must watch at least 30 seconds of this video to proceed"). 
*Note: The old generic toast message was commented out to preserve historical implementation context.*

### 3. Auto-Resolving Quiz `watchItemId` (Backend Fallback)
**Issue:** When a student starts a quiz, the backend creates a `watchItemId` which the frontend holds in memory. If a student refreshed the page during the quiz, they lost this ID. Submitting the quiz without the ID caused the backend to crash out and fail to mark the item complete.
**Fix:** In `ProgressService.ts`, the `handleQuizeProgressAfterSubmission` function now includes an auto-resolve fallback. If the frontend forgets to send the `watchItemId`, the backend will proactively query the database to find the latest active (un-stopped) `watchTime` for that student and quiz, ensuring progress is correctly tracked regardless of a page refresh.

### 4. Cohort ID Mismatches in Legacy Progress (Backend Fallback)
**Issue:** If a student was enrolled in a cohort, the system strictly checked that their watch-time document had a matching `cohortId`. If they completed an item before joining the cohort (or due to an old frontend bug that dropped the ID), the progress query would return false, locking them out of the next lesson.
**Fix:** In `ProgressRepository.ts`, the `isItemCompleted` method now employs a cascading search strategy. It first searches for a match with the specified `cohortId`. If no match is found, it safely falls back to looking for a generic watch-time record (where `cohortId` is null or undefined). 

## Testing Performed
- [x] Verified sequence traversal successfully skips hidden and deleted items without breaking progression.
- [x] Verified frontend UI gracefully handles validation rejections from fast-forwarding.
- [x] Verified quiz completions accurately track and unlock the subsequent sequence even if the `watchItemId` is stripped from the API payload.
- [x] Verified historical progress lacking a `cohortId` successfully validates during linear progression checks.