### PR TITLE
feat: surface approved student MCQs in quiz attempts as ungraded extras

### DIFF
--- a/backend/src/modules/quizzes/index.ts
+++ b/backend/src/modules/quizzes/index.ts
@@ -14,6 +14,7 @@ import { } from './classes/validators/QuizValidator.js';
 import { authContainerModule } from '../auth/container.js';
 import { notificationsContainerModule } from '../notifications/container.js';
 import { usersContainerModule } from '../users/container.js';
+import { studentQuestionsContainerModule } from '../studentQuestions/container.js';
 
 export const quizzesContainerModules: ContainerModule[] = [
   quizzesContainerModule,
@@ -21,7 +22,8 @@ export const quizzesContainerModules: ContainerModule[] = [
   coursesContainerModule,
   authContainerModule,
   notificationsContainerModule,
-  usersContainerModule
+  usersContainerModule,
+  studentQuestionsContainerModule,
 ];
 
 export const quizzesModuleControllers: Function[] = [

--- a/backend/src/modules/quizzes/interfaces/grading.ts
+++ b/backend/src/modules/quizzes/interfaces/grading.ts
@@ -103,6 +103,11 @@ interface IQuizSubmissionExport {
 interface IQuestionDetails {
   questionId: string | ObjectId;
   parameterMap?: ParameterMap;
+  /**
+   * Marks where the question originated. Defaults to bank-sourced (undefined).
+   * STUDENT_GENERATED entries are rendered ungraded; grading skips them.
+   */
+  source?: 'STUDENT_GENERATED';
 }
 
 interface IQuestionAnswerFeedback {

--- a/backend/src/modules/quizzes/services/AttemptService.ts
+++ b/backend/src/modules/quizzes/services/AttemptService.ts
@@ -62,6 +62,16 @@ import { USERS_TYPES } from '#root/modules/users/types.js';
 import { ProgressRepository } from '#root/shared/database/providers/mongo/repositories/ProgressRepository.js';
 import { ICourseRepository } from '#root/shared/database/interfaces/ICourseRepository.js';
 import { ProgressService } from '#root/modules/users/services/ProgressService.js';
+import { StudentQuestionRepository } from '#root/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.js';
+import {
+  IStudentQuestionOption,
+  IStudentSegmentQuestion,
+} from '#root/modules/studentQuestions/classes/transformers/StudentSegmentQuestion.js';
+import { STUDENT_QUESTION_TYPES } from '#root/modules/studentQuestions/types.js';
+
+const PEER_QUESTION_DEFAULT_POINTS = 0;
+const PEER_QUESTION_DEFAULT_TIME_LIMIT_SECONDS = 60;
+
 @injectable()
 class AttemptService extends BaseService {
   constructor(
@@ -100,6 +110,9 @@ class AttemptService extends BaseService {
 
     @inject(GLOBAL_TYPES.CourseRepo)
     private readonly courseRepo: ICourseRepository,
+
+    @inject(STUDENT_QUESTION_TYPES.StudentQuestionRepo)
+    private readonly studentQuestionRepo: StudentQuestionRepository,
 
     @inject(GLOBAL_TYPES.Database)
     private readonly database: MongoDatabase,
@@ -140,7 +153,94 @@ class AttemptService extends BaseService {
         new QuestionProcessor(question).render(questionDetail.parameterMap),
       );
     }
+
+    // Phase 3: append APPROVED student MCQs tied to the video segments
+    // immediately preceding this quiz (contiguous run, no other quiz in between).
+    // These are rendered as ungraded extras: points=0, skipped in grading.
+    if (quiz._id) {
+      const precedingSegmentIds = await this._findPrecedingVideoSegments(
+        quiz._id.toString(),
+      );
+      if (precedingSegmentIds.length > 0) {
+        const approved = await this.studentQuestionRepo.findApprovedForSegments(
+          precedingSegmentIds,
+        );
+        for (const sq of approved) {
+          questionDetails.push({
+            questionId: sq._id as ObjectId,
+            parameterMap: null,
+            source: 'STUDENT_GENERATED',
+          });
+          questionRenderViews.push(
+            this._adaptStudentQuestionToRenderView(sq),
+          );
+        }
+      }
+    }
+
     return { questionDetails, questionRenderViews };
+  }
+
+  /**
+   * Phase 3 helper. Returns the IDs of VIDEO items that immediately precede
+   * the given quiz item in its items group (contiguous run, stopping at any
+   * other QUIZ item). Hidden items are skipped.
+   */
+  private async _findPrecedingVideoSegments(
+    quizItemId: string,
+  ): Promise<string[]> {
+    const itemsGroup = await this.itemRepo.findItemsGroupByItemId(quizItemId);
+    if (!itemsGroup || !Array.isArray(itemsGroup.items)) return [];
+
+    const items = itemsGroup.items;
+    const quizIndex = items.findIndex(
+      it => it._id?.toString() === quizItemId.toString(),
+    );
+    if (quizIndex === -1) return [];
+
+    const videoIds: string[] = [];
+    for (let i = quizIndex - 1; i >= 0; i--) {
+      const it = items[i];
+      if (it.type === ItemType.QUIZ) break;
+      if (it.type === ItemType.VIDEO && !it.isHidden && it._id) {
+        videoIds.push(it._id.toString());
+      }
+    }
+    return videoIds;
+  }
+
+  /**
+   * Phase 3 adapter. Converts a single-answer student MCQ into a
+   * SOL-shaped render view marked as peer-contributed (ungraded).
+   */
+  private _adaptStudentQuestionToRenderView(
+    sq: IStudentSegmentQuestion,
+  ): IQuestionRenderView {
+    const lotItems: ILotItem[] = sq.options.map(
+      (option: IStudentQuestionOption) => ({
+        _id: new ObjectId(),
+        text: option.text,
+        explaination: '',
+      }),
+    );
+    // Shuffle so the correct option isn't always at the same index
+    for (let i = lotItems.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [lotItems[i], lotItems[j]] = [lotItems[j], lotItems[i]];
+    }
+    const renderView = {
+      _id: sq._id as ObjectId,
+      text: sq.questionText,
+      type: 'SELECT_ONE_IN_LOT' as QuestionType,
+      isParameterized: false,
+      parameters: [],
+      hint: undefined,
+      timeLimitSeconds: PEER_QUESTION_DEFAULT_TIME_LIMIT_SECONDS,
+      points: PEER_QUESTION_DEFAULT_POINTS,
+      lotItems,
+      isPeerContributed: true,
+    } as unknown as IQuestionRenderView;
+    return renderView;
   }
 
   private _buildGradingResult(
@@ -186,8 +286,17 @@ class AttemptService extends BaseService {
     let totalScore = 0;
     let totalMaxScore = 0;
 
-    // Calculate totalMaxScore from ALL questions in the attempt, not just answered ones
+    // Phase 3: peer-contributed (STUDENT_GENERATED) questions are ungraded.
+    // Pre-compute their ids so we can skip them everywhere below.
+    const peerQuestionIds = new Set(
+      attempt.questionDetails
+        .filter(qd => qd.source === 'STUDENT_GENERATED')
+        .map(qd => qd.questionId.toString()),
+    );
+
+    // Calculate totalMaxScore from graded questions in the attempt only
     for (const questionDetail of attempt.questionDetails) {
+      if (questionDetail.source === 'STUDENT_GENERATED') continue;
       const question = await this.questionService.getById(
         questionDetail.questionId.toString(),
         true,
@@ -196,8 +305,9 @@ class AttemptService extends BaseService {
     }
 
 
-    // Now grade only the answered questions
+    // Now grade only the answered, graded (non-peer) questions
     for (const answer of answers) {
+      if (peerQuestionIds.has(answer.questionId.toString())) continue;
       const question = await this.questionService.getById(
         answer.questionId.toString(),
         true,
@@ -220,7 +330,14 @@ class AttemptService extends BaseService {
       totalScore += feedback.score;
     }
 
-    if (answers.length != attempt.questionDetails.length) {
+    // Completion check: every graded (non-peer) question must have an answer.
+    // Peer-contributed questions are optional and don't affect completion.
+    const requiredAnswerCount =
+      attempt.questionDetails.length - peerQuestionIds.size;
+    const submittedNonPeerAnswers = answers.filter(
+      a => !peerQuestionIds.has(a.questionId.toString()),
+    ).length;
+    if (submittedNonPeerAnswers != requiredAnswerCount) {
       const result: IGradingResult = {
         gradingStatus: 'FAILED',
         overallFeedback: feedbacks,
@@ -235,12 +352,13 @@ class AttemptService extends BaseService {
     const effectivePassThreshold =
       process.env.E2E_TESTING === 'true'?
       0 : quiz.details.passThreshold;
-    
+
+    // If totalMaxScore is zero (e.g. quiz with only peer questions), treat as PASSED.
+    const passed =
+      totalMaxScore === 0 ||
+      totalScore / totalMaxScore >= effectivePassThreshold;
     const result: IGradingResult = {
-      gradingStatus:
-        totalScore / totalMaxScore >= effectivePassThreshold
-          ? 'PASSED'
-          : 'FAILED',
+      gradingStatus: passed ? 'PASSED' : 'FAILED',
       overallFeedback: feedbacks,
       totalMaxScore,
       totalScore,

--- a/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
+++ b/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
@@ -101,6 +101,20 @@ export class StudentQuestionRepository {
       .toArray();
   }
 
+  async findApprovedForSegments(
+    segmentIds: string[],
+  ): Promise<IStudentSegmentQuestion[]> {
+    await this.init();
+    if (segmentIds.length === 0) return [];
+    return await this.collection
+      .find({
+        segmentId: {$in: segmentIds.map(id => new ObjectId(id))},
+        status: 'APPROVED',
+        isDeleted: {$ne: true},
+      })
+      .toArray();
+  }
+
   async findById(input: {
     courseId: string;
     courseVersionId: string;

--- a/frontend/src/components/quiz.tsx
+++ b/frontend/src/components/quiz.tsx
@@ -273,7 +273,9 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
         question: question.text,
         points: question.points,
         timeLimit: question.timeLimitSeconds,
-        hint: question.hint
+        hint: question.hint,
+        // Phase 3: peer-contributed (student-submitted) MCQs are surfaced ungraded.
+        isPeerContributed: (question as { isPeerContributed?: boolean }).isPeerContributed === true,
       };
 
       // Add type-specific properties
@@ -1961,6 +1963,12 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
               <Trophy className="mr-1 h-3 w-3" />
               {currentQuestion.points} points
             </Badge>
+            {currentQuestion.isPeerContributed && (
+              <Badge variant="secondary" className="border border-primary/30 bg-primary/5 text-primary">
+                <Users className="mr-1 h-3 w-3" />
+                Peer-contributed — ungraded
+              </Badge>
+            )}
           </div>
           <h2 className="text-2xl font-semibold leading-tight">
             {/* <MathRenderer>

--- a/frontend/src/types/quiz.types.ts
+++ b/frontend/src/types/quiz.types.ts
@@ -29,6 +29,8 @@ export interface QuizQuestion {
   decimalPrecision?: number;
   expression?: string;
   lotItems?: Array<{ text: string; explaination: string; _id: { buffer: { type: string; data: number[] } } | string }>;
+  // Phase 3: marker for peer-contributed (student-submitted) MCQs surfaced ungraded.
+  isPeerContributed?: boolean;
 }
 
 export interface BufferLike {


### PR DESCRIPTION
Completes the loop opened by PR #1 (submission) and PR #2 (review). APPROVED student MCQs now appear inside the regular quiz attempt for the relevant segment's next quiz, rendered as ungraded "peer-contributed" extras. Single source of truth: no copy into question banks, no schema change on studentSegmentQuestions.

Backend:
- AttemptService._getQuestionsForAttempt now, after assembling bank-sourced questions, looks up video segments preceding the current quiz in its items group (contiguous run, stopping at any other QUIZ, hidden items skipped), queries studentQuestionRepo.findApprovedForSegments, and adapts each IStudentSegmentQuestion to a SOL-shaped IQuestionRenderView with shuffled lotItems, points=0, timeLimitSeconds=60, and an isPeerContributed=true marker.
- IQuestionDetails gains an optional source: 'STUDENT_GENERATED' field. _grade now skips student-sourced entries in the totalMaxScore loop and the per-answer scoring loop, and the completion check requires only non-peer answers (peer answers are optional).
- Guard against totalMaxScore===0 (quiz with only peer questions) so the result is PASSED rather than NaN.
- StudentQuestionRepository.findApprovedForSegments(segmentIds) added.
- studentQuestionsContainerModule loaded by the quizzes container so AttemptService can inject StudentQuestionRepository.

Frontend:
- QuizQuestion gains optional isPeerContributed. convertBackendQuestions carries the marker through.
- quiz.tsx renders a 'Peer-contributed — ungraded' badge next to the points badge when isPeerContributed is true.

Out of scope: peer validation track, audit dashboard, random sampling of peer questions, configurable peer-question points, student 'my submissions' view.