### PR TITLE
fix: allow teachers to reorder items regardless of linear progression…

### DIFF
--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -927,17 +927,9 @@ export class ItemService extends BaseService {
     body: MoveItemBody,
   ) {
     return this._withTransaction(async session => {
-      const [versionStatus,isLinearProgressionEnabled]=await Promise.all(
-        [this.courseRepo.getCourseVersionStatus(versionId,session),
-        this.courseSettingService.isLinearProgressionEnabledByVersionId(versionId,session)]);
-
-
-      if(versionStatus==="archived"){
+      const versionStatus = await this.courseRepo.getCourseVersionStatus(versionId, session);
+      if (versionStatus === "archived") {
         throw new ForbiddenError("This course version is archived and cannot be modified.");
-      }
-
-      if(isLinearProgressionEnabled){
-        throw new ForbiddenError("Cannot re-order items, because Linear progression is enabled")
       }
       
       const { afterItemId, beforeItemId } = body;

--- a/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
@@ -1096,12 +1096,14 @@ export class CourseRepository implements ICourseRepository {
 
           if (items) {
             // Delete watch time by item id
-            items.items.forEach(async item => {
-              await this.progressRepo.deleteWatchTimeByItemId(
-                item._id.toString(),
-                session,
-              );
-            });
+            await Promise.all(
+              items.items.map(item =>
+                this.progressRepo.deleteWatchTimeByItemId(
+                  item._id.toString(),
+                  session,
+                )
+              )
+            );
           }
         }
 


### PR DESCRIPTION
Changes :
Item reorder blocked by linear progression (ItemService.ts)
Removed the isLinearProgressionEnabled check and related Promise.all fetch from moveItem flow. Linear progression is a student-side restriction and should not block teachers from rearranging items in the course management flow.
Delete module request hanging (CourseRepository.ts)
Updated deleteModule flow by replacing async forEach calls with Promise.all handling for deleteWatchTimeByItemId execution. This prevents pending transaction issues caused by unawaited async operations inside the MongoDB transaction flow.