### PR TITLE
feat: import quiz questions from CSV

### DIFF
--- a/frontend/public/templates/quiz-questions-template.csv
+++ b/frontend/public/templates/quiz-questions-template.csv
@@ -1,0 +1,3 @@
+S.No.,Question,Hint,Option A,Expln-A,Option B,Expln-B,Option C,Expln-C,Option D,Expln-D,Correct Answer
+1,What is 2 + 2?,Basic addition,3,Incorrect — 3 is one less than 4,4,Correct — 2 + 2 equals 4,5,Incorrect — 5 is one more than 4,22,Incorrect — string concatenation is not addition,B
+2,Which planet is known as the Red Planet?,Think rust-colored,Venus,Venus is shrouded in yellow clouds,Mars,Mars appears red due to iron oxide on its surface,Jupiter,Jupiter is a gas giant with banded colors,Mercury,Mercury is gray and rocky,B

--- a/frontend/src/app/pages/teacher/teacher-course-page.tsx
+++ b/frontend/src/app/pages/teacher/teacher-course-page.tsx
@@ -150,6 +150,8 @@ function TeacherCourseContent() {
     navigate({ to: "/auth" });
   };
   const createQuestion = useCreateQuestion();
+  const createQuestionBank = useCreateQuestionBank();
+  const addQuestionBankToQuiz = useAddQuestionBankToQuiz();
   const user = useAuthStore().user;
   const { currentCourse, setCurrentCourse } = useCourseStore();
   // Use correct keys for course/version IDs
@@ -453,6 +455,15 @@ function TeacherCourseContent() {
   const [youtubeUrl, setYoutubeUrl] = useState('');
   const userCSVtoItem = userParseCSVtoItems();
   const queryClient = useQueryClient()
+
+  // Quiz creation flow: after picking "Quiz" from the Add Item dropdown the user
+  // chooses between starting blank or uploading a CSV of questions.
+  const [quizChoiceOpen, setQuizChoiceOpen] = useState(false);
+  const [pendingQuizContext, setPendingQuizContext] = useState<{
+    moduleId: string;
+    sectionId: string;
+  } | null>(null);
+  const [quizCsvDialogOpen, setQuizCsvDialogOpen] = useState(false);
 
 
   const updateItemOptional = useUpdateItemOptional();
@@ -1234,6 +1245,157 @@ function TeacherCourseContent() {
     }
   };
 
+  type QuizCsvRow = {
+    Question?: string;
+    Hint?: string;
+    'Option A'?: string;
+    'Option B'?: string;
+    'Option C'?: string;
+    'Option D'?: string;
+    'Expln-A'?: string;
+    'Expln-B'?: string;
+    'Expln-C'?: string;
+    'Expln-D'?: string;
+    'Correct Answer'?: string;
+  };
+
+  // Creates the quiz item + populates its question bank from an uploaded CSV.
+  // Defers item creation until the file is actually being uploaded so cancelling
+  // the dialog doesn't leave an orphan empty quiz behind.
+  const handleQuizCsvUpload = async (file: File) => {
+    if (!versionId || !pendingQuizContext) {
+      throw new Error("Missing course/section context for quiz creation.");
+    }
+    const { moduleId, sectionId } = pendingQuizContext;
+
+    const parsed = (Papa as any).parse(await file.text(), {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (h: string) => h.trim(),
+    }) as { data: QuizCsvRow[]; errors: Array<{ message: string }> };
+    if (parsed.errors.length) {
+      throw new Error(`CSV parse error: ${parsed.errors[0].message}`);
+    }
+    const rows: QuizCsvRow[] = parsed.data.filter((r: QuizCsvRow) => (r.Question ?? '').trim().length > 0);
+    if (rows.length === 0) {
+      throw new Error("CSV has no question rows.");
+    }
+
+    const requiredCols = ['Question', 'Option A', 'Option B', 'Option C', 'Option D', 'Correct Answer'] as const;
+    rows.forEach((row: QuizCsvRow, i: number) => {
+      const missing = requiredCols.filter(c => !((row as any)[c]?.toString().trim()));
+      if (missing.length) {
+        throw new Error(`Row ${i + 1}: missing ${missing.join(', ')}.`);
+      }
+      const ans = (row['Correct Answer'] ?? '').toString().trim().toUpperCase();
+      if (!['A', 'B', 'C', 'D'].includes(ans)) {
+        throw new Error(`Row ${i + 1}: Correct Answer must be A, B, C, or D.`);
+      }
+    });
+
+    // 1. Create the quiz item now that we know we'll populate it.
+    // Backend requires a fully-populated quizDetails when type === 'QUIZ';
+    // we pick sensible defaults matched to the imported CSV. Teacher can edit
+    // these later in the quiz settings dialog.
+    const created = await createItemAsync({
+      params: { path: { versionId, moduleId, sectionId } },
+      body: {
+        type: 'QUIZ',
+        name: 'New QUIZ',
+        description: 'Imported from CSV',
+        quizDetails: {
+          passThreshold: 0.7,
+          maxAttempts: -1,
+          quizType: 'NO_DEADLINE',
+          approximateTimeToComplete: '00:30:00',
+          allowPartialGrading: true,
+          allowHint: true,
+          allowSkip: true,
+          showCorrectAnswersAfterSubmission: true,
+          showExplanationAfterSubmission: true,
+          showScoreAfterSubmission: true,
+          questionVisibility: rows.length,
+          releaseTime: new Date().toISOString(),
+          questionBankRefs: [],
+        },
+      },
+    });
+    const newQuiz: any =
+      (created as any)?.createdItem || (created as any)?.item || (created as any)?.data;
+    const newQuizId: string | undefined = newQuiz?._id || newQuiz?.itemId;
+    if (!newQuizId) {
+      throw new Error("Quiz was created but no ID was returned.");
+    }
+
+    // 2. Create one question per row.
+    const questionIds: string[] = [];
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i];
+      const correct = (row['Correct Answer'] ?? '').toString().trim().toUpperCase() as 'A' | 'B' | 'C' | 'D';
+      const opts: Record<'A' | 'B' | 'C' | 'D', string> = {
+        A: row['Option A']!.toString(),
+        B: row['Option B']!.toString(),
+        C: row['Option C']!.toString(),
+        D: row['Option D']!.toString(),
+      };
+      // Backend requires non-empty explaination for every lot item; fall back
+      // when the CSV cell is blank or missing.
+      const explFallback = "No explanation provided.";
+      const expl: Record<'A' | 'B' | 'C' | 'D', string> = {
+        A: row['Expln-A']?.toString().trim() || explFallback,
+        B: row['Expln-B']?.toString().trim() || explFallback,
+        C: row['Expln-C']?.toString().trim() || explFallback,
+        D: row['Expln-D']?.toString().trim() || explFallback,
+      };
+      const incorrectKeys = (['A', 'B', 'C', 'D'] as const).filter(k => k !== correct);
+
+      const res = await createQuestion.mutateAsync({
+        body: {
+          question: {
+            text: row.Question!.toString(),
+            type: 'SELECT_ONE_IN_LOT',
+            isParameterized: false,
+            parameters: [],
+            hint: row.Hint?.toString() ?? '',
+            timeLimitSeconds: 60,
+            points: 1,
+            priority: 'MEDIUM',
+          },
+          solution: {
+            correctLotItem: { text: opts[correct], explaination: expl[correct] },
+            incorrectLotItems: incorrectKeys.map(k => ({
+              text: opts[k],
+              explaination: expl[k],
+            })),
+          },
+        },
+      });
+      questionIds.push(res.questionId);
+    }
+
+    // 3. Bundle the questions into a bank.
+    const bankRes = await createQuestionBank.mutateAsync({
+      body: {
+        courseId,
+        courseVersionId: versionId,
+        questions: questionIds,
+        title: 'Imported Questions',
+        description: 'Imported from CSV',
+      },
+    });
+
+    // 4. Attach the bank to the new quiz.
+    await addQuestionBankToQuiz.mutateAsync({
+      params: { path: { quizId: newQuizId } },
+      body: { bankId: bankRes.questionBankId, count: questionIds.length },
+    });
+
+    refetchVersion();
+    if (shouldFetchItems) refetchItems();
+    setActiveSectionInfo({ moduleId, sectionId });
+    setPendingQuizContext(null);
+  };
+
   const navigate = useNavigate();
 
   // Interim state of modules
@@ -1561,6 +1723,67 @@ function TeacherCourseContent() {
           }
         }}
       />
+
+      {/* Quiz creation: blank vs upload-CSV choice */}
+      <Dialog
+        open={quizChoiceOpen}
+        onOpenChange={(open) => {
+          setQuizChoiceOpen(open);
+          if (!open) setPendingQuizContext(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-[420px]">
+          <DialogHeader>
+            <DialogTitle>Add Quiz</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            How would you like to start this quiz?
+          </p>
+          <div className="grid gap-2 pt-2">
+            <Button
+              variant="default"
+              onClick={() => {
+                if (!pendingQuizContext) return;
+                const { moduleId, sectionId } = pendingQuizContext;
+                setQuizModuleId(moduleId);
+                setQuizSectionId(sectionId);
+                if (currentCourse) {
+                  setCurrentCourse({ ...currentCourse, moduleId, sectionId });
+                }
+                setQuizWizardOpen(true);
+                setQuizChoiceOpen(false);
+                setPendingQuizContext(null);
+              }}
+            >
+              Start blank
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setQuizChoiceOpen(false);
+                setQuizCsvDialogOpen(true);
+              }}
+              disabled={!pendingQuizContext}
+            >
+              Upload CSV to populate questions
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Quiz-from-CSV upload (no YouTube URL, no Smart Upload) */}
+      <QuestionUploadDialog
+        open={quizCsvDialogOpen}
+        mode="quiz-questions"
+        onOpenChange={(open) => {
+          setQuizCsvDialogOpen(open);
+          if (!open) setPendingQuizContext(null);
+        }}
+        onUploadComplete={async (_youtubeUrl: string, csvFile: File) => {
+          await handleQuizCsvUpload(csvFile);
+        }}
+      />
+
       {/* Mobile Sidebar Overlay */}
       {/* {isMobileSidebarOpen && (
         <div
@@ -1892,28 +2115,10 @@ function TeacherCourseContent() {
 
                                                     } else if (type === "quiz") {
 
-                                                      setQuizModuleId(module.moduleId);
-
-                                                      setQuizSectionId(section.sectionId);
-
-                                                      // Update course store with current context
-
-                                                      if (currentCourse) {
-
-                                                        setCurrentCourse({
-
-                                                          ...currentCourse,
-
-                                                          moduleId: module.moduleId,
-
-                                                          sectionId: section.sectionId
-
-                                                        });
-
-                                                      }
-
-                                                      setQuizWizardOpen(true);
-
+                                                      // Defer creation until the teacher decides between starting
+                                                      // blank (existing wizard) and importing questions from a CSV.
+                                                      setPendingQuizContext({ moduleId: module.moduleId, sectionId: section.sectionId });
+                                                      setQuizChoiceOpen(true);
 
                                                     }
                                                     else if (type === "project") {

--- a/frontend/src/components/question-upload-dialog.tsx
+++ b/frontend/src/components/question-upload-dialog.tsx
@@ -21,6 +21,10 @@ interface QuestionUploadDialogProps {
   onUploadComplete: (youtubeURL: string,  csvFile:File) => Promise<void>
   moduleId?: string;
   sectionId?: string;
+  // "video-segments" (default): existing flow that pairs a YouTube URL with a segmented CSV.
+  // "quiz-questions": upload a CSV of questions to populate a single quiz; hides the YouTube URL
+  // field, the Smart Upload button, and uses the quiz-questions CSV template + help text.
+  mode?: "video-segments" | "quiz-questions";
 }
 
 const processingMessages = [
@@ -39,8 +43,10 @@ type Step = "input" | "generating" | "response" | "csv-preview" | "csv-confirm" 
 export const QuestionUploadDialog = ({
   open,
   onOpenChange,
-  onUploadComplete
+  onUploadComplete,
+  mode = "video-segments",
 }: QuestionUploadDialogProps) => {
+  const isQuizQuestionsMode = mode === "quiz-questions";
   const [step, setStep] = useState<Step>("input");
   const [youtubeUrl, setYoutubeUrl] = useState("");
   const [urlError, setUrlError] = useState("");
@@ -354,23 +360,25 @@ const handleGenerateLLMResponse = async () => {
           (<DialogContent className="sm:max-w-[500px]">
               <DialogHeader>
                 <DialogTitle>Upload Questions</DialogTitle>
-                
+
               </DialogHeader>
 
               <div className="grid gap-4 py-4">
-                <div className="space-y-2">
-                  <Label htmlFor="youtube-url">YouTube Video URL</Label>
-                  <Input
-                    id="youtube-url"
-                    placeholder="https://www.youtube.com/watch?v=..."
-                    value={youtubeUrl}
-                    onChange={(e) => setYoutubeUrl(e.target.value)}
-                    disabled={step=="uploading"}
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    The video that these questions are based on
-                  </p>
-                </div>
+                {!isQuizQuestionsMode && (
+                  <div className="space-y-2">
+                    <Label htmlFor="youtube-url">YouTube Video URL</Label>
+                    <Input
+                      id="youtube-url"
+                      placeholder="https://www.youtube.com/watch?v=..."
+                      value={youtubeUrl}
+                      onChange={(e) => setYoutubeUrl(e.target.value)}
+                      disabled={step=="uploading"}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      The video that these questions are based on
+                    </p>
+                  </div>
+                )}
 
                 <div className="space-y-2">
                   <Label>Questions CSV File</Label>
@@ -426,7 +434,12 @@ const handleGenerateLLMResponse = async () => {
 
                   <Button
                   variant="secondary"
-                  onClick={() => window.open("/templates/QB - template_Sheet1.csv", "_blank")}
+                  onClick={() => window.open(
+                    isQuizQuestionsMode
+                      ? "/templates/quiz-questions-template.csv"
+                      : "/templates/QB - template_Sheet1.csv",
+                    "_blank"
+                  )}
                   className="flex items-center gap-2"
                  >
                   <Download className="w-4 h-4" />
@@ -434,31 +447,42 @@ const handleGenerateLLMResponse = async () => {
                   </Button>
                 <div className="text-xs text-muted-foreground">
                   <p className="font-medium mb-1">CSV Format:</p>
-                  <ul className="list-disc pl-5 space-y-1">
-                    <li>First row should be the header with column names</li>
-                    <li>Required columns: Segment, Question, Option A, Option B, Option C, Option D, Correct Answer</li>
-                    <li>Segment: Numeric value to group questions</li>
-                    <li>Correct Answer: Should be A, B, C, or D</li>
-                  </ul>
+                  {isQuizQuestionsMode ? (
+                    <ul className="list-disc pl-5 space-y-1">
+                      <li>First row should be the header with column names</li>
+                      <li>Required columns: Question, Option A, Option B, Option C, Option D, Correct Answer</li>
+                      <li>Optional columns: S.No., Hint, Expln-A, Expln-B, Expln-C, Expln-D</li>
+                      <li>Correct Answer: Should be A, B, C, or D</li>
+                    </ul>
+                  ) : (
+                    <ul className="list-disc pl-5 space-y-1">
+                      <li>First row should be the header with column names</li>
+                      <li>Required columns: Segment, Question, Option A, Option B, Option C, Option D, Correct Answer</li>
+                      <li>Segment: Numeric value to group questions</li>
+                      <li>Correct Answer: Should be A, B, C, or D</li>
+                    </ul>
+                  )}
                 </div>
               </div>
 
-             <div className="flex justify-between gap-2">
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  setYoutubeUrl('');
-                  setCustomCSVFile(null);
-                  setShowAdvancedFlow(true); 
-                }}
-                disabled={step=="uploading"}
+             <div className={`flex gap-2 ${isQuizQuestionsMode ? "justify-end" : "justify-between"}`}>
+              {!isQuizQuestionsMode && (
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    setYoutubeUrl('');
+                    setCustomCSVFile(null);
+                    setShowAdvancedFlow(true);
+                  }}
+                  disabled={step=="uploading"}
 
-              >
-                Smart Upload (Claude AI)
-              </Button>
+                >
+                  Smart Upload (Claude AI)
+                </Button>
+              )}
 
               <div className="flex gap-2">
-                
+
 
                 <Button
                   variant="outline"
@@ -474,7 +498,7 @@ const handleGenerateLLMResponse = async () => {
 
                 <Button
                   onClick={async () => {
-                    if (!youtubeUrl) {
+                    if (!isQuizQuestionsMode && !youtubeUrl) {
                       toast.error("Please enter a YouTube URL");
                       return;
                     }
@@ -496,7 +520,7 @@ const handleGenerateLLMResponse = async () => {
                       toast.error(error instanceof Error ? error.message : "Failed to process CSV");
                     }
                   }}
-                  disabled={!youtubeUrl || !customCSVFile || step=="uploading"}
+                  disabled={(!isQuizQuestionsMode && !youtubeUrl) || !customCSVFile || step=="uploading"}
                 >
                   {step =="uploading" ?"Uploading..." :"Upload"}
                 </Button>


### PR DESCRIPTION
Picking Quiz from the Add Item dropdown now opens a Start blank vs Upload CSV choice. The CSV path reuses QuestionUploadDialog in a new quiz-questions mode (no YouTube URL, no Smart Upload), parses the file client-side, and populates the new quiz via the existing question/bank endpoints. A sample template is included.

