### PR TITLE
fix: remove cohortId null filter in findEnrollment to support cohort-…

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -125,7 +125,7 @@ export class EnrollmentRepository {
         courseVersionId: {
           $in: [courseVersionId, new ObjectId(courseVersionId)],
         },
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : { cohortId: null }),
+        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
         isDeleted: { $ne: true },
       },
       { session },
@@ -204,7 +204,7 @@ export class EnrollmentRepository {
         courseVersionId: {
           $in: [courseVersionId, new ObjectId(courseVersionId)],
         },
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : { cohortId: null }),
+        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
       },
       { session },
     );
@@ -364,7 +364,7 @@ export class EnrollmentRepository {
         userId: { $in: userFilter },
         courseId: courseObjectId,
         courseVersionId: courseVersionObjectId,
-        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : { cohortId: null }),
+        ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
       },
       {
         $set: {
@@ -3844,7 +3844,7 @@ export class EnrollmentRepository {
         {
           userId: userObjectId,
           quizId: { $in: quizObjectIds },
-          ...(cohortId ? { cohortId: new ObjectId(cohortId) } : { cohortId: null }),
+          ...(cohortId ? { cohortId: new ObjectId(cohortId) } : {}),
         },
         {
           session,


### PR DESCRIPTION
Removed { cohortId: null } filter in findEnrollment and replaced with {} so students enrolled via a cohort can also be found when cohortId is not passed in the query