### PR TITLE
feat: add crowdsourced question submission engine

### DIFF
--- a/backend/src/modules/setting/classes/validators/CourseSettingValidators.ts
+++ b/backend/src/modules/setting/classes/validators/CourseSettingValidators.ts
@@ -189,6 +189,15 @@ export class SettingsDto {
   })
   randomizeItems?: boolean;
 
+  @IsOptional()
+  @IsBoolean()
+  @JSONSchema({
+    description: 'Enables student crowdsourced question submission after video completion',
+    examples: [true, false],
+    default: false,
+  })
+  crowdsourcedQuestionSubmissionEnabled?: boolean;
+
   // jsonSchema?:any
   // uiSchema?:any
   @IsOptional()
@@ -416,6 +425,15 @@ export class AddCourseProctoringBody {
     default: false,
   })
   randomizeItems?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @JSONSchema({
+    description: 'Enables student crowdsourced question submission after video completion',
+    examples: [true, false],
+    default: false,
+  })
+  crowdsourcedQuestionSubmissionEnabled?: boolean;
 }
 
 // This class represents the validation schema of Parameters for removing proctoring from a course.

--- a/backend/src/modules/setting/controllers/CourseSettingController.ts
+++ b/backend/src/modules/setting/controllers/CourseSettingController.ts
@@ -127,6 +127,7 @@ export class CourseSettingController {
       hpSystem,
       baseHp,
       randomizeItems,
+      crowdsourcedQuestionSubmissionEnabled,
     } = body;
     const userId = user._id.toString();
 
@@ -141,6 +142,7 @@ export class CourseSettingController {
       baseHp,
       randomizeItems,
       userId,
+      crowdsourcedQuestionSubmissionEnabled ?? false,
     );
 
     setAuditTrail(req, {
@@ -161,6 +163,8 @@ export class CourseSettingController {
           dectors: detectors,
           linearProgressionEnabled: linearProgressionEnabled,
           seekForwardEnabled: seekForwardEnabled,
+          crowdsourcedQuestionSubmissionEnabled:
+            crowdsourcedQuestionSubmissionEnabled ?? false,
         },
       },
       outcome: {

--- a/backend/src/modules/setting/services/CourseSettingService.ts
+++ b/backend/src/modules/setting/services/CourseSettingService.ts
@@ -164,6 +164,7 @@ class CourseSettingService extends BaseService {
     baseHp: number,
     randomizeItems: boolean,
     userId: string,
+    crowdsourcedQuestionSubmissionEnabled: boolean = false,
   ): Promise<boolean> {
     return this._withTransaction(async session => {
       const versionStatus =
@@ -191,6 +192,8 @@ class CourseSettingService extends BaseService {
         settings.hpSystem = hpSystem;
         settings.baseHp = baseHp;
         settings.randomizeItems = randomizeItems;
+        settings.crowdsourcedQuestionSubmissionEnabled =
+          crowdsourcedQuestionSubmissionEnabled;
 
         settings.audit = [
           {
@@ -207,6 +210,7 @@ class CourseSettingService extends BaseService {
                 hpSystem,
                 baseHp,
                 randomizeItems,
+                crowdsourcedQuestionSubmissionEnabled,
               },
             },
           },
@@ -241,6 +245,8 @@ class CourseSettingService extends BaseService {
         hpSystem: courseSettings.settings?.hpSystem,
         baseHp: courseSettings.settings?.baseHp,
         randomizeItems: courseSettings.settings?.randomizeItems,
+        crowdsourcedQuestionSubmissionEnabled:
+          courseSettings.settings?.crowdsourcedQuestionSubmissionEnabled,
       };
 
       const afterState = {
@@ -251,6 +257,7 @@ class CourseSettingService extends BaseService {
         hpSystem,
         baseHp,
         randomizeItems,
+        crowdsourcedQuestionSubmissionEnabled,
       };
 
       const audit: AuditingDto = {
@@ -275,6 +282,7 @@ class CourseSettingService extends BaseService {
         randomizeItems,
         audit,
         session,
+        crowdsourcedQuestionSubmissionEnabled,
       );
 
       if (!result) {

--- a/backend/src/modules/studentQuestions/classes/index.ts
+++ b/backend/src/modules/studentQuestions/classes/index.ts
@@ -1,0 +1,2 @@
+export * from './transformers/index.js';
+export * from './validators/index.js';

--- a/backend/src/modules/studentQuestions/classes/transformers/StudentSegmentQuestion.ts
+++ b/backend/src/modules/studentQuestions/classes/transformers/StudentSegmentQuestion.ts
@@ -1,0 +1,82 @@
+import {ObjectId} from 'mongodb';
+
+export type StudentQuestionStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
+
+export type StudentQuestionSource = 'STUDENT_GENERATED';
+
+export type StudentQuestionType = 'SELECT_ONE_IN_LOT';
+
+export interface IStudentQuestionOption {
+  text: string;
+}
+
+export interface IStudentSegmentQuestion {
+  _id?: ObjectId;
+  courseId: ObjectId;
+  courseVersionId: ObjectId;
+  segmentId: ObjectId;
+  questionType: StudentQuestionType;
+  questionText: string;
+  options: IStudentQuestionOption[];
+  correctOptionIndex: number;
+  normalizedSignature: string;
+  status: StudentQuestionStatus;
+  source: StudentQuestionSource;
+  createdBy: ObjectId;
+  reviewedBy?: ObjectId;
+  reviewedAt?: Date;
+  rejectionReason?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  isDeleted?: boolean;
+  deletedAt?: Date;
+}
+
+export class StudentSegmentQuestion implements IStudentSegmentQuestion {
+  _id?: ObjectId;
+  courseId: ObjectId;
+  courseVersionId: ObjectId;
+  segmentId: ObjectId;
+  questionType: StudentQuestionType;
+  questionText: string;
+  options: IStudentQuestionOption[];
+  correctOptionIndex: number;
+  normalizedSignature: string;
+  status: StudentQuestionStatus;
+  source: StudentQuestionSource;
+  createdBy: ObjectId;
+  reviewedBy?: ObjectId;
+  reviewedAt?: Date;
+  rejectionReason?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  isDeleted?: boolean;
+  deletedAt?: Date;
+
+  constructor(input: {
+    courseId: string;
+    courseVersionId: string;
+    segmentId: string;
+    questionType: StudentQuestionType;
+    questionText: string;
+    options: IStudentQuestionOption[];
+    correctOptionIndex: number;
+    normalizedSignature: string;
+    createdBy: string;
+  }) {
+    this.courseId = new ObjectId(input.courseId);
+    this.courseVersionId = new ObjectId(input.courseVersionId);
+    this.segmentId = new ObjectId(input.segmentId);
+    this.questionType = input.questionType;
+    this.questionText = input.questionText;
+    this.options = input.options;
+    this.correctOptionIndex = input.correctOptionIndex;
+    this.normalizedSignature = input.normalizedSignature;
+    this.status = 'PENDING';
+    this.source = 'STUDENT_GENERATED';
+    this.createdBy = new ObjectId(input.createdBy);
+    this.createdAt = new Date();
+    this.updatedAt = new Date();
+    this.isDeleted = false;
+  }
+}

--- a/backend/src/modules/studentQuestions/classes/transformers/index.ts
+++ b/backend/src/modules/studentQuestions/classes/transformers/index.ts
@@ -1,0 +1,1 @@
+export * from './StudentSegmentQuestion.js';

--- a/backend/src/modules/studentQuestions/classes/validators/StudentQuestionValidator.ts
+++ b/backend/src/modules/studentQuestions/classes/validators/StudentQuestionValidator.ts
@@ -1,0 +1,173 @@
+import {Type} from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsInt,
+  IsMongoId,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Length,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import {JSONSchema} from 'class-validator-jsonschema';
+
+const QUESTION_TYPES = ['SELECT_ONE_IN_LOT'] as const;
+type QuestionTypeLiteral = (typeof QUESTION_TYPES)[number];
+const STATUS_VALUES = ['PENDING', 'APPROVED', 'REJECTED'] as const;
+type StatusLiteral = (typeof STATUS_VALUES)[number];
+
+export class StudentQuestionOptionDto {
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 150)
+  @JSONSchema({
+    description: 'Text content of the MCQ option (1-150 characters).',
+    example: 'It allows us to repeatedly halve the search space.',
+  })
+  text!: string;
+}
+
+export class CreateStudentQuestionBody {
+  @IsString()
+  @IsNotEmpty()
+  @JSONSchema({
+    description: 'Question type. Only SELECT_ONE_IN_LOT (single-answer MCQ) is supported in v1.',
+    enum: [...QUESTION_TYPES],
+    default: 'SELECT_ONE_IN_LOT',
+  })
+  questionType!: QuestionTypeLiteral;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(10, 300)
+  @JSONSchema({
+    description: 'The MCQ prompt (10-300 characters after trimming).',
+    example: 'Why must the input be sorted for binary search to work?',
+  })
+  questionText!: string;
+
+  @IsArray()
+  @ArrayMinSize(2)
+  @ArrayMaxSize(8)
+  @ValidateNested({each: true})
+  @Type(() => StudentQuestionOptionDto)
+  @JSONSchema({
+    description: 'Between 2 and 8 answer options.',
+  })
+  options!: StudentQuestionOptionDto[];
+
+  @IsInt()
+  @Min(0)
+  @Max(7)
+  @JSONSchema({
+    description: 'Zero-based index of the correct option in the options array.',
+    example: 0,
+  })
+  correctOptionIndex!: number;
+}
+
+export class StudentQuestionPathParams {
+  @IsMongoId()
+  courseId!: string;
+
+  @IsMongoId()
+  courseVersionId!: string;
+
+  @IsMongoId()
+  segmentId!: string;
+}
+
+export class StudentQuestionStatusPathParams {
+  @IsMongoId()
+  courseId!: string;
+
+  @IsMongoId()
+  courseVersionId!: string;
+
+  @IsMongoId()
+  segmentId!: string;
+
+  @IsMongoId()
+  questionId!: string;
+}
+
+export class StudentQuestionListQuery {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number;
+}
+
+export class UpdateStudentQuestionStatusBody {
+  @IsString()
+  @IsNotEmpty()
+  @JSONSchema({
+    enum: [...STATUS_VALUES],
+    description: 'Target status. REJECTED requires a non-empty `reason`.',
+  })
+  status!: StatusLiteral;
+
+  @IsOptional()
+  @IsString()
+  @Length(3, 500)
+  @JSONSchema({
+    description: 'Required when status is REJECTED. 3-500 characters.',
+  })
+  reason?: string;
+}
+
+export class StudentQuestionCreateResponse {
+  @IsString()
+  questionId!: string;
+}
+
+export class StudentQuestionListItemResponse {
+  @IsString()
+  _id!: string;
+
+  @IsString()
+  questionText!: string;
+
+  @IsArray()
+  options!: {text: string}[];
+
+  @IsInt()
+  correctOptionIndex!: number;
+
+  @IsString()
+  status!: StatusLiteral;
+
+  @IsString()
+  source!: string;
+
+  @IsString()
+  createdBy!: string;
+
+  @IsString()
+  createdAt!: string;
+
+  @IsOptional()
+  @IsString()
+  reviewedBy?: string;
+
+  @IsOptional()
+  @IsString()
+  reviewedAt?: string;
+
+  @IsOptional()
+  @IsString()
+  rejectionReason?: string;
+}
+
+export class StudentQuestionListResponse {
+  @IsArray()
+  @ValidateNested({each: true})
+  @Type(() => StudentQuestionListItemResponse)
+  items!: StudentQuestionListItemResponse[];
+}

--- a/backend/src/modules/studentQuestions/classes/validators/index.ts
+++ b/backend/src/modules/studentQuestions/classes/validators/index.ts
@@ -1,0 +1,1 @@
+export * from './StudentQuestionValidator.js';

--- a/backend/src/modules/studentQuestions/container.ts
+++ b/backend/src/modules/studentQuestions/container.ts
@@ -1,0 +1,22 @@
+import {ContainerModule} from 'inversify';
+import {STUDENT_QUESTION_TYPES} from './types.js';
+import {StudentQuestionService} from './services/StudentQuestionService.js';
+import {StudentQuestionController} from './controllers/StudentQuestionController.js';
+import {StudentQuestionRepository} from './repositories/providers/mongodb/StudentQuestionRepository.js';
+
+export const studentQuestionsContainerModule = new ContainerModule(options => {
+  // Repository
+  options.bind(StudentQuestionRepository).toSelf().inSingletonScope();
+  options
+    .bind(STUDENT_QUESTION_TYPES.StudentQuestionRepo)
+    .to(StudentQuestionRepository);
+
+  // Service
+  options.bind(StudentQuestionService).toSelf().inSingletonScope();
+  options
+    .bind(STUDENT_QUESTION_TYPES.StudentQuestionService)
+    .to(StudentQuestionService);
+
+  // Controller
+  options.bind(StudentQuestionController).toSelf().inSingletonScope();
+});

--- a/backend/src/modules/studentQuestions/controllers/StudentQuestionController.ts
+++ b/backend/src/modules/studentQuestions/controllers/StudentQuestionController.ts
@@ -1,0 +1,120 @@
+import {inject, injectable} from 'inversify';
+import {
+  Authorized,
+  Body,
+  CurrentUser,
+  ForbiddenError,
+  Get,
+  HttpCode,
+  JsonController,
+  Params,
+  Patch,
+  Post,
+  QueryParams,
+} from 'routing-controllers';
+import {OpenAPI, ResponseSchema} from 'routing-controllers-openapi';
+import {IUser} from '#root/shared/interfaces/models.js';
+import {STUDENT_QUESTION_TYPES} from '../types.js';
+import {StudentQuestionService} from '../services/StudentQuestionService.js';
+import {
+  CreateStudentQuestionBody,
+  StudentQuestionCreateResponse,
+  StudentQuestionListQuery,
+  StudentQuestionListResponse,
+  StudentQuestionPathParams,
+  StudentQuestionStatusPathParams,
+  UpdateStudentQuestionStatusBody,
+} from '../classes/validators/StudentQuestionValidator.js';
+
+@OpenAPI({
+  tags: ['Student Questions'],
+})
+@JsonController('/student-questions')
+@injectable()
+export class StudentQuestionController {
+  constructor(
+    @inject(STUDENT_QUESTION_TYPES.StudentQuestionService)
+    private readonly service: StudentQuestionService,
+  ) {}
+
+  @Authorized()
+  @Post('/courses/:courseId/versions/:courseVersionId/segments/:segmentId')
+  @HttpCode(201)
+  @ResponseSchema(StudentQuestionCreateResponse)
+  async create(
+    @Params() params: StudentQuestionPathParams,
+    @Body() body: CreateStudentQuestionBody,
+    @CurrentUser() user: IUser,
+  ): Promise<StudentQuestionCreateResponse> {
+    const createdBy = user._id?.toString();
+    if (!createdBy) {
+      throw new ForbiddenError('Unable to resolve authenticated user.');
+    }
+    const questionId = await this.service.createQuestion({
+      courseId: params.courseId,
+      courseVersionId: params.courseVersionId,
+      segmentId: params.segmentId,
+      questionType: body.questionType,
+      questionText: body.questionText,
+      options: body.options,
+      correctOptionIndex: body.correctOptionIndex,
+      createdBy,
+    });
+    return {questionId};
+  }
+
+  @Authorized()
+  @Get('/courses/:courseId/versions/:courseVersionId/segments/:segmentId')
+  @HttpCode(200)
+  @ResponseSchema(StudentQuestionListResponse)
+  async listBySegment(
+    @Params() params: StudentQuestionPathParams,
+    @QueryParams() query: StudentQuestionListQuery,
+  ): Promise<StudentQuestionListResponse> {
+    const questions = await this.service.listSegmentQuestions({
+      courseId: params.courseId,
+      courseVersionId: params.courseVersionId,
+      segmentId: params.segmentId,
+      limit: query.limit ?? 20,
+    });
+    return {
+      items: questions.map(q => ({
+        _id: q._id?.toString() || '',
+        questionText: q.questionText,
+        options: q.options.map(o => ({text: o.text})),
+        correctOptionIndex: q.correctOptionIndex,
+        status: q.status,
+        source: q.source,
+        createdBy: q.createdBy.toString(),
+        createdAt: q.createdAt.toISOString(),
+        reviewedBy: q.reviewedBy?.toString(),
+        reviewedAt: q.reviewedAt?.toISOString(),
+        rejectionReason: q.rejectionReason,
+      })),
+    };
+  }
+
+  @Authorized()
+  @Patch('/courses/:courseId/versions/:courseVersionId/segments/:segmentId/questions/:questionId/status')
+  @HttpCode(200)
+  async updateStatus(
+    @Params() params: StudentQuestionStatusPathParams,
+    @Body() body: UpdateStudentQuestionStatusBody,
+    @CurrentUser() user: IUser,
+  ): Promise<{success: true}> {
+    const reviewedBy = user._id?.toString();
+    if (!reviewedBy) {
+      throw new ForbiddenError('Unable to resolve authenticated user.');
+    }
+    await this.service.updateQuestionStatus({
+      courseId: params.courseId,
+      courseVersionId: params.courseVersionId,
+      segmentId: params.segmentId,
+      questionId: params.questionId,
+      status: body.status,
+      reviewedBy,
+      reason: body.reason,
+    });
+    return {success: true};
+  }
+}

--- a/backend/src/modules/studentQuestions/controllers/index.ts
+++ b/backend/src/modules/studentQuestions/controllers/index.ts
@@ -1,0 +1,1 @@
+export * from './StudentQuestionController.js';

--- a/backend/src/modules/studentQuestions/index.ts
+++ b/backend/src/modules/studentQuestions/index.ts
@@ -1,0 +1,60 @@
+import {Container, ContainerModule} from 'inversify';
+import {RoutingControllersOptions, useContainer} from 'routing-controllers';
+import {sharedContainerModule} from '#root/container.js';
+import {InversifyAdapter} from '#root/inversify-adapter.js';
+import {authContainerModule} from '../auth/container.js';
+import {studentQuestionsContainerModule} from './container.js';
+import {StudentQuestionController} from './controllers/StudentQuestionController.js';
+import {
+  CreateStudentQuestionBody,
+  StudentQuestionListQuery,
+  StudentQuestionListResponse,
+  StudentQuestionOptionDto,
+  StudentQuestionPathParams,
+  StudentQuestionStatusPathParams,
+  UpdateStudentQuestionStatusBody,
+} from './classes/validators/StudentQuestionValidator.js';
+
+export const studentQuestionsContainerModules: ContainerModule[] = [
+  studentQuestionsContainerModule,
+  sharedContainerModule,
+  authContainerModule,
+];
+
+export const studentQuestionsModuleControllers: Function[] = [
+  StudentQuestionController,
+];
+
+export async function setupStudentQuestionsContainer(): Promise<void> {
+  const container = new Container();
+  await container.load(...studentQuestionsContainerModules);
+  const inversifyAdapter = new InversifyAdapter(container);
+  useContainer(inversifyAdapter);
+}
+
+export const studentQuestionsModuleOptions: RoutingControllersOptions = {
+  controllers: studentQuestionsModuleControllers,
+  middlewares: [],
+  defaultErrorHandler: true,
+  authorizationChecker: async function () {
+    return true;
+  },
+  validation: true,
+};
+
+export const studentQuestionsModuleValidators: Function[] = [
+  CreateStudentQuestionBody,
+  StudentQuestionOptionDto,
+  StudentQuestionPathParams,
+  StudentQuestionStatusPathParams,
+  StudentQuestionListQuery,
+  StudentQuestionListResponse,
+  UpdateStudentQuestionStatusBody,
+];
+
+export * from './classes/index.js';
+export * from './controllers/index.js';
+export * from './services/index.js';
+export * from './repositories/index.js';
+export * from './types.js';
+export * from './container.js';

--- a/backend/src/modules/studentQuestions/repositories/index.ts
+++ b/backend/src/modules/studentQuestions/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './providers/index.js';

--- a/backend/src/modules/studentQuestions/repositories/providers/index.ts
+++ b/backend/src/modules/studentQuestions/repositories/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './mongodb/StudentQuestionRepository.js';

--- a/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
+++ b/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
@@ -1,0 +1,113 @@
+import 'reflect-metadata';
+import {Collection, ObjectId, ClientSession} from 'mongodb';
+import {injectable, inject} from 'inversify';
+import {MongoDatabase} from '#shared/database/providers/mongo/MongoDatabase.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {
+  IStudentSegmentQuestion,
+  StudentQuestionStatus,
+  StudentSegmentQuestion,
+} from '../../../classes/transformers/StudentSegmentQuestion.js';
+
+@injectable()
+export class StudentQuestionRepository {
+  private collection!: Collection<IStudentSegmentQuestion>;
+  private initialized = false;
+
+  constructor(@inject(GLOBAL_TYPES.Database) private db: MongoDatabase) {}
+
+  private async init() {
+    if (this.initialized) return;
+    this.collection = await this.db.getCollection<IStudentSegmentQuestion>(
+      'studentSegmentQuestions',
+    );
+    this.initialized = true;
+
+    try {
+      await this.collection.createIndex(
+        {courseVersionId: 1, segmentId: 1, isDeleted: 1},
+        {background: true},
+      );
+      await this.collection.createIndex(
+        {courseVersionId: 1, segmentId: 1, normalizedSignature: 1, isDeleted: 1},
+        {background: true},
+      );
+    } catch {
+      // index already exists
+    }
+  }
+
+  async create(
+    question: StudentSegmentQuestion,
+    session?: ClientSession,
+  ): Promise<string> {
+    await this.init();
+    const result = await this.collection.insertOne(question, {session});
+    return result.insertedId.toString();
+  }
+
+  async findDuplicate(input: {
+    courseVersionId: string;
+    segmentId: string;
+    normalizedSignature: string;
+  }): Promise<IStudentSegmentQuestion | null> {
+    await this.init();
+    return await this.collection.findOne({
+      courseVersionId: new ObjectId(input.courseVersionId),
+      segmentId: new ObjectId(input.segmentId),
+      normalizedSignature: input.normalizedSignature,
+      isDeleted: {$ne: true},
+    });
+  }
+
+  async listBySegment(input: {
+    courseId: string;
+    courseVersionId: string;
+    segmentId: string;
+    limit: number;
+  }): Promise<IStudentSegmentQuestion[]> {
+    await this.init();
+    return await this.collection
+      .find({
+        courseId: new ObjectId(input.courseId),
+        courseVersionId: new ObjectId(input.courseVersionId),
+        segmentId: new ObjectId(input.segmentId),
+        isDeleted: {$ne: true},
+      })
+      .sort({createdAt: -1})
+      .limit(input.limit)
+      .toArray();
+  }
+
+  async updateStatus(input: {
+    courseId: string;
+    courseVersionId: string;
+    segmentId: string;
+    questionId: string;
+    status: StudentQuestionStatus;
+    reviewedBy: string;
+    rejectionReason?: string;
+  }): Promise<boolean> {
+    await this.init();
+    const result = await this.collection.updateOne(
+      {
+        _id: new ObjectId(input.questionId),
+        courseId: new ObjectId(input.courseId),
+        courseVersionId: new ObjectId(input.courseVersionId),
+        segmentId: new ObjectId(input.segmentId),
+        isDeleted: {$ne: true},
+      },
+      {
+        $set: {
+          status: input.status,
+          reviewedBy: new ObjectId(input.reviewedBy),
+          reviewedAt: new Date(),
+          rejectionReason:
+            input.status === 'REJECTED' ? input.rejectionReason : undefined,
+          updatedAt: new Date(),
+        },
+      },
+    );
+    return result.matchedCount > 0;
+  }
+}

--- a/backend/src/modules/studentQuestions/services/StudentQuestionService.ts
+++ b/backend/src/modules/studentQuestions/services/StudentQuestionService.ts
@@ -1,0 +1,207 @@
+import {inject, injectable} from 'inversify';
+import {BadRequestError, ForbiddenError, NotFoundError} from 'routing-controllers';
+import {STUDENT_QUESTION_TYPES} from '../types.js';
+import {StudentQuestionRepository} from '../repositories/providers/mongodb/StudentQuestionRepository.js';
+import {
+  IStudentQuestionOption,
+  StudentQuestionStatus,
+  StudentQuestionType,
+  StudentSegmentQuestion,
+} from '../classes/transformers/StudentSegmentQuestion.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {ISettingRepository} from '#shared/database/index.js';
+
+const REPEATED_CHAR_PATTERN = /(.)\1{7,}/;
+const REPEATED_WORD_PATTERN = /(\b\w+\b)(\s+\1){4,}/;
+const URL_TOKEN_PATTERN = /^https?:\/\/\S+$/i;
+
+@injectable()
+export class StudentQuestionService {
+  constructor(
+    @inject(STUDENT_QUESTION_TYPES.StudentQuestionRepo)
+    private readonly repository: StudentQuestionRepository,
+    @inject(GLOBAL_TYPES.SettingRepo)
+    private readonly settingRepo: ISettingRepository,
+  ) {}
+
+  private normalize(text: string): string {
+    return text.trim().replace(/\s+/g, ' ').toLowerCase();
+  }
+
+  private validateQuestionText(questionText: string): string {
+    const trimmed = questionText.trim();
+    if (trimmed.length < 10 || trimmed.length > 300) {
+      throw new BadRequestError(
+        'Question must be between 10 and 300 characters.',
+      );
+    }
+
+    const normalized = this.normalize(trimmed);
+    const tokens = normalized.split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) {
+      throw new BadRequestError('Question cannot be empty.');
+    }
+
+    if (tokens.every(token => URL_TOKEN_PATTERN.test(token))) {
+      throw new BadRequestError('Question cannot contain only URLs.');
+    }
+
+    if (REPEATED_CHAR_PATTERN.test(normalized) || REPEATED_WORD_PATTERN.test(normalized)) {
+      throw new BadRequestError('Question looks like spam. Please rewrite it.');
+    }
+
+    return trimmed;
+  }
+
+  private validateOptions(options: IStudentQuestionOption[]): IStudentQuestionOption[] {
+    if (!Array.isArray(options) || options.length < 2 || options.length > 8) {
+      throw new BadRequestError('MCQ must include between 2 and 8 options.');
+    }
+    return options.map((option, index) => {
+      const text = option.text?.trim();
+      if (!text) {
+        throw new BadRequestError(`Option ${index + 1} text is required.`);
+      }
+      if (text.length > 150) {
+        throw new BadRequestError(
+          `Option ${index + 1} text must be 150 characters or fewer.`,
+        );
+      }
+      return {text};
+    });
+  }
+
+  private buildSignature(input: {
+    questionText: string;
+    options: IStudentQuestionOption[];
+    correctOptionIndex: number;
+  }): string {
+    const optionSig = input.options
+      .map(o => this.normalize(o.text))
+      .join('|');
+    return [
+      this.normalize(input.questionText),
+      optionSig,
+      String(input.correctOptionIndex),
+    ].join('||');
+  }
+
+  private async ensureSubmissionEnabled(
+    courseId: string,
+    courseVersionId: string,
+  ): Promise<void> {
+    const courseSettings = await this.settingRepo.readCourseSettings(
+      courseId,
+      courseVersionId,
+    );
+    const enabled =
+      courseSettings?.settings?.crowdsourcedQuestionSubmissionEnabled === true;
+    if (!enabled) {
+      throw new ForbiddenError(
+        'Question submission is not enabled for this course version.',
+      );
+    }
+  }
+
+  async createQuestion(input: {
+    courseId: string;
+    courseVersionId: string;
+    segmentId: string;
+    questionType: StudentQuestionType;
+    questionText: string;
+    options: IStudentQuestionOption[];
+    correctOptionIndex: number;
+    createdBy: string;
+  }): Promise<string> {
+    await this.ensureSubmissionEnabled(input.courseId, input.courseVersionId);
+
+    if (input.questionType !== 'SELECT_ONE_IN_LOT') {
+      throw new BadRequestError(
+        'Only single-answer MCQ submissions are supported.',
+      );
+    }
+
+    const questionText = this.validateQuestionText(input.questionText);
+    const options = this.validateOptions(input.options);
+
+    if (
+      !Number.isInteger(input.correctOptionIndex) ||
+      input.correctOptionIndex < 0 ||
+      input.correctOptionIndex >= options.length
+    ) {
+      throw new BadRequestError('Correct option index is out of range.');
+    }
+
+    const normalizedSignature = this.buildSignature({
+      questionText,
+      options,
+      correctOptionIndex: input.correctOptionIndex,
+    });
+
+    const duplicate = await this.repository.findDuplicate({
+      courseVersionId: input.courseVersionId,
+      segmentId: input.segmentId,
+      normalizedSignature,
+    });
+    if (duplicate) {
+      throw new BadRequestError(
+        'A similar question already exists for this segment.',
+      );
+    }
+
+    const question = new StudentSegmentQuestion({
+      courseId: input.courseId,
+      courseVersionId: input.courseVersionId,
+      segmentId: input.segmentId,
+      questionType: input.questionType,
+      questionText,
+      options,
+      correctOptionIndex: input.correctOptionIndex,
+      normalizedSignature,
+      createdBy: input.createdBy,
+    });
+
+    return await this.repository.create(question);
+  }
+
+  async listSegmentQuestions(input: {
+    courseId: string;
+    courseVersionId: string;
+    segmentId: string;
+    limit: number;
+  }) {
+    return await this.repository.listBySegment(input);
+  }
+
+  async updateQuestionStatus(input: {
+    courseId: string;
+    courseVersionId: string;
+    segmentId: string;
+    questionId: string;
+    status: StudentQuestionStatus;
+    reviewedBy: string;
+    reason?: string;
+  }): Promise<void> {
+    if (input.status === 'REJECTED') {
+      const reason = input.reason?.trim();
+      if (!reason || reason.length < 3 || reason.length > 500) {
+        throw new BadRequestError(
+          'A rejection reason of 3 to 500 characters is required.',
+        );
+      }
+    }
+
+    const matched = await this.repository.updateStatus({
+      courseId: input.courseId,
+      courseVersionId: input.courseVersionId,
+      segmentId: input.segmentId,
+      questionId: input.questionId,
+      status: input.status,
+      reviewedBy: input.reviewedBy,
+      rejectionReason: input.reason?.trim(),
+    });
+    if (!matched) {
+      throw new NotFoundError('Student question not found for the given segment.');
+    }
+  }
+}

--- a/backend/src/modules/studentQuestions/services/index.ts
+++ b/backend/src/modules/studentQuestions/services/index.ts
@@ -1,0 +1,1 @@
+export * from './StudentQuestionService.js';

--- a/backend/src/modules/studentQuestions/types.ts
+++ b/backend/src/modules/studentQuestions/types.ts
@@ -1,0 +1,6 @@
+const STUDENT_QUESTION_TYPES = {
+  StudentQuestionService: Symbol.for('StudentQuestionService'),
+  StudentQuestionRepo: Symbol.for('StudentQuestionRepo'),
+};
+
+export { STUDENT_QUESTION_TYPES };

--- a/backend/src/shared/database/interfaces/ISettingRepository.ts
+++ b/backend/src/shared/database/interfaces/ISettingRepository.ts
@@ -67,6 +67,7 @@ export interface ISettingRepository {
     randomizeItems: boolean,
     audit: AuditingDto,
     session?: ClientSession,
+    crowdsourcedQuestionSubmissionEnabled?: boolean,
   ): Promise<UpdateResult | null>;
 
   updateRegistrationSchemas(

--- a/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
@@ -278,6 +278,7 @@ export class SettingRepository implements ISettingRepository {
     randomizeItems: boolean,
     audit: AuditingDto,
     session?: ClientSession,
+    crowdsourcedQuestionSubmissionEnabled: boolean = false,
   ): Promise<UpdateResult | null> {
     await this.init();
 
@@ -335,6 +336,8 @@ export class SettingRepository implements ISettingRepository {
           'settings.isPublic': isPublic,
           'settings.baseHp': baseHp,
           'settings.randomizeItems': randomizeItems,
+          'settings.crowdsourcedQuestionSubmissionEnabled':
+            crowdsourcedQuestionSubmissionEnabled,
         },
         $push: {
           'settings.audit': audit,

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -589,6 +589,7 @@ export interface ISettings {
   isPublic?: boolean;
   baseHp?: number;
   randomizeItems?: boolean;
+  crowdsourcedQuestionSubmissionEnabled?: boolean;
   // registration_settings?: IRegistrationSettings[];
   registration?: {
     jsonSchema?: any;

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -20,6 +20,7 @@ import { useCourseStore } from "@/store/course-store";
 import { Link, Navigate, useRouter } from "@tanstack/react-router";
 import StudentProjectItem from "./components/StudentProjectItem";
 import type { Item, ItemContainerRef } from "@/types/item-container.types";
+import type { PendingStudentQuestionContext } from "@/types/student-question.types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AuroraText } from "@/components/magicui/aurora-text";
 import confetti from "canvas-confetti";
@@ -222,6 +223,7 @@ export default function CoursePage() {
   const [isQuizSkipped, setIsQuizSkipped] = useState(false);
   const [readyToDetect, setReadyToDetect] = useState(false);
   const [isNavigatingToPrev, setIsNavigatingToPrev] = useState<boolean>(false);
+  const [pendingStudentQuestionContext, setPendingStudentQuestionContext] = useState<PendingStudentQuestionContext | null>(null);
   const completedItemIdsRef = useRef<Set<string>>(new Set());
   // State for sidebar visibility
   const [isDesktopSidebarVisible, setIsDesktopSidebarVisible] = useState(true);
@@ -485,6 +487,13 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
       sectionItems[waitingForNextSection.sectionId].length > 0) {
 
       const firstItem = sectionItems[waitingForNextSection.sectionId][0];
+
+      // If the first item of the newly-loaded section isn't a quiz, drop any
+      // pending pre-quiz prompt that was tentatively set before this section
+      // finished loading.
+      if (firstItem?.type?.toLowerCase() !== 'quiz') {
+        setPendingStudentQuestionContext(null);
+      }
 
       // Clear waiting state
       setWaitingForNextSection(null);
@@ -785,6 +794,8 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
   const handleSelectItem = useCallback((moduleId: string, sectionId: string, itemId: string) => {
     enqueueNavigation(async () => {
       setIsNavigatingToNext(true);
+      // Sidebar navigation away cancels any pending pre-quiz prompt.
+      setPendingStudentQuestionContext(null);
 
       try {
         // Stop current item immediately
@@ -871,7 +882,13 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
   };
 
   // Helper function to find the next item in the course structure
-  const findNextItem = useCallback(() => {
+  const findNextItem = useCallback((): {
+    moduleId: string;
+    sectionId: string;
+    itemId: string | null;
+    type?: string | null;
+    needsLoading?: boolean;
+  } | null => {
     if (!courseVersionData || !selectedModuleId || !selectedSectionId || !selectedItemId) {
       return null;
     }
@@ -901,7 +918,8 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
       return {
         moduleId: selectedModuleId,
         sectionId: selectedSectionId,
-        itemId: nextItem._id
+        itemId: nextItem._id,
+        type: nextItem.type?.toLowerCase() ?? null,
       };
     }
 
@@ -913,7 +931,8 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
         return {
           moduleId: selectedModuleId,
           sectionId: nextSection.sectionId,
-          itemId: nextSectionItems[0]._id
+          itemId: nextSectionItems[0]._id,
+          type: nextSectionItems[0].type?.toLowerCase() ?? null,
         };
       } else {
         // Next section exists but items not loaded - return section info to trigger loading
@@ -921,6 +940,7 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
           moduleId: selectedModuleId,
           sectionId: nextSection.sectionId,
           itemId: null, // Will be set after items are loaded
+          type: null,
           needsLoading: true
         };
       }
@@ -937,7 +957,8 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
           return {
             moduleId: nextModule.moduleId,
             sectionId: firstNextSection.sectionId,
-            itemId: nextModuleItems[0]._id
+            itemId: nextModuleItems[0]._id,
+            type: nextModuleItems[0].type?.toLowerCase() ?? null,
           };
         } else {
           // Next section exists but items not loaded - return section info to trigger loading
@@ -945,6 +966,7 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
             moduleId: nextModule.moduleId,
             sectionId: firstNextSection.sectionId,
             itemId: null, // Will be set after items are loaded
+            type: null,
             needsLoading: true
           };
         }
@@ -1159,7 +1181,30 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
 
         // 2️⃣ Determine next item
         const nextItem = findNextItem();
-       
+
+        // If a video just finished and the next item is a quiz, and the course
+        // version has crowdsourced question submission enabled, stage a pre-quiz
+        // prompt so the student can contribute an MCQ before the quiz auto-starts.
+        const justFinishedItem = sectionItems[selectedSectionId!]?.find(
+          (item: any) => item._id === selectedItemId,
+        );
+        const isVideoToQuizTransition =
+          justFinishedItem?.type?.toLowerCase() === 'video' &&
+          nextItem?.type === 'quiz';
+        if (
+          isVideoToQuizTransition &&
+          proctoringData?.settings?.crowdsourcedQuestionSubmissionEnabled === true &&
+          selectedItemId
+        ) {
+          setPendingStudentQuestionContext({
+            courseId: COURSE_ID,
+            courseVersionId: VERSION_ID,
+            segmentId: selectedItemId,
+          });
+        } else {
+          setPendingStudentQuestionContext(null);
+        }
+
         if (!nextItem) {
           console.log("🎉 Course complete");
           setIsNavigatingToNext(false);
@@ -2287,6 +2332,8 @@ return false;
                         nextItem={findNextItem()}
                         cohortId={COHORT_ID}
                         cohortName={COHORT_NAME}
+                        pendingStudentQuestionContext={pendingStudentQuestionContext}
+                        clearPendingStudentQuestionContext={() => setPendingStudentQuestionContext(null)}
                       />
                     )}
 

--- a/frontend/src/components/EditProctoringModal.tsx
+++ b/frontend/src/components/EditProctoringModal.tsx
@@ -66,6 +66,7 @@ export function ProctoringModal({
   const [isPublic, setIsPublic] = useState(false);
   const [isAdditionalSettingsExpanded, setIsAdditionalSettingsExpanded] = useState(false);
   const [enableRandomize, setEnableRandomize] = useState<boolean>(false);
+  const [crowdsourcedQuestionSubmissionEnabled, setCrowdsourcedQuestionSubmissionEnabled] = useState(false);
   const { data: courseVersion, isLoading: versionLoading } = useCourseVersionById(courseVersionId || "")
 
   useEffect(() => {
@@ -80,6 +81,9 @@ export function ProctoringModal({
           setHpSystemEnabled(result.settings?.hpSystem ?? false)
           setbaseHp(result.settings?.baseHp ?? 0)
           setEnableRandomize(result.settings?.randomizeItems ?? false)
+          setCrowdsourcedQuestionSubmissionEnabled(
+            result.settings?.crowdsourcedQuestionSubmissionEnabled ?? false,
+          )
         }
       } catch (err) {
         console.error("Failed to fetch proctoring settings:", err)
@@ -101,7 +105,7 @@ export function ProctoringModal({
 
   const handleSubmit = async () => {
     try {
-      const result = await editSettings(courseId, courseVersionId, detectors, isNew, linearProgressionEnabled, seekForwardEnabled, isPublic, hpSystemEnabled, baseHp, enableRandomize)
+      const result = await editSettings(courseId, courseVersionId, detectors, isNew, linearProgressionEnabled, seekForwardEnabled, isPublic, hpSystemEnabled, baseHp, enableRandomize, crowdsourcedQuestionSubmissionEnabled)
       if (result != undefined) {
         onSuccess?.();
         onClose();
@@ -273,6 +277,20 @@ export function ProctoringModal({
                         <p className="text-xs text-muted-foreground">Shuffle content order for a unique student experience.</p>
                       </div>
                       <Switch checked={enableRandomize} disabled={linearProgressionEnabled} onCheckedChange={() => setEnableRandomize(prev => !prev)} />
+                    </div>
+                  </div>
+                  <div>
+                    <div className="flex items-center justify-between space-x-3">
+                      <div className="space-y-1">
+                        <Label className="text-sm font-medium">Student Question Submission</Label>
+                        <p className="text-xs text-muted-foreground">Allow students to submit a post-video MCQ before the next quiz.</p>
+                      </div>
+                      <Switch
+                        checked={crowdsourcedQuestionSubmissionEnabled}
+                        onCheckedChange={() =>
+                          setCrowdsourcedQuestionSubmissionEnabled(prev => !prev)
+                        }
+                      />
                     </div>
                   </div>
                 </div>

--- a/frontend/src/components/Item-container.tsx
+++ b/frontend/src/components/Item-container.tsx
@@ -16,7 +16,7 @@ export interface ISubmitFeedbackBody {
   // isSkipped?: boolean;
   cohortId?: string;
 }
-const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, nextItem, doGesture, onNext, onPrevVideo, isProgressUpdating, isNavigatingToPrev, readyToDetect, attemptId, anomalies, setQuizPassed, setAttemptId, rewindVid, pauseVid, displayNextLesson, keyboardLockEnabled, setIsQuizSkipped, linearProgressionEnabled, seekForwardEnabled, courseId, versionId, completedItemIdsRef, cohortId, cohortName, previousItem }, ref) => {
+const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, nextItem, doGesture, onNext, onPrevVideo, isProgressUpdating, isNavigatingToPrev, readyToDetect, attemptId, anomalies, setQuizPassed, setAttemptId, rewindVid, pauseVid, displayNextLesson, keyboardLockEnabled, setIsQuizSkipped, linearProgressionEnabled, seekForwardEnabled, courseId, versionId, completedItemIdsRef, cohortId, cohortName, previousItem, pendingStudentQuestionContext, clearPendingStudentQuestionContext }, ref) => {
   const articleRef = useRef<ArticleRef>(null);
   const quizRef = useRef<QuizRef>(null);
 
@@ -103,6 +103,8 @@ const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, 
           isAlreadyWatched={item.isAlreadyWatched || false}
           completedItemIdsRef={completedItemIdsRef}
           nextItemId={nextItem?.itemId?.toString()}
+          pendingStudentQuestionContext={pendingStudentQuestionContext}
+          clearPendingStudentQuestionContext={clearPendingStudentQuestionContext}
         />;
 
       case 'article':

--- a/frontend/src/components/StudentQuestionComposer.tsx
+++ b/frontend/src/components/StudentQuestionComposer.tsx
@@ -1,0 +1,184 @@
+import {useEffect, useState} from 'react';
+import {Plus, Trash2} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {Input} from '@/components/ui/input';
+import {Label} from '@/components/ui/label';
+import {Textarea} from '@/components/ui/textarea';
+import type {
+  StudentQuestionOptionInput,
+  StudentQuestionSubmissionPayload,
+} from '@/types/student-question.types';
+
+const MIN_OPTIONS = 2;
+const MAX_OPTIONS = 8;
+const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+
+function emptyOption(): StudentQuestionOptionInput {
+  return {text: ''};
+}
+
+function initialPayload(): StudentQuestionSubmissionPayload {
+  return {
+    questionType: 'SELECT_ONE_IN_LOT',
+    questionText: '',
+    options: [emptyOption(), emptyOption()],
+    correctOptionIndex: 0,
+  };
+}
+
+interface StudentQuestionComposerProps {
+  isOpen: boolean;
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onSubmit: (payload: StudentQuestionSubmissionPayload) => Promise<void> | void;
+}
+
+export default function StudentQuestionComposer({
+  isOpen,
+  isSubmitting,
+  onCancel,
+  onSubmit,
+}: StudentQuestionComposerProps) {
+  const [payload, setPayload] = useState<StudentQuestionSubmissionPayload>(initialPayload);
+
+  useEffect(() => {
+    if (isOpen) {
+      setPayload(initialPayload());
+    }
+  }, [isOpen]);
+
+  const updateOption = (index: number, text: string) => {
+    setPayload(current => ({
+      ...current,
+      options: current.options.map((option, i) => (i === index ? {text} : option)),
+    }));
+  };
+
+  const addOption = () => {
+    setPayload(current => {
+      if (current.options.length >= MAX_OPTIONS) return current;
+      return {...current, options: [...current.options, emptyOption()]};
+    });
+  };
+
+  const removeOption = (index: number) => {
+    setPayload(current => {
+      if (current.options.length <= MIN_OPTIONS) return current;
+      const nextOptions = current.options.filter((_, i) => i !== index);
+      const nextCorrect =
+        current.correctOptionIndex === index
+          ? 0
+          : current.correctOptionIndex > index
+            ? current.correctOptionIndex - 1
+            : current.correctOptionIndex;
+      return {...current, options: nextOptions, correctOptionIndex: nextCorrect};
+    });
+  };
+
+  const trimmedQuestion = payload.questionText.trim();
+  const disabled =
+    isSubmitting ||
+    trimmedQuestion.length < 10 ||
+    trimmedQuestion.length > 300 ||
+    payload.options.length < MIN_OPTIONS ||
+    payload.options.some(option => !option.text?.trim());
+
+  return (
+    <div className="grid gap-4">
+      <div className="grid gap-1.5">
+        <Label htmlFor="student-question-text" className="text-sm font-medium">
+          Question prompt
+        </Label>
+        <Textarea
+          id="student-question-text"
+          placeholder="Write the MCQ prompt students should answer (10-300 characters)"
+          className="min-h-[80px] resize-none text-sm"
+          maxLength={300}
+          value={payload.questionText}
+          onChange={event =>
+            setPayload(current => ({...current, questionText: event.target.value}))
+          }
+        />
+        <p className="text-xs text-muted-foreground">
+          {trimmedQuestion.length}/300 characters
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        <div className="flex items-center justify-between">
+          <Label className="text-sm font-medium">
+            Options{' '}
+            <span className="text-xs font-normal text-muted-foreground">
+              — select the correct answer
+            </span>
+          </Label>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            onClick={addOption}
+            disabled={payload.options.length >= MAX_OPTIONS}
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            Add option
+          </Button>
+        </div>
+
+        {payload.options.map((option, index) => (
+          <div key={`option-${index}`} className="flex items-center gap-2">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">
+              {OPTION_LABELS[index]}
+            </span>
+            <Input
+              placeholder="Option text"
+              className="h-8 flex-1 text-sm"
+              maxLength={150}
+              value={option.text}
+              onChange={event => updateOption(index, event.target.value)}
+            />
+            <input
+              type="radio"
+              name="student-question-correct-option"
+              checked={payload.correctOptionIndex === index}
+              onChange={() =>
+                setPayload(current => ({...current, correctOptionIndex: index}))
+              }
+              className="h-4 w-4 shrink-0 accent-primary"
+              title="Mark as correct answer"
+            />
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border text-muted-foreground hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-30"
+              onClick={() => removeOption(index)}
+              disabled={payload.options.length <= MIN_OPTIONS}
+              title="Remove option"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex justify-end gap-2 pt-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onCancel}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => onSubmit(payload)}
+          disabled={disabled}
+        >
+          {isSubmitting ? 'Submitting...' : 'Submit MCQ'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/quiz.tsx
+++ b/frontend/src/components/quiz.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useImperativeHandle, forwardRe
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { toast } from "sonner";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -10,7 +11,9 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
 import { Clock, Trophy, ChevronLeft, ChevronRight, RotateCcw, GripVertical, PlayCircle, BookOpen, Target, Timer, Users, AlertCircle, Eye, FileQuestion, ChevronDown } from "lucide-react";
-import { useAttemptQuiz, useSubmitQuiz, useSaveQuiz, useStartItem, useStopItem, CreateAttemptResponse, SaveQuizResponse, useSkipOptionalItem } from '@/hooks/hooks';
+import { useAttemptQuiz, useSubmitQuiz, useSaveQuiz, useStartItem, useStopItem, CreateAttemptResponse, SaveQuizResponse, useSkipOptionalItem, useSubmitStudentQuestion } from '@/hooks/hooks';
+import StudentQuestionComposer from './StudentQuestionComposer';
+import type { StudentQuestionSubmissionPayload } from '@/types/student-question.types';
 import { useCourseStore } from "@/store/course-store";
 import MathRenderer from "./math-renderer";
 import { bufferToHex } from '@/utils/helpers';
@@ -55,7 +58,9 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
   linearProgressionEnabled,
   isAlreadyWatched,
   completedItemIdsRef,
-  nextItemId
+  nextItemId,
+  pendingStudentQuestionContext,
+  clearPendingStudentQuestionContext,
 }, ref) => {
   // console.log('Quiz component rendered with props:', {});
   // ===== CORE STATE =====
@@ -83,6 +88,7 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
   const [emptyQuizRedirectCountdown, setEmptyQuizRedirectCountdown] = useState<number | null>(null);
   const emptyQuizNextTimerRef = useRef<ReturnType<typeof window.setTimeout> | undefined>(undefined);
   const [finshingQuiz, setFinshingQuiz] = useState(false);
+  const [showQuestionModal, setShowQuestionModal] = useState(false);
 
   // ===== REFS AND CONSTANTS =====
   const itemStartedRef = useRef(false);
@@ -99,6 +105,38 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
   const stopItem = useStopItem();
   const isStopping = stopItem.isPending;
   const { mutateAsync: skipItemAsync } = useSkipOptionalItem();
+  const { submitQuestion, loading: isSubmittingQuestion } = useSubmitStudentQuestion();
+
+  const handleContinueToQuiz = useCallback(() => {
+    setShowQuestionModal(false);
+    clearPendingStudentQuestionContext?.();
+  }, [clearPendingStudentQuestionContext]);
+
+  const handleQuestionSubmit = useCallback(async (payload: StudentQuestionSubmissionPayload) => {
+    if (!pendingStudentQuestionContext) {
+      toast.error('Unable to submit question for this video.');
+      return;
+    }
+    try {
+      await submitQuestion(
+        pendingStudentQuestionContext.courseId,
+        pendingStudentQuestionContext.courseVersionId,
+        pendingStudentQuestionContext.segmentId,
+        payload,
+      );
+      toast.success('Question submitted successfully');
+      setShowQuestionModal(false);
+      clearPendingStudentQuestionContext?.();
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to submit question');
+    }
+  }, [clearPendingStudentQuestionContext, pendingStudentQuestionContext, submitQuestion]);
+
+  useEffect(() => {
+    if (!pendingStudentQuestionContext) {
+      setShowQuestionModal(false);
+    }
+  }, [pendingStudentQuestionContext]);
 
   const handleSkipItem = async () => {
     if (!currentCourse?.itemId) return;
@@ -566,6 +604,10 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
       return;
     }
 
+    // If the pre-quiz crowd-question prompt is still open, clicking "Start Quiz"
+    // implicitly skips it.
+    clearPendingStudentQuestionContext?.();
+
     quizAttemptedRef.current = true;
 
     try {
@@ -670,7 +712,7 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
       quizAttemptedRef.current = false;
       toast.error('Failed to start quiz: ' + errorMessage);
     }
-  }, [attemptQuiz, processedQuizId, setAttemptId, convertBackendQuestions, handleSendStartItem, stopItem, currentCourse, attemptId, nextItemId, quizStarted, isPending]);
+  }, [attemptQuiz, processedQuizId, setAttemptId, convertBackendQuestions, handleSendStartItem, stopItem, currentCourse, attemptId, nextItemId, quizStarted, isPending, clearPendingStudentQuestionContext]);
 
   const completeQuiz = useCallback(async (isSkipped?: boolean) => {
     if (!attemptId) {
@@ -1034,9 +1076,11 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
     setShowHint(false);
   }, [currentQuestionIndex]);
 
-  // Auto-start quiz for NO_DEADLINE type, but first check if quiz is empty
+  // Auto-start quiz for NO_DEADLINE type, but first check if quiz is empty.
+  // Hold off auto-start while a pre-quiz crowd-question prompt is pending so the
+  // student gets a chance to submit (or skip) before the quiz takes over.
   useEffect(() => {
-    if (!quizStarted && !quizCompleted && !isEmptyQuiz && !noAttemptsLeft && quizType === 'NO_DEADLINE' && quizQuestions.length === 0 && !isPending && !quizAttemptedRef.current && !dontStart) {
+    if (!quizStarted && !quizCompleted && !isEmptyQuiz && !noAttemptsLeft && quizType === 'NO_DEADLINE' && quizQuestions.length === 0 && !isPending && !quizAttemptedRef.current && !dontStart && !pendingStudentQuestionContext) {
       // Check if quiz has any question banks first to detect empty quizzes early
       if (!questionBankRefs || questionBankRefs.length === 0) {
         handleEmptyQuiz();
@@ -1045,7 +1089,7 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
       }
       setDontStart(true);
     }
-  }, [quizType, quizStarted, quizCompleted, isEmptyQuiz, noAttemptsLeft, quizQuestions.length, isPending, dontStart, startQuiz, questionBankRefs]);
+  }, [quizType, quizStarted, quizCompleted, isEmptyQuiz, noAttemptsLeft, quizQuestions.length, isPending, dontStart, startQuiz, questionBankRefs, pendingStudentQuestionContext]);
 
 
   useEffect(() => {
@@ -1178,6 +1222,69 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
   // Quiz not started
 
   if (!quizStarted) {
+    if (pendingStudentQuestionContext && !noAttemptsLeft && !isEmptyQuiz) {
+      return (
+        <div className="mx-auto space-y-8">
+          <Card className="border-2 border-primary/20 bg-gradient-to-br from-background to-muted/40">
+            <CardHeader className="pb-4">
+              <div className="space-y-3">
+                <CardTitle className="text-2xl font-bold">
+                  Before the Quiz, Submit an MCQ for This Video
+                </CardTitle>
+                <CardDescription className="text-base text-muted-foreground">
+                  You just completed the video segment. Please submit one MCQ for this segment before proceeding to the quiz.
+                </CardDescription>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  onClick={() => setShowQuestionModal(true)}
+                  disabled={isSubmittingQuestion}
+                >
+                  Submit MCQ Question
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={handleContinueToQuiz}
+                  disabled={isSubmittingQuestion}
+                >
+                  Skip and Continue to Quiz
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Single-answer MCQ, 2 to 8 options, 10 to 300 character prompt.
+              </p>
+            </CardContent>
+          </Card>
+
+          <Dialog
+            open={showQuestionModal}
+            onOpenChange={(open) => {
+              if (!isSubmittingQuestion) {
+                setShowQuestionModal(open);
+              }
+            }}
+          >
+            <DialogContent
+              className="sm:max-w-[760px] max-h-[90vh] overflow-y-auto"
+              onInteractOutside={e => e.preventDefault()}
+              onEscapeKeyDown={e => e.preventDefault()}
+            >
+              <DialogHeader>
+                <DialogTitle>Submit an MCQ Question</DialogTitle>
+              </DialogHeader>
+              <StudentQuestionComposer
+                isOpen={showQuestionModal}
+                isSubmitting={isSubmittingQuestion}
+                onCancel={() => setShowQuestionModal(false)}
+                onSubmit={handleQuestionSubmit}
+              />
+            </DialogContent>
+          </Dialog>
+        </div>
+      );
+    }
     if (quizType === 'DEADLINE') {
       return (
         <div className="mx-auto space-y-8">

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -2139,6 +2139,7 @@ export function useEditProctoringSettings() {
     hpSystem: boolean,
     baseHp: number,
     randomizeItems: boolean,
+    crowdsourcedQuestionSubmissionEnabled: boolean = false,
   ) => {
     setLoading(true);
     setError(null);
@@ -2160,6 +2161,7 @@ export function useEditProctoringSettings() {
         hpSystem,
         baseHp,
         randomizeItems,
+        crowdsourcedQuestionSubmissionEnabled,
       };
 
       const res = await fetch(url, {
@@ -2182,6 +2184,63 @@ export function useEditProctoringSettings() {
   };
 
   return { editSettings, loading, error };
+}
+
+export function useSubmitStudentQuestion(): {
+  submitQuestion: (
+    courseId: string,
+    courseVersionId: string,
+    segmentId: string,
+    payload: import('@/types/student-question.types').StudentQuestionSubmissionPayload,
+  ) => Promise<{ questionId: string }>;
+  loading: boolean;
+  error: string | null;
+} {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submitQuestion = async (
+    courseId: string,
+    courseVersionId: string,
+    segmentId: string,
+    payload: import('@/types/student-question.types').StudentQuestionSubmissionPayload,
+  ): Promise<{ questionId: string }> => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/student-questions/courses/${courseId}/versions/${courseVersionId}/segments/${segmentId}`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        let serverMessage = '';
+        try {
+          const errBody = await response.json();
+          serverMessage = errBody?.message || errBody?.error || '';
+        } catch {
+          /* response had no JSON body */
+        }
+        throw new Error(serverMessage || `Failed to submit question: ${response.status}`);
+      }
+
+      return await response.json();
+    } catch (err: any) {
+      const message = err?.message || 'Failed to submit student question';
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { submitQuestion, loading, error };
 }
 
 export function usePublicCourses(

--- a/frontend/src/types/item-container.types.ts
+++ b/frontend/src/types/item-container.types.ts
@@ -1,4 +1,5 @@
 import type { questionBankRef } from './quiz.types';
+import type { PendingStudentQuestionContext } from './student-question.types';
 
 export interface Item {
   _id: string;
@@ -70,7 +71,9 @@ export interface ItemContainerProps {
   nextItem: {itemId:string};
   cohortId?: string;
   cohortname?: string;
-  previousItem?: object
+  previousItem?: object;
+  pendingStudentQuestionContext?: PendingStudentQuestionContext | null;
+  clearPendingStudentQuestionContext?: () => void;
 }
 
 export interface ItemContainerRef {

--- a/frontend/src/types/quiz.types.ts
+++ b/frontend/src/types/quiz.types.ts
@@ -77,6 +77,8 @@ export interface QuizProps {
   isAlreadyWatched?: boolean;
   completedItemIdsRef: React.RefObject<Set<string>>;
   nextItemId?: string;
+  pendingStudentQuestionContext?: import('./student-question.types').PendingStudentQuestionContext | null;
+  clearPendingStudentQuestionContext?: () => void;
 }
 
 export interface QuizRef {

--- a/frontend/src/types/student-question.types.ts
+++ b/frontend/src/types/student-question.types.ts
@@ -1,0 +1,38 @@
+export interface PendingStudentQuestionContext {
+  courseId: string;
+  courseVersionId: string;
+  segmentId: string;
+}
+
+export type StudentQuestionType = 'SELECT_ONE_IN_LOT';
+
+export interface StudentQuestionOptionInput {
+  text: string;
+}
+
+export interface StudentQuestionSubmissionPayload {
+  questionType: StudentQuestionType;
+  questionText: string;
+  options: StudentQuestionOptionInput[];
+  correctOptionIndex: number;
+}
+
+export type StudentQuestionStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
+
+export interface StudentQuestionListItem {
+  _id: string;
+  questionText: string;
+  options: {text: string}[];
+  correctOptionIndex: number;
+  status: StudentQuestionStatus;
+  source: string;
+  createdBy: string;
+  createdAt: string;
+  reviewedBy?: string;
+  reviewedAt?: string;
+  rejectionReason?: string;
+}
+
+export interface StudentQuestionListResponse {
+  items: StudentQuestionListItem[];
+}


### PR DESCRIPTION
Teachers can enable a per-course-version toggle that prompts students to contribute one MCQ at video->quiz transitions. Submissions land in db.studentSegmentQuestions at status PENDING; teacher review UI is a follow-up.

- Backend studentQuestions module: controller, service, MongoDB repository, validators, DTOs. Routes scoped to (courseId, versionId, segmentId).
- ISettings.crowdsourcedQuestionSubmissionEnabled threaded through the setting module's DTO, controller, service, repository.
- Frontend toggle under Proctoring Settings -> Additional Settings.
- StudentQuestionComposer (text-only, 2-8 options, 10-300 chars).
- Pre-quiz card in quiz.tsx with auto-start gating and hardened dialog.
- pendingStudentQuestionContext plumbed through student/course-page -> ItemContainer -> Quiz.

