### PR TITLE
feat: add teacher review queue for student MCQ submissions

### DIFF
--- a/backend/src/modules/studentQuestions/classes/validators/StudentQuestionValidator.ts
+++ b/backend/src/modules/studentQuestions/classes/validators/StudentQuestionValidator.ts
@@ -19,6 +19,8 @@ const QUESTION_TYPES = ['SELECT_ONE_IN_LOT'] as const;
 type QuestionTypeLiteral = (typeof QUESTION_TYPES)[number];
 const STATUS_VALUES = ['PENDING', 'APPROVED', 'REJECTED'] as const;
 type StatusLiteral = (typeof STATUS_VALUES)[number];
+const STATUS_FILTER_VALUES = ['PENDING', 'APPROVED', 'REJECTED', 'ALL'] as const;
+type StatusFilterLiteral = (typeof STATUS_FILTER_VALUES)[number];
 
 export class StudentQuestionOptionDto {
   @IsString()
@@ -132,6 +134,9 @@ export class StudentQuestionListItemResponse {
   _id!: string;
 
   @IsString()
+  segmentId!: string;
+
+  @IsString()
   questionText!: string;
 
   @IsArray()
@@ -170,4 +175,76 @@ export class StudentQuestionListResponse {
   @ValidateNested({each: true})
   @Type(() => StudentQuestionListItemResponse)
   items!: StudentQuestionListItemResponse[];
+}
+
+export class CourseVersionStudentQuestionPathParams {
+  @IsMongoId()
+  courseId!: string;
+
+  @IsMongoId()
+  courseVersionId!: string;
+}
+
+export class CourseVersionStudentQuestionListQuery {
+  @IsOptional()
+  @IsString()
+  @JSONSchema({
+    enum: [...STATUS_FILTER_VALUES],
+    description: 'Status filter. Defaults to ALL.',
+  })
+  status?: StatusFilterLiteral;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number;
+}
+
+export class UpdateStudentQuestionBody {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @Length(10, 300)
+  @JSONSchema({
+    description: 'Updated question prompt (10-300 characters). Required only if changing content.',
+  })
+  questionText?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMinSize(2)
+  @ArrayMaxSize(8)
+  @ValidateNested({each: true})
+  @Type(() => StudentQuestionOptionDto)
+  @JSONSchema({
+    description: 'Updated options (2-8). Required only if changing content.',
+  })
+  options?: StudentQuestionOptionDto[];
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(7)
+  @JSONSchema({
+    description: 'Zero-based index of the correct option (0-7). Required only if changing content.',
+  })
+  correctOptionIndex?: number;
+
+  @IsOptional()
+  @IsString()
+  @JSONSchema({
+    enum: [...STATUS_VALUES],
+    description: 'Optional concurrent status transition. REJECTED requires `reason`.',
+  })
+  status?: StatusLiteral;
+
+  @IsOptional()
+  @IsString()
+  @Length(3, 500)
+  @JSONSchema({
+    description: 'Required when status is REJECTED. 3-500 characters.',
+  })
+  reason?: string;
 }

--- a/backend/src/modules/studentQuestions/controllers/StudentQuestionController.ts
+++ b/backend/src/modules/studentQuestions/controllers/StudentQuestionController.ts
@@ -17,12 +17,15 @@ import {IUser} from '#root/shared/interfaces/models.js';
 import {STUDENT_QUESTION_TYPES} from '../types.js';
 import {StudentQuestionService} from '../services/StudentQuestionService.js';
 import {
+  CourseVersionStudentQuestionListQuery,
+  CourseVersionStudentQuestionPathParams,
   CreateStudentQuestionBody,
   StudentQuestionCreateResponse,
   StudentQuestionListQuery,
   StudentQuestionListResponse,
   StudentQuestionPathParams,
   StudentQuestionStatusPathParams,
+  UpdateStudentQuestionBody,
   UpdateStudentQuestionStatusBody,
 } from '../classes/validators/StudentQuestionValidator.js';
 
@@ -80,6 +83,7 @@ export class StudentQuestionController {
     return {
       items: questions.map(q => ({
         _id: q._id?.toString() || '',
+        segmentId: q.segmentId.toString(),
         questionText: q.questionText,
         options: q.options.map(o => ({text: o.text})),
         correctOptionIndex: q.correctOptionIndex,
@@ -92,6 +96,65 @@ export class StudentQuestionController {
         rejectionReason: q.rejectionReason,
       })),
     };
+  }
+
+  @Authorized()
+  @Get('/courses/:courseId/versions/:courseVersionId')
+  @HttpCode(200)
+  @ResponseSchema(StudentQuestionListResponse)
+  async listByCourseVersion(
+    @Params() params: CourseVersionStudentQuestionPathParams,
+    @QueryParams() query: CourseVersionStudentQuestionListQuery,
+  ): Promise<StudentQuestionListResponse> {
+    const questions = await this.service.listCourseVersionQuestions({
+      courseId: params.courseId,
+      courseVersionId: params.courseVersionId,
+      status: query.status,
+      limit: query.limit ?? 100,
+    });
+    return {
+      items: questions.map(q => ({
+        _id: q._id?.toString() || '',
+        segmentId: q.segmentId.toString(),
+        questionText: q.questionText,
+        options: q.options.map(o => ({text: o.text})),
+        correctOptionIndex: q.correctOptionIndex,
+        status: q.status,
+        source: q.source,
+        createdBy: q.createdBy.toString(),
+        createdAt: q.createdAt.toISOString(),
+        reviewedBy: q.reviewedBy?.toString(),
+        reviewedAt: q.reviewedAt?.toISOString(),
+        rejectionReason: q.rejectionReason,
+      })),
+    };
+  }
+
+  @Authorized()
+  @Patch('/courses/:courseId/versions/:courseVersionId/segments/:segmentId/questions/:questionId')
+  @HttpCode(200)
+  async updateQuestion(
+    @Params() params: StudentQuestionStatusPathParams,
+    @Body() body: UpdateStudentQuestionBody,
+    @CurrentUser() user: IUser,
+  ): Promise<{success: true}> {
+    const reviewedBy = user._id?.toString();
+    if (!reviewedBy) {
+      throw new ForbiddenError('Unable to resolve authenticated user.');
+    }
+    await this.service.updateQuestion({
+      courseId: params.courseId,
+      courseVersionId: params.courseVersionId,
+      segmentId: params.segmentId,
+      questionId: params.questionId,
+      questionText: body.questionText,
+      options: body.options,
+      correctOptionIndex: body.correctOptionIndex,
+      status: body.status,
+      reason: body.reason,
+      reviewedBy,
+    });
+    return {success: true};
   }
 
   @Authorized()

--- a/backend/src/modules/studentQuestions/index.ts
+++ b/backend/src/modules/studentQuestions/index.ts
@@ -6,12 +6,15 @@ import {authContainerModule} from '../auth/container.js';
 import {studentQuestionsContainerModule} from './container.js';
 import {StudentQuestionController} from './controllers/StudentQuestionController.js';
 import {
+  CourseVersionStudentQuestionListQuery,
+  CourseVersionStudentQuestionPathParams,
   CreateStudentQuestionBody,
   StudentQuestionListQuery,
   StudentQuestionListResponse,
   StudentQuestionOptionDto,
   StudentQuestionPathParams,
   StudentQuestionStatusPathParams,
+  UpdateStudentQuestionBody,
   UpdateStudentQuestionStatusBody,
 } from './classes/validators/StudentQuestionValidator.js';
 
@@ -50,6 +53,9 @@ export const studentQuestionsModuleValidators: Function[] = [
   StudentQuestionListQuery,
   StudentQuestionListResponse,
   UpdateStudentQuestionStatusBody,
+  CourseVersionStudentQuestionPathParams,
+  CourseVersionStudentQuestionListQuery,
+  UpdateStudentQuestionBody,
 ];
 
 export * from './classes/index.js';

--- a/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
+++ b/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
@@ -79,6 +79,105 @@ export class StudentQuestionRepository {
       .toArray();
   }
 
+  async listByCourseVersion(input: {
+    courseId: string;
+    courseVersionId: string;
+    status?: StudentQuestionStatus;
+    limit: number;
+  }): Promise<IStudentSegmentQuestion[]> {
+    await this.init();
+    const filter: Record<string, unknown> = {
+      courseId: new ObjectId(input.courseId),
+      courseVersionId: new ObjectId(input.courseVersionId),
+      isDeleted: {$ne: true},
+    };
+    if (input.status) {
+      filter.status = input.status;
+    }
+    return await this.collection
+      .find(filter)
+      .sort({createdAt: -1})
+      .limit(input.limit)
+      .toArray();
+  }
+
+  async findById(input: {
+    courseId: string;
+    courseVersionId: string;
+    segmentId: string;
+    questionId: string;
+  }): Promise<IStudentSegmentQuestion | null> {
+    await this.init();
+    return await this.collection.findOne({
+      _id: new ObjectId(input.questionId),
+      courseId: new ObjectId(input.courseId),
+      courseVersionId: new ObjectId(input.courseVersionId),
+      segmentId: new ObjectId(input.segmentId),
+      isDeleted: {$ne: true},
+    });
+  }
+
+  async findDuplicateExcluding(input: {
+    courseVersionId: string;
+    segmentId: string;
+    normalizedSignature: string;
+    excludeQuestionId: string;
+  }): Promise<IStudentSegmentQuestion | null> {
+    await this.init();
+    return await this.collection.findOne({
+      _id: {$ne: new ObjectId(input.excludeQuestionId)},
+      courseVersionId: new ObjectId(input.courseVersionId),
+      segmentId: new ObjectId(input.segmentId),
+      normalizedSignature: input.normalizedSignature,
+      isDeleted: {$ne: true},
+    });
+  }
+
+  async updateContent(input: {
+    courseId: string;
+    courseVersionId: string;
+    segmentId: string;
+    questionId: string;
+    questionText: string;
+    options: {text: string}[];
+    correctOptionIndex: number;
+    normalizedSignature: string;
+    statusTransition?: {
+      status: StudentQuestionStatus;
+      reviewedBy: string;
+      rejectionReason?: string;
+    };
+  }): Promise<boolean> {
+    await this.init();
+    const set: Record<string, unknown> = {
+      questionText: input.questionText,
+      options: input.options,
+      correctOptionIndex: input.correctOptionIndex,
+      normalizedSignature: input.normalizedSignature,
+      updatedAt: new Date(),
+    };
+    if (input.statusTransition) {
+      set.status = input.statusTransition.status;
+      set.reviewedBy = new ObjectId(input.statusTransition.reviewedBy);
+      set.reviewedAt = new Date();
+      set.rejectionReason =
+        input.statusTransition.status === 'REJECTED'
+          ? input.statusTransition.rejectionReason
+          : undefined;
+    }
+    const result = await this.collection.updateOne(
+      {
+        _id: new ObjectId(input.questionId),
+        courseId: new ObjectId(input.courseId),
+        courseVersionId: new ObjectId(input.courseVersionId),
+        segmentId: new ObjectId(input.segmentId),
+        isDeleted: {$ne: true},
+      },
+      {$set: set},
+    );
+    return result.matchedCount > 0;
+  }
+
   async updateStatus(input: {
     courseId: string;
     courseVersionId: string;

--- a/backend/src/modules/studentQuestions/services/StudentQuestionService.ts
+++ b/backend/src/modules/studentQuestions/services/StudentQuestionService.ts
@@ -173,6 +173,138 @@ export class StudentQuestionService {
     return await this.repository.listBySegment(input);
   }
 
+  async listCourseVersionQuestions(input: {
+    courseId: string;
+    courseVersionId: string;
+    status?: 'PENDING' | 'APPROVED' | 'REJECTED' | 'ALL';
+    limit: number;
+  }) {
+    const repoStatus =
+      input.status && input.status !== 'ALL' ? input.status : undefined;
+    return await this.repository.listByCourseVersion({
+      courseId: input.courseId,
+      courseVersionId: input.courseVersionId,
+      status: repoStatus,
+      limit: input.limit,
+    });
+  }
+
+  async updateQuestion(input: {
+    courseId: string;
+    courseVersionId: string;
+    segmentId: string;
+    questionId: string;
+    questionText?: string;
+    options?: {text: string}[];
+    correctOptionIndex?: number;
+    status?: StudentQuestionStatus;
+    reason?: string;
+    reviewedBy: string;
+  }): Promise<void> {
+    const existing = await this.repository.findById({
+      courseId: input.courseId,
+      courseVersionId: input.courseVersionId,
+      segmentId: input.segmentId,
+      questionId: input.questionId,
+    });
+    if (!existing) {
+      throw new NotFoundError('Student question not found for the given segment.');
+    }
+    if (existing.status !== 'PENDING') {
+      throw new ForbiddenError(
+        'Only PENDING questions can be edited.',
+      );
+    }
+
+    const hasContentChange =
+      input.questionText !== undefined ||
+      input.options !== undefined ||
+      input.correctOptionIndex !== undefined;
+
+    if (!hasContentChange && !input.status) {
+      throw new BadRequestError(
+        'Nothing to update. Provide question content fields and/or a status.',
+      );
+    }
+
+    const nextQuestionText = this.validateQuestionText(
+      input.questionText ?? existing.questionText,
+    );
+    const nextOptions = this.validateOptions(
+      input.options ?? existing.options,
+    );
+    const nextCorrectIndex =
+      input.correctOptionIndex !== undefined
+        ? input.correctOptionIndex
+        : existing.correctOptionIndex;
+    if (
+      !Number.isInteger(nextCorrectIndex) ||
+      nextCorrectIndex < 0 ||
+      nextCorrectIndex >= nextOptions.length
+    ) {
+      throw new BadRequestError('Correct option index is out of range.');
+    }
+
+    const nextSignature = this.buildSignature({
+      questionText: nextQuestionText,
+      options: nextOptions,
+      correctOptionIndex: nextCorrectIndex,
+    });
+
+    if (nextSignature !== existing.normalizedSignature) {
+      const duplicate = await this.repository.findDuplicateExcluding({
+        courseVersionId: input.courseVersionId,
+        segmentId: input.segmentId,
+        normalizedSignature: nextSignature,
+        excludeQuestionId: input.questionId,
+      });
+      if (duplicate) {
+        throw new BadRequestError(
+          'A similar question already exists for this segment.',
+        );
+      }
+    }
+
+    let statusTransition:
+      | {status: StudentQuestionStatus; reviewedBy: string; rejectionReason?: string}
+      | undefined;
+    if (input.status) {
+      if (input.status === 'REJECTED') {
+        const reason = input.reason?.trim();
+        if (!reason || reason.length < 3 || reason.length > 500) {
+          throw new BadRequestError(
+            'A rejection reason of 3 to 500 characters is required.',
+          );
+        }
+        statusTransition = {
+          status: 'REJECTED',
+          reviewedBy: input.reviewedBy,
+          rejectionReason: reason,
+        };
+      } else {
+        statusTransition = {
+          status: input.status,
+          reviewedBy: input.reviewedBy,
+        };
+      }
+    }
+
+    const matched = await this.repository.updateContent({
+      courseId: input.courseId,
+      courseVersionId: input.courseVersionId,
+      segmentId: input.segmentId,
+      questionId: input.questionId,
+      questionText: nextQuestionText,
+      options: nextOptions,
+      correctOptionIndex: nextCorrectIndex,
+      normalizedSignature: nextSignature,
+      statusTransition,
+    });
+    if (!matched) {
+      throw new NotFoundError('Student question not found for the given segment.');
+    }
+  }
+
   async updateQuestionStatus(input: {
     courseId: string;
     courseVersionId: string;

--- a/frontend/src/app/pages/teacher/StudentQuestionReview.tsx
+++ b/frontend/src/app/pages/teacher/StudentQuestionReview.tsx
@@ -1,0 +1,191 @@
+import {useCallback, useEffect, useState} from 'react';
+import {toast} from 'sonner';
+import {Loader2, RefreshCw} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select';
+import {useCourseStore} from '@/store/course-store';
+import {
+  useListStudentQuestions,
+  useUpdateStudentQuestionContent,
+  useUpdateStudentQuestionStatus,
+} from '@/hooks/hooks';
+import type {
+  StudentQuestionListItem,
+  StudentQuestionStatusFilter,
+  UpdateStudentQuestionPayload,
+} from '@/types/student-question.types';
+import StudentQuestionRow from './components/StudentQuestionRow';
+import StudentQuestionRejectDialog from './components/StudentQuestionRejectDialog';
+import StudentQuestionEditDialog from './components/StudentQuestionEditDialog';
+import CourseBackButton from './CourseBackButton';
+
+const STATUS_FILTER_OPTIONS: StudentQuestionStatusFilter[] = [
+  'ALL',
+  'PENDING',
+  'APPROVED',
+  'REJECTED',
+];
+
+export default function StudentQuestionReview() {
+  const {currentCourse} = useCourseStore();
+  const courseId = currentCourse?.courseId;
+  const courseVersionId = currentCourse?.versionId;
+
+  const [statusFilter, setStatusFilter] = useState<StudentQuestionStatusFilter>('PENDING');
+  const [items, setItems] = useState<StudentQuestionListItem[]>([]);
+  const [hasFetched, setHasFetched] = useState(false);
+
+  const {listForCourseVersion, loading: isFetching} = useListStudentQuestions();
+  const {updateStatus, loading: isUpdatingStatus} = useUpdateStudentQuestionStatus();
+  const {updateContent, loading: isUpdatingContent} = useUpdateStudentQuestionContent();
+
+  const isMutating = isUpdatingStatus || isUpdatingContent;
+
+  const [rejectTarget, setRejectTarget] = useState<StudentQuestionListItem | null>(null);
+  const [editTarget, setEditTarget] = useState<StudentQuestionListItem | null>(null);
+
+  const fetchQuestions = useCallback(async () => {
+    if (!courseId || !courseVersionId) return;
+    try {
+      const response = await listForCourseVersion(courseId, courseVersionId, statusFilter, 100);
+      setItems(response?.items ?? []);
+      setHasFetched(true);
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to load student questions');
+    }
+  }, [courseId, courseVersionId, listForCourseVersion, statusFilter]);
+
+  useEffect(() => {
+    void fetchQuestions();
+  }, [fetchQuestions]);
+
+  const handleApprove = async (question: StudentQuestionListItem) => {
+    if (!courseId || !courseVersionId) return;
+    try {
+      await updateStatus(courseId, courseVersionId, question.segmentId, question._id, 'APPROVED');
+      toast.success('Question approved');
+      await fetchQuestions();
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to approve');
+    }
+  };
+
+  const handleRejectConfirm = async (reason: string) => {
+    if (!courseId || !courseVersionId || !rejectTarget) return;
+    try {
+      await updateStatus(
+        courseId,
+        courseVersionId,
+        rejectTarget.segmentId,
+        rejectTarget._id,
+        'REJECTED',
+        reason,
+      );
+      toast.success('Question rejected');
+      setRejectTarget(null);
+      await fetchQuestions();
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to reject');
+    }
+  };
+
+  const handleEditSubmit = async (payload: UpdateStudentQuestionPayload) => {
+    if (!courseId || !courseVersionId || !editTarget) return;
+    try {
+      await updateContent(courseId, courseVersionId, editTarget.segmentId, editTarget._id, payload);
+      toast.success(payload.status === 'APPROVED' ? 'Saved and approved' : 'Saved');
+      setEditTarget(null);
+      await fetchQuestions();
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to save');
+    }
+  };
+
+  if (!courseId || !courseVersionId) {
+    return (
+      <div className="p-6">
+        <p className="text-sm text-muted-foreground">Select a course version first.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-4 md:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <CourseBackButton />
+          <div>
+            <h1 className="text-xl font-semibold">Student Question Review</h1>
+            <p className="text-xs text-muted-foreground">
+              Approve, reject, or edit MCQs submitted by students.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select
+            value={statusFilter}
+            onValueChange={value => setStatusFilter(value as StudentQuestionStatusFilter)}
+          >
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              {STATUS_FILTER_OPTIONS.map(option => (
+                <SelectItem key={option} value={option}>
+                  {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => void fetchQuestions()}
+            disabled={isFetching}
+            title="Refresh"
+          >
+            <RefreshCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
+      </div>
+
+      {isFetching && !hasFetched ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-md border border-dashed py-10 text-center text-sm text-muted-foreground">
+          No student questions match the current filter.
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {items.map(question => (
+            <StudentQuestionRow
+              key={question._id}
+              question={question}
+              showSegmentBadge
+              isMutating={isMutating}
+              onApprove={() => void handleApprove(question)}
+              onReject={() => setRejectTarget(question)}
+              onEdit={() => setEditTarget(question)}
+            />
+          ))}
+        </div>
+      )}
+
+      <StudentQuestionRejectDialog
+        isOpen={rejectTarget !== null}
+        isSubmitting={isUpdatingStatus}
+        onCancel={() => setRejectTarget(null)}
+        onConfirm={handleRejectConfirm}
+      />
+      <StudentQuestionEditDialog
+        isOpen={editTarget !== null}
+        question={editTarget}
+        isSubmitting={isUpdatingContent}
+        onCancel={() => setEditTarget(null)}
+        onSubmit={handleEditSubmit}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/pages/teacher/components/StudentQuestionEditDialog.tsx
+++ b/frontend/src/app/pages/teacher/components/StudentQuestionEditDialog.tsx
@@ -1,0 +1,220 @@
+import {useEffect, useState} from 'react';
+import {Plus, Trash2} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle} from '@/components/ui/dialog';
+import {Input} from '@/components/ui/input';
+import {Label} from '@/components/ui/label';
+import {Textarea} from '@/components/ui/textarea';
+import type {
+  StudentQuestionListItem,
+  UpdateStudentQuestionPayload,
+} from '@/types/student-question.types';
+
+const MIN_OPTIONS = 2;
+const MAX_OPTIONS = 8;
+const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+
+interface EditState {
+  questionText: string;
+  options: {text: string}[];
+  correctOptionIndex: number;
+}
+
+function stateFromQuestion(question: StudentQuestionListItem): EditState {
+  return {
+    questionText: question.questionText,
+    options: question.options.map(o => ({text: o.text})),
+    correctOptionIndex: question.correctOptionIndex,
+  };
+}
+
+interface StudentQuestionEditDialogProps {
+  isOpen: boolean;
+  question: StudentQuestionListItem | null;
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onSubmit: (payload: UpdateStudentQuestionPayload) => Promise<void> | void;
+}
+
+export default function StudentQuestionEditDialog({
+  isOpen,
+  question,
+  isSubmitting,
+  onCancel,
+  onSubmit,
+}: StudentQuestionEditDialogProps) {
+  const [state, setState] = useState<EditState | null>(null);
+
+  useEffect(() => {
+    if (isOpen && question) {
+      setState(stateFromQuestion(question));
+    } else if (!isOpen) {
+      setState(null);
+    }
+  }, [isOpen, question]);
+
+  if (!state) return null;
+
+  const updateOption = (index: number, text: string) => {
+    setState(current => current && ({
+      ...current,
+      options: current.options.map((option, i) => (i === index ? {text} : option)),
+    }));
+  };
+
+  const addOption = () => {
+    setState(current => {
+      if (!current) return current;
+      if (current.options.length >= MAX_OPTIONS) return current;
+      return {...current, options: [...current.options, {text: ''}]};
+    });
+  };
+
+  const removeOption = (index: number) => {
+    setState(current => {
+      if (!current) return current;
+      if (current.options.length <= MIN_OPTIONS) return current;
+      const nextOptions = current.options.filter((_, i) => i !== index);
+      const nextCorrect =
+        current.correctOptionIndex === index
+          ? 0
+          : current.correctOptionIndex > index
+            ? current.correctOptionIndex - 1
+            : current.correctOptionIndex;
+      return {...current, options: nextOptions, correctOptionIndex: nextCorrect};
+    });
+  };
+
+  const trimmedQuestion = state.questionText.trim();
+  const invalid =
+    trimmedQuestion.length < 10 ||
+    trimmedQuestion.length > 300 ||
+    state.options.length < MIN_OPTIONS ||
+    state.options.some(option => !option.text?.trim());
+
+  const buildPayload = (status?: 'APPROVED'): UpdateStudentQuestionPayload => ({
+    questionText: state.questionText,
+    options: state.options.map(o => ({text: o.text.trim()})),
+    correctOptionIndex: state.correctOptionIndex,
+    ...(status ? {status} : {}),
+  });
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={open => {
+        if (!isSubmitting && !open) {
+          onCancel();
+        }
+      }}
+    >
+      <DialogContent
+        className="sm:max-w-[640px] max-h-[90vh] overflow-y-auto"
+        onInteractOutside={e => e.preventDefault()}
+        onEscapeKeyDown={e => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Edit student MCQ</DialogTitle>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-1.5">
+            <Label htmlFor="edit-question-text" className="text-sm font-medium">
+              Question prompt
+            </Label>
+            <Textarea
+              id="edit-question-text"
+              className="min-h-[80px] resize-none text-sm"
+              maxLength={300}
+              value={state.questionText}
+              onChange={event =>
+                setState(current => current && ({...current, questionText: event.target.value}))
+              }
+            />
+            <p className="text-xs text-muted-foreground">
+              {trimmedQuestion.length}/300 characters
+            </p>
+          </div>
+
+          <div className="grid gap-2">
+            <div className="flex items-center justify-between">
+              <Label className="text-sm font-medium">
+                Options{' '}
+                <span className="text-xs font-normal text-muted-foreground">
+                  — select the correct answer
+                </span>
+              </Label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={addOption}
+                disabled={state.options.length >= MAX_OPTIONS || isSubmitting}
+              >
+                <Plus className="mr-1 h-3 w-3" />
+                Add option
+              </Button>
+            </div>
+
+            {state.options.map((option, index) => (
+              <div key={`edit-option-${index}`} className="flex items-center gap-2">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold">
+                  {OPTION_LABELS[index]}
+                </span>
+                <Input
+                  className="h-8 flex-1 text-sm"
+                  maxLength={150}
+                  value={option.text}
+                  onChange={event => updateOption(index, event.target.value)}
+                  disabled={isSubmitting}
+                />
+                <input
+                  type="radio"
+                  name="edit-correct-option"
+                  checked={state.correctOptionIndex === index}
+                  onChange={() =>
+                    setState(current => current && ({...current, correctOptionIndex: index}))
+                  }
+                  className="h-4 w-4 shrink-0 accent-primary"
+                  title="Mark as correct answer"
+                  disabled={isSubmitting}
+                />
+                <button
+                  type="button"
+                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border text-muted-foreground hover:bg-accent hover:text-destructive disabled:pointer-events-none disabled:opacity-30"
+                  onClick={() => removeOption(index)}
+                  disabled={state.options.length <= MIN_OPTIONS || isSubmitting}
+                  title="Remove option"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => onSubmit(buildPayload())}
+            disabled={invalid || isSubmitting}
+          >
+            Save
+          </Button>
+          <Button
+            type="button"
+            onClick={() => onSubmit(buildPayload('APPROVED'))}
+            disabled={invalid || isSubmitting}
+          >
+            {isSubmitting ? 'Saving...' : 'Save and Approve'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/pages/teacher/components/StudentQuestionPanel.tsx
+++ b/frontend/src/app/pages/teacher/components/StudentQuestionPanel.tsx
@@ -1,0 +1,180 @@
+import {useCallback, useEffect, useState} from 'react';
+import {toast} from 'sonner';
+import {Loader2, RefreshCw} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import {
+  useListStudentQuestions,
+  useUpdateStudentQuestionContent,
+  useUpdateStudentQuestionStatus,
+} from '@/hooks/hooks';
+import type {
+  StudentQuestionListItem,
+  UpdateStudentQuestionPayload,
+} from '@/types/student-question.types';
+import StudentQuestionRow from './StudentQuestionRow';
+import StudentQuestionRejectDialog from './StudentQuestionRejectDialog';
+import StudentQuestionEditDialog from './StudentQuestionEditDialog';
+
+interface StudentQuestionPanelProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  courseId: string;
+  courseVersionId: string;
+  segmentId: string;
+  segmentTitle?: string;
+}
+
+export default function StudentQuestionPanel({
+  isOpen,
+  onOpenChange,
+  courseId,
+  courseVersionId,
+  segmentId,
+  segmentTitle,
+}: StudentQuestionPanelProps) {
+  const [items, setItems] = useState<StudentQuestionListItem[]>([]);
+  const [hasFetched, setHasFetched] = useState(false);
+
+  const {listForSegment, loading: isFetching} = useListStudentQuestions();
+  const {updateStatus, loading: isUpdatingStatus} = useUpdateStudentQuestionStatus();
+  const {updateContent, loading: isUpdatingContent} = useUpdateStudentQuestionContent();
+
+  const isMutating = isUpdatingStatus || isUpdatingContent;
+
+  const [rejectTarget, setRejectTarget] = useState<StudentQuestionListItem | null>(null);
+  const [editTarget, setEditTarget] = useState<StudentQuestionListItem | null>(null);
+
+  const fetchQuestions = useCallback(async () => {
+    if (!isOpen || !courseId || !courseVersionId || !segmentId) return;
+    try {
+      const response = await listForSegment(courseId, courseVersionId, segmentId, 100);
+      setItems(response?.items ?? []);
+      setHasFetched(true);
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to load student questions');
+    }
+  }, [isOpen, courseId, courseVersionId, segmentId, listForSegment]);
+
+  useEffect(() => {
+    if (isOpen) {
+      void fetchQuestions();
+    } else {
+      setItems([]);
+      setHasFetched(false);
+      setRejectTarget(null);
+      setEditTarget(null);
+    }
+  }, [isOpen, fetchQuestions]);
+
+  const handleApprove = async (question: StudentQuestionListItem) => {
+    try {
+      await updateStatus(courseId, courseVersionId, question.segmentId, question._id, 'APPROVED');
+      toast.success('Question approved');
+      await fetchQuestions();
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to approve');
+    }
+  };
+
+  const handleRejectConfirm = async (reason: string) => {
+    if (!rejectTarget) return;
+    try {
+      await updateStatus(
+        courseId,
+        courseVersionId,
+        rejectTarget.segmentId,
+        rejectTarget._id,
+        'REJECTED',
+        reason,
+      );
+      toast.success('Question rejected');
+      setRejectTarget(null);
+      await fetchQuestions();
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to reject');
+    }
+  };
+
+  const handleEditSubmit = async (payload: UpdateStudentQuestionPayload) => {
+    if (!editTarget) return;
+    try {
+      await updateContent(courseId, courseVersionId, editTarget.segmentId, editTarget._id, payload);
+      toast.success(payload.status === 'APPROVED' ? 'Saved and approved' : 'Saved');
+      setEditTarget(null);
+      await fetchQuestions();
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to save');
+    }
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Student questions for this segment</SheetTitle>
+          <SheetDescription>
+            {segmentTitle
+              ? `Submissions for "${segmentTitle}". Approve, reject, or edit each one.`
+              : 'Submissions tied to the selected video. Approve, reject, or edit each one.'}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex items-center justify-end pt-2">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => void fetchQuestions()}
+            disabled={isFetching}
+            title="Refresh"
+          >
+            <RefreshCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
+
+        {isFetching && !hasFetched ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="rounded-md border border-dashed py-10 text-center text-sm text-muted-foreground">
+            No submissions for this segment yet.
+          </div>
+        ) : (
+          <div className="mt-3 grid gap-3">
+            {items.map(question => (
+              <StudentQuestionRow
+                key={question._id}
+                question={question}
+                isMutating={isMutating}
+                onApprove={() => void handleApprove(question)}
+                onReject={() => setRejectTarget(question)}
+                onEdit={() => setEditTarget(question)}
+              />
+            ))}
+          </div>
+        )}
+
+        <StudentQuestionRejectDialog
+          isOpen={rejectTarget !== null}
+          isSubmitting={isUpdatingStatus}
+          onCancel={() => setRejectTarget(null)}
+          onConfirm={handleRejectConfirm}
+        />
+        <StudentQuestionEditDialog
+          isOpen={editTarget !== null}
+          question={editTarget}
+          isSubmitting={isUpdatingContent}
+          onCancel={() => setEditTarget(null)}
+          onSubmit={handleEditSubmit}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/app/pages/teacher/components/StudentQuestionRejectDialog.tsx
+++ b/frontend/src/app/pages/teacher/components/StudentQuestionRejectDialog.tsx
@@ -1,0 +1,78 @@
+import {useEffect, useState} from 'react';
+import {Button} from '@/components/ui/button';
+import {Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle} from '@/components/ui/dialog';
+import {Label} from '@/components/ui/label';
+import {Textarea} from '@/components/ui/textarea';
+
+interface StudentQuestionRejectDialogProps {
+  isOpen: boolean;
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onConfirm: (reason: string) => Promise<void> | void;
+}
+
+export default function StudentQuestionRejectDialog({
+  isOpen,
+  isSubmitting,
+  onCancel,
+  onConfirm,
+}: StudentQuestionRejectDialogProps) {
+  const [reason, setReason] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setReason('');
+    }
+  }, [isOpen]);
+
+  const trimmed = reason.trim();
+  const disabled = isSubmitting || trimmed.length < 3 || trimmed.length > 500;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={open => {
+        if (!isSubmitting && !open) {
+          onCancel();
+        }
+      }}
+    >
+      <DialogContent
+        className="sm:max-w-[480px]"
+        onInteractOutside={e => e.preventDefault()}
+        onEscapeKeyDown={e => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Reject this submission</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-2 py-2">
+          <Label htmlFor="rejection-reason" className="text-sm font-medium">
+            Rejection reason
+          </Label>
+          <Textarea
+            id="rejection-reason"
+            placeholder="Explain why this submission is being rejected (3–500 characters)"
+            className="min-h-[100px] resize-none text-sm"
+            maxLength={500}
+            value={reason}
+            onChange={event => setReason(event.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">{trimmed.length}/500 characters</p>
+        </div>
+        <DialogFooter className="gap-2">
+          <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => onConfirm(trimmed)}
+            disabled={disabled}
+          >
+            {isSubmitting ? 'Rejecting...' : 'Reject'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/pages/teacher/components/StudentQuestionRow.tsx
+++ b/frontend/src/app/pages/teacher/components/StudentQuestionRow.tsx
@@ -1,0 +1,117 @@
+import {Check, X, Pencil} from 'lucide-react';
+import {Badge} from '@/components/ui/badge';
+import {Button} from '@/components/ui/button';
+import {Card, CardContent} from '@/components/ui/card';
+import type {
+  StudentQuestionListItem,
+  StudentQuestionStatus,
+} from '@/types/student-question.types';
+
+const STATUS_VARIANT: Record<StudentQuestionStatus, 'default' | 'secondary' | 'destructive'> = {
+  PENDING: 'secondary',
+  APPROVED: 'default',
+  REJECTED: 'destructive',
+};
+
+const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+
+interface StudentQuestionRowProps {
+  question: StudentQuestionListItem;
+  showSegmentBadge?: boolean;
+  isMutating?: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+  onEdit: () => void;
+}
+
+export default function StudentQuestionRow({
+  question,
+  showSegmentBadge,
+  isMutating,
+  onApprove,
+  onReject,
+  onEdit,
+}: StudentQuestionRowProps) {
+  const isPending = question.status === 'PENDING';
+  return (
+    <Card className="border">
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1.5 min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={STATUS_VARIANT[question.status]}>{question.status}</Badge>
+              {showSegmentBadge && (
+                <span className="text-xs text-muted-foreground">
+                  segment: <code className="font-mono">{question.segmentId.slice(-6)}</code>
+                </span>
+              )}
+              <span className="text-xs text-muted-foreground">
+                submitted {new Date(question.createdAt).toLocaleString()}
+              </span>
+            </div>
+            <p className="text-sm font-medium break-words">{question.questionText}</p>
+          </div>
+        </div>
+
+        <ul className="grid gap-1.5">
+          {question.options.map((option, index) => {
+            const isCorrect = index === question.correctOptionIndex;
+            return (
+              <li
+                key={`option-${index}`}
+                className={`flex items-start gap-2 rounded-md border px-3 py-2 text-sm ${
+                  isCorrect ? 'border-primary/40 bg-primary/5' : 'border-border'
+                }`}
+              >
+                <span
+                  className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${
+                    isCorrect ? 'bg-primary text-primary-foreground' : 'bg-muted'
+                  }`}
+                >
+                  {OPTION_LABELS[index]}
+                </span>
+                <span className="break-words">{option.text}</span>
+                {isCorrect && (
+                  <span className="ml-auto text-xs font-medium text-primary">correct</span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+
+        {question.status === 'REJECTED' && question.rejectionReason && (
+          <p className="rounded-md bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            <span className="font-semibold">Reason:</span> {question.rejectionReason}
+          </p>
+        )}
+
+        {isPending && (
+          <div className="flex flex-wrap justify-end gap-2 pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onEdit}
+              disabled={isMutating}
+            >
+              <Pencil className="mr-1 h-3.5 w-3.5" />
+              Edit
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onReject}
+              disabled={isMutating}
+            >
+              <X className="mr-1 h-3.5 w-3.5" />
+              Reject
+            </Button>
+            <Button size="sm" onClick={onApprove} disabled={isMutating}>
+              <Check className="mr-1 h-3.5 w-3.5" />
+              Approve
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/app/pages/teacher/course-page.tsx
+++ b/frontend/src/app/pages/teacher/course-page.tsx
@@ -41,6 +41,7 @@ import {
   Activity,
   MoreVertical,
   MoreVerticalIcon,
+  MessageSquareQuote,
 } from "lucide-react"
 import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
@@ -1437,6 +1438,18 @@ function VersionCard({
     storePageAndNavigate("/teacher/courses/registration-requests")
   }
 
+  const goToStudentQuestions = () => {
+    setCurrentCourse({
+      courseId: courseId,
+      versionId: selectedVersionId ? selectedVersionId : null,
+      moduleId: null,
+      sectionId: null,
+      itemId: null,
+      watchItemId: null,
+    })
+    storePageAndNavigate("/teacher/courses/student-questions")
+  }
+
   const viewInstructors = () => {
     // Set course info in store and navigate to instructors page
     setCurrentCourse({
@@ -1734,6 +1747,15 @@ function VersionCard({
                       >
                         <Settings2 className="mr-2 h-4 w-4" />
                         Settings
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          goToStudentQuestions();
+                        }}
+                      >
+                        <MessageSquareQuote className="mr-2 h-4 w-4" />
+                        Student Questions
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={configureCohorts}>
                         <Layers className="mr-2 h-4 w-4" />

--- a/frontend/src/app/pages/teacher/teacher-course-page.tsx
+++ b/frontend/src/app/pages/teacher/teacher-course-page.tsx
@@ -36,7 +36,8 @@ import {
   Loader2,
   ArrowUp,
   ArrowDown,
-  Pencil
+  Pencil,
+  MessageSquareQuote,
 } from "lucide-react";
 
 import { useNavigate } from "@tanstack/react-router";
@@ -47,6 +48,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { useCourseVersionById, useCreateModule, useUpdateModule, useDeleteModule, useCreateSection, useUpdateSection, useDeleteSection, useCreateItem, useUpdateItem, useDeleteItem, useItemsBySectionId, useItemById, useQuizDetails, useQuizAnalytics, useQuizPerformance, useQuizResults, useMoveModule, useMoveSection, useMoveItem, useUpdateCourseItem, useCourseById, useHideModule, useHideSection } from "@/hooks/hooks";
 import { useCourseStore } from "@/store/course-store";
 import VideoModal from "./components/Video-modal";
+import StudentQuestionPanel from "./components/StudentQuestionPanel";
 import EnhancedQuizEditor from "./components/enhanced-quiz-editor";
 import EnhancedBlogEditor from "./components/enhanced-blog-editor";
 import QuizWizardModal from "./components/quiz-wizard";
@@ -282,6 +284,10 @@ function TeacherCourseContent() {
     parentIds?: { moduleId: string; sectionId?: string; itemsGroupId?: string };
   } | null>(null);
   const [isEditingItem, setIsEditingItem] = useState(false);
+  const [studentQuestionSegment, setStudentQuestionSegment] = useState<{
+    segmentId: string;
+    segmentTitle?: string;
+  } | null>(null);
 
   // Add this state for the add video modal
   const [showAddVideoModal, setShowAddVideoModal] = useState<{
@@ -1861,6 +1867,28 @@ function TeacherCourseContent() {
                                                       )}
                                                       <span className="sr-only">Hide Item</span>
                                                     </Button>
+                                                    {item.type === 'VIDEO' && (
+                                                      <Button
+                                                        className="absolute top-0 right-8"
+                                                        size="icon"
+                                                        variant="ghost"
+                                                        title="View student questions for this video"
+                                                        onClick={(e) => {
+                                                          e.stopPropagation();
+                                                          setStudentQuestionSegment({
+                                                            segmentId: item._id,
+                                                            segmentTitle: item.name,
+                                                          });
+                                                        }}
+                                                      >
+                                                        <MessageSquareQuote
+                                                          className={`h-4 w-4 ${selectedItem.id == item._id
+                                                            ? "text-gray-200"
+                                                            : "text-muted-foreground"}`}
+                                                        />
+                                                        <span className="sr-only">View student questions</span>
+                                                      </Button>
+                                                    )}
                                                   </SidebarMenuSubItem>
                                                 </Reorder.Item>
                                               ))}
@@ -3389,6 +3417,19 @@ function TeacherCourseContent() {
         quizWizardOpen={quizWizardOpen}
         setQuizWizardOpen={setQuizWizardOpen}
       />
+
+      {studentQuestionSegment && courseId && versionId && (
+        <StudentQuestionPanel
+          isOpen={studentQuestionSegment !== null}
+          onOpenChange={(open) => {
+            if (!open) setStudentQuestionSegment(null);
+          }}
+          courseId={courseId}
+          courseVersionId={versionId}
+          segmentId={studentQuestionSegment.segmentId}
+          segmentTitle={studentQuestionSegment.segmentTitle}
+        />
+      )}
 
     </ResizablePanelGroup>
   );

--- a/frontend/src/app/routes/router.tsx
+++ b/frontend/src/app/routes/router.tsx
@@ -41,6 +41,7 @@ import AiWorkflow from '../pages/teacher/AiWorkflow'
 import AnomaliesList from '../pages/teacher/AnomaliesList'
 // import CourseInstructors from '../pages/teacher/course-instructors'
 import RegisteredUsers from '../pages/teacher/CourseRegistrationRequests'
+import StudentQuestionReview from '../pages/teacher/StudentQuestionReview'
 import CourseRegistration from '../pages/student/CourseRegistration'
 import CourseIssueReports from '../pages/student/FlagResponse'
 // import LoginPage from '../pages/LoginPage'
@@ -356,6 +357,12 @@ const teacherCourseRegistrationRequests = new Route({
   getParentRoute: () => teacherLayoutRoute,
   path: '/courses/registration-requests',
   component: RegisteredUsers
+})
+
+const teacherStudentQuestionsRoute = new Route({
+  getParentRoute: () => teacherLayoutRoute,
+  path: '/courses/student-questions',
+  component: StudentQuestionReview,
 })
 
 
@@ -679,6 +686,7 @@ const routeTree = rootRoute.addChildren([
     teacherCourseAnomaliesRoute,
     // teacherCourseInstructorsRoute,
     teacherCourseRegistrationRequests,
+    teacherStudentQuestionsRoute,
     teacherFeedBackEditorRoute,
     teacherAnnouncementsRoute,
     teacherAuditRoute,

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -2243,6 +2243,196 @@ export function useSubmitStudentQuestion(): {
   return { submitQuestion, loading, error };
 }
 
+export function useListStudentQuestions(): {
+  listForCourseVersion: (
+    courseId: string,
+    courseVersionId: string,
+    status?: import('@/types/student-question.types').StudentQuestionStatusFilter,
+    limit?: number,
+  ) => Promise<import('@/types/student-question.types').StudentQuestionListResponse>;
+  listForSegment: (
+    courseId: string,
+    courseVersionId: string,
+    segmentId: string,
+    limit?: number,
+  ) => Promise<import('@/types/student-question.types').StudentQuestionListResponse>;
+  loading: boolean;
+  error: string | null;
+} {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const request = async (url: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+      });
+      if (!response.ok) {
+        let serverMessage = '';
+        try {
+          const errBody = await response.json();
+          serverMessage = errBody?.message || errBody?.error || '';
+        } catch {
+          /* response had no JSON body */
+        }
+        throw new Error(serverMessage || `Failed to load student questions: ${response.status}`);
+      }
+      return await response.json();
+    } catch (err: any) {
+      const message = err?.message || 'Failed to load student questions';
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const listForCourseVersion = async (
+    courseId: string,
+    courseVersionId: string,
+    status: import('@/types/student-question.types').StudentQuestionStatusFilter = 'ALL',
+    limit = 100,
+  ) => {
+    const params = new URLSearchParams();
+    if (status && status !== 'ALL') params.set('status', status);
+    params.set('limit', String(limit));
+    const url = `${import.meta.env.VITE_BASE_URL}/student-questions/courses/${courseId}/versions/${courseVersionId}?${params.toString()}`;
+    return await request(url);
+  };
+
+  const listForSegment = async (
+    courseId: string,
+    courseVersionId: string,
+    segmentId: string,
+    limit = 100,
+  ) => {
+    const params = new URLSearchParams();
+    params.set('limit', String(limit));
+    const url = `${import.meta.env.VITE_BASE_URL}/student-questions/courses/${courseId}/versions/${courseVersionId}/segments/${segmentId}?${params.toString()}`;
+    return await request(url);
+  };
+
+  return { listForCourseVersion, listForSegment, loading, error };
+}
+
+export function useUpdateStudentQuestionStatus(): {
+  updateStatus: (
+    courseId: string,
+    courseVersionId: string,
+    segmentId: string,
+    questionId: string,
+    status: import('@/types/student-question.types').StudentQuestionStatus,
+    reason?: string,
+  ) => Promise<void>;
+  loading: boolean;
+  error: string | null;
+} {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateStatus = async (
+    courseId: string,
+    courseVersionId: string,
+    segmentId: string,
+    questionId: string,
+    status: import('@/types/student-question.types').StudentQuestionStatus,
+    reason?: string,
+  ): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/student-questions/courses/${courseId}/versions/${courseVersionId}/segments/${segmentId}/questions/${questionId}/status`;
+      const response = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+        body: JSON.stringify({ status, reason }),
+      });
+      if (!response.ok) {
+        let serverMessage = '';
+        try {
+          const errBody = await response.json();
+          serverMessage = errBody?.message || errBody?.error || '';
+        } catch {
+          /* response had no JSON body */
+        }
+        throw new Error(serverMessage || `Failed to update status: ${response.status}`);
+      }
+    } catch (err: any) {
+      const message = err?.message || 'Failed to update student question status';
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { updateStatus, loading, error };
+}
+
+export function useUpdateStudentQuestionContent(): {
+  updateContent: (
+    courseId: string,
+    courseVersionId: string,
+    segmentId: string,
+    questionId: string,
+    payload: import('@/types/student-question.types').UpdateStudentQuestionPayload,
+  ) => Promise<void>;
+  loading: boolean;
+  error: string | null;
+} {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateContent = async (
+    courseId: string,
+    courseVersionId: string,
+    segmentId: string,
+    questionId: string,
+    payload: import('@/types/student-question.types').UpdateStudentQuestionPayload,
+  ): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/student-questions/courses/${courseId}/versions/${courseVersionId}/segments/${segmentId}/questions/${questionId}`;
+      const response = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        let serverMessage = '';
+        try {
+          const errBody = await response.json();
+          serverMessage = errBody?.message || errBody?.error || '';
+        } catch {
+          /* response had no JSON body */
+        }
+        throw new Error(serverMessage || `Failed to update question: ${response.status}`);
+      }
+    } catch (err: any) {
+      const message = err?.message || 'Failed to update student question';
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { updateContent, loading, error };
+}
+
 export function usePublicCourses(
   page: number,
   limit: number,

--- a/frontend/src/types/student-question.types.ts
+++ b/frontend/src/types/student-question.types.ts
@@ -21,6 +21,7 @@ export type StudentQuestionStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
 
 export interface StudentQuestionListItem {
   _id: string;
+  segmentId: string;
   questionText: string;
   options: {text: string}[];
   correctOptionIndex: number;
@@ -35,4 +36,18 @@ export interface StudentQuestionListItem {
 
 export interface StudentQuestionListResponse {
   items: StudentQuestionListItem[];
+}
+
+export type StudentQuestionStatusFilter =
+  | 'PENDING'
+  | 'APPROVED'
+  | 'REJECTED'
+  | 'ALL';
+
+export interface UpdateStudentQuestionPayload {
+  questionText?: string;
+  options?: {text: string}[];
+  correctOptionIndex?: number;
+  status?: StudentQuestionStatus;
+  reason?: string;
 }


### PR DESCRIPTION
Teachers can now act on the PENDING submissions accumulating from PR #1. Two surfaces (page-level overview + per-segment right-slide panel) and three actions per row (Approve, Reject with reason, Edit with optional combined approval).

Backend (studentQuestions module extended):
- GET /student-questions/courses/:c/versions/:v lists submissions across segments with optional status filter (PENDING | APPROVED | REJECTED | ALL) and limit (default 100).
- PATCH /student-questions/courses/:c/versions/:v/segments/:s/questions/:q updates content (questionText, options, correctOptionIndex) with optional atomic status transition. PENDING-only. Re-validates length / options / correct-index / spam, re-computes normalizedSignature, checks duplicates excluding self.
- StudentQuestionListItemResponse now includes segmentId (used by both endpoints).

Frontend:
- New page /teacher/courses/student-questions (StudentQuestionReview) with status filter + refresh.
- New right-slide StudentQuestionPanel anchored per video segment in the teacher item tree (teacher-course-page.tsx).
- Shared StudentQuestionRow with status badge, correct-option highlight, and PENDING-only Approve / Reject / Edit buttons.
- StudentQuestionEditDialog with both Save and Save-and-Approve actions.
- StudentQuestionRejectDialog requiring a 3-500 char reason.
- New menu item 'Student Questions' in the version dropdown (course-page.tsx), navigating to the review page.
- 3 new hooks in hooks.ts: useListStudentQuestions, useUpdateStudentQuestionStatus, useUpdateStudentQuestionContent.
- Types extended: StudentQuestionStatusFilter, UpdateStudentQuestionPayload, segmentId on list items.

No regression to PR #1 endpoints, types, or UI.