### PR TITLE
Secure progress and leaderboard endpoints

### DIFF
--- a/backend/src/modules/users/classes/validators/ProgressValidators.ts
+++ b/backend/src/modules/users/classes/validators/ProgressValidators.ts
@@ -10,7 +10,6 @@ import {
   IsNumber,
   IsEnum,
   ValidateNested,
-  IsEmail,
   Min,
   Max,
   IsArray,
@@ -83,14 +82,6 @@ export class LeaderboardNoAuthResponse {
   userName!: string;
 
   @JSONSchema({
-    description: 'User email address',
-    type: 'string',
-    format: 'email',
-  })
-  @IsEmail()
-  email!: string;
-
-  @JSONSchema({
     description: 'Completion percentage of the course',
     type: 'number',
     minimum: 0,
@@ -142,6 +133,54 @@ export class GetLeaderboardResponse {
   @ValidateNested({each: true})
   @Type(() => LeaderboardNoAuthResponse)
   data!: LeaderboardNoAuthResponse[];
+}
+
+export class PaginatedLeaderboardResponse {
+  @JSONSchema({
+    description: 'Leaderboard rows for the requested page',
+    type: 'array',
+    items: {$ref: '#/components/schemas/LeaderboardNoAuthResponse'},
+  })
+  @IsArray()
+  @ValidateNested({each: true})
+  @Type(() => LeaderboardNoAuthResponse)
+  data!: LeaderboardNoAuthResponse[];
+
+  @JSONSchema({
+    description: 'Total leaderboard rows available',
+    type: 'number',
+    minimum: 0,
+  })
+  @IsNumber()
+  @Min(0)
+  totalDocuments!: number;
+
+  @JSONSchema({
+    description: 'Total pages available for the requested page size',
+    type: 'number',
+    minimum: 0,
+  })
+  @IsNumber()
+  @Min(0)
+  totalPages!: number;
+
+  @JSONSchema({
+    description: 'Current page number',
+    type: 'number',
+    minimum: 1,
+  })
+  @IsNumber()
+  @Min(1)
+  currentPage!: number;
+
+  @JSONSchema({
+    description: 'Current user leaderboard stats, when available',
+    oneOf: [{$ref: '#/components/schemas/LeaderboardNoAuthResponse'}, {type: 'null'}],
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => LeaderboardNoAuthResponse)
+  myStats!: LeaderboardNoAuthResponse | null;
 }
 
 export class StartItemBody {

--- a/backend/src/modules/users/controllers/ProgressController.ts
+++ b/backend/src/modules/users/controllers/ProgressController.ts
@@ -19,8 +19,7 @@ import {
   TotalWatchTimeResponse,
   ItemIdparams,
   GetLeaderboardQuery,
-  LeaderboardNoAuthResponse,
-  GetLeaderboardResponse,
+  PaginatedLeaderboardResponse,
 } from '#users/classes/validators/ProgressValidators.js';
 import { ProgressService } from '#users/services/ProgressService.js';
 import { USERS_TYPES } from '#users/types.js';
@@ -735,9 +734,8 @@ It returns an empty body with a 200 status code.
     description:
       'Returns ranked list of students based on completion percentage and time',
   })
-  @ResponseSchema(ProgressDataResponse, {
+  @ResponseSchema(PaginatedLeaderboardResponse, {
     description: 'Leaderboard retrieved successfully',
-    isArray: true,
   })
   @Authorized()
   @ResponseSchema(InternalServerErrorResponse, {
@@ -748,6 +746,7 @@ It returns an empty body with a 200 status code.
     @Params() params: GetUserProgressParams,
     @QueryParams() query: GetLeaderboardQuery,
     @CurrentUser() user: IUser,
+    @Ability(getProgressAbility) { ability },
   ): Promise<{
     data: Array<{
       userId: string;
@@ -759,10 +758,26 @@ It returns an empty body with a 200 status code.
     totalDocuments: number;
     totalPages: number;
     currentPage: number;
+    myStats: {
+      userId: string;
+      userName: string;
+      completionPercentage: number;
+      completedAt: Date | null;
+      rank: number;
+    } | null;
   }> {
     const { courseId, versionId } = params;
     const { page = 1, limit = 10, cohortId } = query;
     const userId = user._id?.toString();
+
+    const progressResource = subject('Progress', {userId, courseId, versionId});
+    if (
+      !ability.can(ProgressActions.View, progressResource) &&
+      !ability.can('manage', progressResource)
+    ) {
+      throw new ForbiddenError('You do not have permission to view this leaderboard');
+    }
+
     return await this.progressService.getLeaderboard(
       userId,
       courseId,
@@ -924,19 +939,40 @@ It returns an empty body with a 200 status code.
   }
 
   ///////////////////////////////////////////////////// TO CORRECT THE WATCHTIME DOC COUNT OF STUDENTS ////////////////////////////////////////////
+  @Authorized()
   @Post('/progress/watch-time/bulk')
   @HttpCode(201)
   @OpenAPI({
     summary: 'Create bulk watch-time records',
     description:
-      'Creates multiple watch-time entries in a single request for better performance',
+      'Admin/instructor maintenance endpoint that backfills missing watch-time entries after validating course-level progress permissions.',
   })
   @ResponseSchema(InternalServerErrorResponse, {
     description: 'Failed to create watch-time records',
     statusCode: 500,
   })
-  async createBulkWatchiTimeDocs(@Body() body: any): Promise<any> {
+  async createBulkWatchiTimeDocs(
+    @Body() body: any,
+    @Ability(getProgressAbility) { ability },
+  ): Promise<any> {
     const { courseId, versionId, userId } = body;
+
+    if (!courseId || !versionId) {
+      throw new BadRequestError('courseId and versionId are required');
+    }
+
+    const progressResource = subject('Progress', {
+      ...(userId ? { userId } : {}),
+      courseId,
+      versionId,
+    });
+
+    if (!ability.can('manage', progressResource)) {
+      throw new ForbiddenError(
+        'You do not have permission to backfill watch-time records',
+      );
+    }
+
     return this.progressService.createBulkWatchiTimeDocs(
       courseId,
       versionId,
@@ -944,14 +980,15 @@ It returns an empty body with a 200 status code.
     );
   }
 
-  /////////////////////////////// TEMP ENDPOINT WITHOUT AUTH //////////////////////////////////
+  /////////////////////////////// DEPRECATED AUTHENTICATED ALIAS //////////////////////////////////
+  @Authorized()
   @Get('/progress/courses/:courseId/versions/:versionId/leaderboard/no-auth')
   @OpenAPI({
-    summary: 'Get course leaderboard without authorization',
+    summary: 'Get course leaderboard (deprecated authenticated alias)',
     description:
-      'Returns ranked list of students based on completion percentage and time',
+      'Deprecated alias retained for compatibility. Authentication is required and private fields such as email are not returned.',
   })
-  @ResponseSchema(GetLeaderboardResponse, {
+  @ResponseSchema(PaginatedLeaderboardResponse, {
     description: 'Leaderboard retrieved successfully',
     statusCode: 200,
   })
@@ -961,15 +998,47 @@ It returns an empty body with a 200 status code.
   })
   async getNoAuthLeaderboard(
     @Params() params: GetUserProgressParams,
-  ): Promise<GetLeaderboardResponse> {
+    @QueryParams() query: GetLeaderboardQuery,
+    @CurrentUser() user: IUser,
+    @Ability(getProgressAbility) { ability },
+  ): Promise<{
+    data: Array<{
+      userId: string;
+      userName: string;
+      completionPercentage: number;
+      completedAt: Date | null;
+      rank: number;
+    }>;
+    totalDocuments: number;
+    totalPages: number;
+    currentPage: number;
+    myStats: {
+      userId: string;
+      userName: string;
+      completionPercentage: number;
+      completedAt: Date | null;
+      rank: number;
+    } | null;
+  }> {
     const { courseId, versionId } = params;
-    // const {page = 1, limit = 10} = query;
+    const { page = 1, limit = 10, cohortId } = query;
+    const userId = user._id?.toString();
 
-    return await this.progressService.getLeaderboardNoAuth(
+    const progressResource = subject('Progress', {userId, courseId, versionId});
+    if (
+      !ability.can(ProgressActions.View, progressResource) &&
+      !ability.can('manage', progressResource)
+    ) {
+      throw new ForbiddenError('You do not have permission to view this leaderboard');
+    }
+
+    return await this.progressService.getLeaderboard(
+      userId,
       courseId,
       versionId,
-      // page,
-      // limit,
+      page,
+      limit,
+      cohortId,
     );
   }
 }

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -33,7 +33,6 @@ import { ISettingRepository } from '#shared/index.js';
 import {
   CompletedProgressResponse,
   GetLeaderboardResponse,
-  LeaderboardNoAuthResponse,
 } from '../classes/index.js';
 import {
   QuizRepository,
@@ -4362,7 +4361,7 @@ class ProgressService extends BaseService {
         const fullName =
           `${user.firstName || ''} ${user.lastName || ''}`.trim() ||
           'Unknown User';
-        userMap.set(user._id?.toString(), { name: fullName, email: user.email });
+        userMap.set(user._id?.toString(), { name: fullName });
       }
     }
 
@@ -4390,7 +4389,6 @@ class ProgressService extends BaseService {
       return {
         userId,
         userName: user?.name || 'Unknown User',
-        email: user?.email || 'No email',
 
         completionPercentage: Math.min(100, enrollment?.completionPercentage) ?? 0,
 


### PR DESCRIPTION
# Security: protect progress mutation and leaderboard endpoints

## Summary

This PR tightens two progress-related endpoints:

- Requires authentication and course-level progress permissions for the bulk watch-time backfill endpoint.
- Converts the deprecated `leaderboard/no-auth` route into an authenticated compatibility alias and removes email exposure from the no-auth response shape/service path.

## Where the problem was

- `backend/src/modules/users/controllers/ProgressController.ts`
  - `POST /users/progress/watch-time/bulk`
  - `GET /users/progress/courses/:courseId/versions/:versionId/leaderboard/no-auth`
- `backend/src/modules/users/classes/validators/ProgressValidators.ts`
- `backend/src/modules/users/services/ProgressService.ts`

## Root cause

The bulk watch-time endpoint was a mutation route without `@Authorized()` and without a CASL ability check. It accepted `courseId`, `versionId`, and `userId` from the request body and delegated directly to `createBulkWatchiTimeDocs`.

The leaderboard route was explicitly labelled as a temporary no-auth endpoint. Its service path loaded user records and returned names and email addresses in leaderboard rows.

Redacted vulnerable shape before this change:

```ts
@Post('/progress/watch-time/bulk')
async createBulkWatchiTimeDocs(@Body() body: any): Promise<any> {
  const { courseId, versionId, userId } = body;
  return this.progressService.createBulkWatchiTimeDocs(courseId, versionId, userId);
}

@Get('/progress/courses/:courseId/versions/:versionId/leaderboard/no-auth')
async getNoAuthLeaderboard(@Params() params: GetUserProgressParams) {
  return await this.progressService.getLeaderboardNoAuth(courseId, versionId);
}
```

## Risk

An unauthenticated mutation endpoint can allow progress/watch-time records to be created without a verified actor or permission context. This can affect learner progress integrity and course completion records.

The public leaderboard route can expose private learner metadata and allows course participation data to be enumerated without login.

## What changed

- Added `@Authorized()` to `POST /progress/watch-time/bulk`.
- Added a required `courseId`/`versionId` validation guard.
- Added `@Ability(getProgressAbility)` and require `ability.can('manage', subject('Progress', ...))` before backfilling watch-time records.
- Added `@Authorized()` to the deprecated `leaderboard/no-auth` route.
- Added course-scoped CASL authorization to both leaderboard routes.
- Routed the deprecated leaderboard alias through the existing authenticated `getLeaderboard` service method.
- Updated leaderboard OpenAPI response metadata to describe the actual paginated response, including `myStats`.
- Removed `email` from `LeaderboardNoAuthResponse`.
- Removed email mapping from `getLeaderboardNoAuth` so the legacy service path is also sanitized if it is accidentally used elsewhere.

## Why this fixes it

The bulk endpoint now requires a logged-in actor and applies the same course-scoped permission model already used by the progress controller. Students keep normal self-progress capabilities, but cannot call the maintenance backfill operation because it requires `manage` on the course progress subject.

The deprecated leaderboard route remains available for compatibility, but it now requires authentication and returns the same privacy-preserving shape as the normal leaderboard endpoint.

Both leaderboard routes now require the requester to have `view` or `manage` permission on the requested course/version progress subject, preventing an arbitrary logged-in user from enumerating another course's leaderboard.

## Safe validation plan

Run these checks only against a local development instance or an authorized staging environment:

- Anonymous request to `POST /users/progress/watch-time/bulk` should return `401 Unauthorized`.
- Authenticated learner request to the bulk backfill endpoint should return `403 Forbidden`.
- Authenticated instructor/manager/admin with course access should be able to run the endpoint for an authorized course fixture.
- Anonymous request to the deprecated leaderboard alias should return `401 Unauthorized`.
- Authenticated user without access to the requested course/version should receive `403 Forbidden`.
- Authenticated leaderboard response should not contain an `email` field in any row.

## Files changed

- `backend/src/modules/users/controllers/ProgressController.ts`
- `backend/src/modules/users/classes/validators/ProgressValidators.ts`
- `backend/src/modules/users/services/ProgressService.ts`
