### PR TITLE
feat: student 'My Submissions' view + status-change notifications

### DIFF
--- a/backend/src/modules/studentQuestions/classes/validators/StudentQuestionValidator.ts
+++ b/backend/src/modules/studentQuestions/classes/validators/StudentQuestionValidator.ts
@@ -136,6 +136,14 @@ export class StudentQuestionListItemResponse {
   @IsString()
   segmentId!: string;
 
+  @IsOptional()
+  @IsString()
+  courseId?: string;
+
+  @IsOptional()
+  @IsString()
+  courseVersionId?: string;
+
   @IsString()
   questionText!: string;
 
@@ -191,6 +199,23 @@ export class CourseVersionStudentQuestionListQuery {
   @JSONSchema({
     enum: [...STATUS_FILTER_VALUES],
     description: 'Status filter. Defaults to ALL.',
+  })
+  status?: StatusFilterLiteral;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number;
+}
+
+export class MyStudentQuestionsListQuery {
+  @IsOptional()
+  @IsString()
+  @JSONSchema({
+    enum: [...STATUS_FILTER_VALUES],
+    description: 'Status filter for the current user\'s submissions. Defaults to ALL.',
   })
   status?: StatusFilterLiteral;
 

--- a/backend/src/modules/studentQuestions/controllers/StudentQuestionController.ts
+++ b/backend/src/modules/studentQuestions/controllers/StudentQuestionController.ts
@@ -20,6 +20,7 @@ import {
   CourseVersionStudentQuestionListQuery,
   CourseVersionStudentQuestionPathParams,
   CreateStudentQuestionBody,
+  MyStudentQuestionsListQuery,
   StudentQuestionCreateResponse,
   StudentQuestionListQuery,
   StudentQuestionListResponse,
@@ -39,6 +40,43 @@ export class StudentQuestionController {
     @inject(STUDENT_QUESTION_TYPES.StudentQuestionService)
     private readonly service: StudentQuestionService,
   ) {}
+
+  @Authorized()
+  @Get('/me')
+  @HttpCode(200)
+  @ResponseSchema(StudentQuestionListResponse)
+  async listMine(
+    @QueryParams() query: MyStudentQuestionsListQuery,
+    @CurrentUser() user: IUser,
+  ): Promise<StudentQuestionListResponse> {
+    const userId = user._id?.toString();
+    if (!userId) {
+      throw new ForbiddenError('Unable to resolve authenticated user.');
+    }
+    const questions = await this.service.listMyQuestions({
+      userId,
+      status: query.status,
+      limit: query.limit ?? 100,
+    });
+    return {
+      items: questions.map(q => ({
+        _id: q._id?.toString() || '',
+        segmentId: q.segmentId.toString(),
+        courseId: q.courseId.toString(),
+        courseVersionId: q.courseVersionId.toString(),
+        questionText: q.questionText,
+        options: q.options.map(o => ({text: o.text})),
+        correctOptionIndex: q.correctOptionIndex,
+        status: q.status,
+        source: q.source,
+        createdBy: q.createdBy.toString(),
+        createdAt: q.createdAt.toISOString(),
+        reviewedBy: q.reviewedBy?.toString(),
+        reviewedAt: q.reviewedAt?.toISOString(),
+        rejectionReason: q.rejectionReason,
+      })),
+    };
+  }
 
   @Authorized()
   @Post('/courses/:courseId/versions/:courseVersionId/segments/:segmentId')
@@ -84,6 +122,8 @@ export class StudentQuestionController {
       items: questions.map(q => ({
         _id: q._id?.toString() || '',
         segmentId: q.segmentId.toString(),
+        courseId: q.courseId.toString(),
+        courseVersionId: q.courseVersionId.toString(),
         questionText: q.questionText,
         options: q.options.map(o => ({text: o.text})),
         correctOptionIndex: q.correctOptionIndex,
@@ -116,6 +156,8 @@ export class StudentQuestionController {
       items: questions.map(q => ({
         _id: q._id?.toString() || '',
         segmentId: q.segmentId.toString(),
+        courseId: q.courseId.toString(),
+        courseVersionId: q.courseVersionId.toString(),
         questionText: q.questionText,
         options: q.options.map(o => ({text: o.text})),
         correctOptionIndex: q.correctOptionIndex,

--- a/backend/src/modules/studentQuestions/index.ts
+++ b/backend/src/modules/studentQuestions/index.ts
@@ -3,12 +3,14 @@ import {RoutingControllersOptions, useContainer} from 'routing-controllers';
 import {sharedContainerModule} from '#root/container.js';
 import {InversifyAdapter} from '#root/inversify-adapter.js';
 import {authContainerModule} from '../auth/container.js';
+import {notificationsContainerModule} from '../notifications/container.js';
 import {studentQuestionsContainerModule} from './container.js';
 import {StudentQuestionController} from './controllers/StudentQuestionController.js';
 import {
   CourseVersionStudentQuestionListQuery,
   CourseVersionStudentQuestionPathParams,
   CreateStudentQuestionBody,
+  MyStudentQuestionsListQuery,
   StudentQuestionListQuery,
   StudentQuestionListResponse,
   StudentQuestionOptionDto,
@@ -22,6 +24,7 @@ export const studentQuestionsContainerModules: ContainerModule[] = [
   studentQuestionsContainerModule,
   sharedContainerModule,
   authContainerModule,
+  notificationsContainerModule,
 ];
 
 export const studentQuestionsModuleControllers: Function[] = [
@@ -56,6 +59,7 @@ export const studentQuestionsModuleValidators: Function[] = [
   CourseVersionStudentQuestionPathParams,
   CourseVersionStudentQuestionListQuery,
   UpdateStudentQuestionBody,
+  MyStudentQuestionsListQuery,
 ];
 
 export * from './classes/index.js';

--- a/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
+++ b/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
@@ -101,6 +101,26 @@ export class StudentQuestionRepository {
       .toArray();
   }
 
+  async listByUserId(input: {
+    userId: string;
+    status?: StudentQuestionStatus;
+    limit: number;
+  }): Promise<IStudentSegmentQuestion[]> {
+    await this.init();
+    const filter: Record<string, unknown> = {
+      createdBy: new ObjectId(input.userId),
+      isDeleted: {$ne: true},
+    };
+    if (input.status) {
+      filter.status = input.status;
+    }
+    return await this.collection
+      .find(filter)
+      .sort({createdAt: -1})
+      .limit(input.limit)
+      .toArray();
+  }
+
   async findApprovedForSegments(
     segmentIds: string[],
   ): Promise<IStudentSegmentQuestion[]> {

--- a/backend/src/modules/studentQuestions/services/StudentQuestionService.ts
+++ b/backend/src/modules/studentQuestions/services/StudentQuestionService.ts
@@ -1,19 +1,24 @@
 import {inject, injectable} from 'inversify';
+import {ObjectId} from 'mongodb';
 import {BadRequestError, ForbiddenError, NotFoundError} from 'routing-controllers';
 import {STUDENT_QUESTION_TYPES} from '../types.js';
 import {StudentQuestionRepository} from '../repositories/providers/mongodb/StudentQuestionRepository.js';
 import {
   IStudentQuestionOption,
+  IStudentSegmentQuestion,
   StudentQuestionStatus,
   StudentQuestionType,
   StudentSegmentQuestion,
 } from '../classes/transformers/StudentSegmentQuestion.js';
 import {GLOBAL_TYPES} from '#root/types.js';
 import {ISettingRepository} from '#shared/database/index.js';
+import {NOTIFICATIONS_TYPES} from '../../notifications/types.js';
+import {NotificationService} from '../../notifications/services/NotificationService.js';
 
 const REPEATED_CHAR_PATTERN = /(.)\1{7,}/;
 const REPEATED_WORD_PATTERN = /(\b\w+\b)(\s+\1){4,}/;
 const URL_TOKEN_PATTERN = /^https?:\/\/\S+$/i;
+const NOTIFICATION_QUESTION_PREVIEW_CHARS = 80;
 
 @injectable()
 export class StudentQuestionService {
@@ -22,7 +27,60 @@ export class StudentQuestionService {
     private readonly repository: StudentQuestionRepository,
     @inject(GLOBAL_TYPES.SettingRepo)
     private readonly settingRepo: ISettingRepository,
+    @inject(NOTIFICATIONS_TYPES.NotificationService)
+    private readonly notificationService: NotificationService,
   ) {}
+
+  /**
+   * Phase 4: emit an in-app notification to the question's author when a
+   * teacher transitions status to APPROVED or REJECTED. Best-effort: errors
+   * are logged but do not block the status update.
+   */
+  private async _notifyStatusChange(
+    question: IStudentSegmentQuestion,
+    nextStatus: StudentQuestionStatus,
+    rejectionReason?: string,
+  ): Promise<void> {
+    if (nextStatus !== 'APPROVED' && nextStatus !== 'REJECTED') return;
+    try {
+      const preview = question.questionText.slice(
+        0,
+        NOTIFICATION_QUESTION_PREVIEW_CHARS,
+      );
+      const ellipsis =
+        question.questionText.length > NOTIFICATION_QUESTION_PREVIEW_CHARS
+          ? '...'
+          : '';
+      await this.notificationService.createNotification({
+        userId: new ObjectId(question.createdBy.toString()),
+        type:
+          nextStatus === 'APPROVED'
+            ? 'mcq_submission_approved'
+            : 'mcq_submission_rejected',
+        title:
+          nextStatus === 'APPROVED'
+            ? 'Your MCQ submission was approved'
+            : 'Your MCQ submission was reviewed',
+        message: `"${preview}${ellipsis}" — ${
+          nextStatus === 'APPROVED' ? 'approved' : 'rejected'
+        }`,
+        courseId: new ObjectId(question.courseId.toString()),
+        courseVersionId: new ObjectId(question.courseVersionId.toString()),
+        read: false,
+        createdAt: new Date(),
+        extra: {
+          studentQuestionId: question._id?.toString(),
+          segmentId: question.segmentId.toString(),
+          ...(nextStatus === 'REJECTED' && rejectionReason
+            ? {rejectionReason}
+            : {}),
+        },
+      });
+    } catch (err) {
+      // Best-effort: don't fail the status update if notification fails.
+      console.error('Failed to emit student question notification', err);
+    }
+  }
 
   private normalize(text: string): string {
     return text.trim().replace(/\s+/g, ' ').toLowerCase();
@@ -303,6 +361,14 @@ export class StudentQuestionService {
     if (!matched) {
       throw new NotFoundError('Student question not found for the given segment.');
     }
+
+    if (statusTransition) {
+      await this._notifyStatusChange(
+        existing,
+        statusTransition.status,
+        statusTransition.rejectionReason,
+      );
+    }
   }
 
   async updateQuestionStatus(input: {
@@ -335,5 +401,37 @@ export class StudentQuestionService {
     if (!matched) {
       throw new NotFoundError('Student question not found for the given segment.');
     }
+
+    // Notify the student author on APPROVED / REJECTED. Fetch fresh so we
+    // have createdBy / segmentId / courseId for the notification payload.
+    if (input.status === 'APPROVED' || input.status === 'REJECTED') {
+      const question = await this.repository.findById({
+        courseId: input.courseId,
+        courseVersionId: input.courseVersionId,
+        segmentId: input.segmentId,
+        questionId: input.questionId,
+      });
+      if (question) {
+        await this._notifyStatusChange(
+          question,
+          input.status,
+          input.reason?.trim(),
+        );
+      }
+    }
+  }
+
+  async listMyQuestions(input: {
+    userId: string;
+    status?: 'PENDING' | 'APPROVED' | 'REJECTED' | 'ALL';
+    limit: number;
+  }) {
+    const repoStatus =
+      input.status && input.status !== 'ALL' ? input.status : undefined;
+    return await this.repository.listByUserId({
+      userId: input.userId,
+      status: repoStatus,
+      limit: input.limit,
+    });
   }
 }

--- a/backend/src/shared/database/interfaces/INotification.ts
+++ b/backend/src/shared/database/interfaces/INotification.ts
@@ -8,7 +8,9 @@ export type NotificationType =
   | 'inactivity_warning'
   | 'appeal_submitted'
   | 'appeal_approved'
-  | 'appeal_rejected';
+  | 'appeal_rejected'
+  | 'mcq_submission_approved'
+  | 'mcq_submission_rejected';
 
 export interface INotification {
   _id?: ObjectId | string;

--- a/frontend/src/app/pages/student/StudentMySubmissions.tsx
+++ b/frontend/src/app/pages/student/StudentMySubmissions.tsx
@@ -1,0 +1,174 @@
+import {useCallback, useEffect, useState} from 'react';
+import {toast} from 'sonner';
+import {Loader2, MessageSquareQuote, RefreshCw} from 'lucide-react';
+import {Badge} from '@/components/ui/badge';
+import {Button} from '@/components/ui/button';
+import {Card, CardContent} from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {useListMyStudentQuestions} from '@/hooks/hooks';
+import type {
+  StudentQuestionListItem,
+  StudentQuestionStatus,
+  StudentQuestionStatusFilter,
+} from '@/types/student-question.types';
+
+const STATUS_FILTER_OPTIONS: StudentQuestionStatusFilter[] = [
+  'ALL',
+  'PENDING',
+  'APPROVED',
+  'REJECTED',
+];
+
+const STATUS_VARIANT: Record<StudentQuestionStatus, 'default' | 'secondary' | 'destructive'> = {
+  PENDING: 'secondary',
+  APPROVED: 'default',
+  REJECTED: 'destructive',
+};
+
+const OPTION_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+
+function formatDate(iso: string | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleString();
+}
+
+function StudentSubmissionRow({question}: {question: StudentQuestionListItem}) {
+  return (
+    <Card className="border">
+      <CardContent className="p-4 space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={STATUS_VARIANT[question.status]}>{question.status}</Badge>
+          <span className="text-xs text-muted-foreground">
+            submitted {formatDate(question.createdAt)}
+          </span>
+          {question.reviewedAt && (
+            <span className="text-xs text-muted-foreground">
+              · reviewed {formatDate(question.reviewedAt)}
+            </span>
+          )}
+        </div>
+        <p className="text-sm font-medium break-words">{question.questionText}</p>
+
+        <ul className="grid gap-1.5">
+          {question.options.map((option, index) => {
+            const isCorrect = index === question.correctOptionIndex;
+            return (
+              <li
+                key={`option-${index}`}
+                className={`flex items-start gap-2 rounded-md border px-3 py-2 text-sm ${
+                  isCorrect ? 'border-primary/40 bg-primary/5' : 'border-border'
+                }`}
+              >
+                <span
+                  className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${
+                    isCorrect ? 'bg-primary text-primary-foreground' : 'bg-muted'
+                  }`}
+                >
+                  {OPTION_LABELS[index]}
+                </span>
+                <span className="break-words">{option.text}</span>
+                {isCorrect && (
+                  <span className="ml-auto text-xs font-medium text-primary">your correct answer</span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+
+        {question.status === 'REJECTED' && question.rejectionReason && (
+          <p className="rounded-md bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            <span className="font-semibold">Reason:</span> {question.rejectionReason}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function StudentMySubmissions() {
+  const [statusFilter, setStatusFilter] = useState<StudentQuestionStatusFilter>('ALL');
+  const [items, setItems] = useState<StudentQuestionListItem[]>([]);
+  const [hasFetched, setHasFetched] = useState(false);
+  const {listMine, loading: isFetching} = useListMyStudentQuestions();
+
+  const fetchSubmissions = useCallback(async () => {
+    try {
+      const response = await listMine(statusFilter, 100);
+      setItems(response?.items ?? []);
+      setHasFetched(true);
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to load your submissions');
+    }
+  }, [listMine, statusFilter]);
+
+  useEffect(() => {
+    void fetchSubmissions();
+  }, [fetchSubmissions]);
+
+  return (
+    <div className="space-y-4 p-4 md:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <MessageSquareQuote className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-xl font-semibold">My Submissions</h1>
+            <p className="text-xs text-muted-foreground">
+              MCQs you've submitted and their review status.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select
+            value={statusFilter}
+            onValueChange={value => setStatusFilter(value as StudentQuestionStatusFilter)}
+          >
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              {STATUS_FILTER_OPTIONS.map(option => (
+                <SelectItem key={option} value={option}>
+                  {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => void fetchSubmissions()}
+            disabled={isFetching}
+            title="Refresh"
+          >
+            <RefreshCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
+      </div>
+
+      {isFetching && !hasFetched ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-md border border-dashed py-10 text-center text-sm text-muted-foreground">
+          You haven't submitted any MCQs yet
+          {statusFilter !== 'ALL' ? ` with status ${statusFilter}` : ''}.
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {items.map(question => (
+            <StudentSubmissionRow key={question._id} question={question} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/routes/router.tsx
+++ b/frontend/src/app/routes/router.tsx
@@ -20,6 +20,7 @@ import StudentDashboard from "@/app/pages/student/dashboard";
 import StudentCourses from "@/app/pages/student/courses";
 import StudentProfile from "@/app/pages/student/profile";
 import StudentAnnouncements from "../pages/student/announcements/StudentAnnouncements";
+import StudentMySubmissions from "../pages/student/StudentMySubmissions";
 import AddCoursePage from '@/app/pages/teacher/AddCoursePage';
 import TeacherProfile from "@/app/pages/teacher/profile";
 import { AudioTranscripter } from '@/app/pages/teacher/AudioTranscripter'
@@ -528,6 +529,13 @@ const studentAnnouncementsRoute = new Route({
   component: StudentAnnouncements,
 });
 
+// Student "my MCQ submissions" route
+const studentMySubmissionsRoute = new Route({
+  getParentRoute: () => studentLayoutRoute,
+  path: '/submissions',
+  component: StudentMySubmissions,
+});
+
 // Student cohorts route
 const studentHpSystemCohortsRoute = new Route({
   getParentRoute: () => studentLayoutRoute,
@@ -709,6 +717,7 @@ const routeTree = rootRoute.addChildren([
     studentIssuesRoute,
     studentLeaderboardRoute,
     studentAnnouncementsRoute,
+    studentMySubmissionsRoute,
     studentHpSystemCohortsRoute,
     studentHpSystemActivitiesRoute,
     studentHpSystemActivitiesDetailRoute,

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -2321,6 +2321,58 @@ export function useListStudentQuestions(): {
   return { listForCourseVersion, listForSegment, loading, error };
 }
 
+export function useListMyStudentQuestions(): {
+  listMine: (
+    status?: import('@/types/student-question.types').StudentQuestionStatusFilter,
+    limit?: number,
+  ) => Promise<import('@/types/student-question.types').StudentQuestionListResponse>;
+  loading: boolean;
+  error: string | null;
+} {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const listMine = async (
+    status: import('@/types/student-question.types').StudentQuestionStatusFilter = 'ALL',
+    limit = 100,
+  ) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (status && status !== 'ALL') params.set('status', status);
+      params.set('limit', String(limit));
+      const url = `${import.meta.env.VITE_BASE_URL}/student-questions/me?${params.toString()}`;
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+      });
+      if (!response.ok) {
+        let serverMessage = '';
+        try {
+          const errBody = await response.json();
+          serverMessage = errBody?.message || errBody?.error || '';
+        } catch {
+          /* response had no JSON body */
+        }
+        throw new Error(serverMessage || `Failed to load my submissions: ${response.status}`);
+      }
+      return await response.json();
+    } catch (err: any) {
+      const message = err?.message || 'Failed to load my submissions';
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { listMine, loading, error };
+}
+
 export function useUpdateStudentQuestionStatus(): {
   updateStatus: (
     courseId: string,

--- a/frontend/src/layouts/student-layout.tsx
+++ b/frontend/src/layouts/student-layout.tsx
@@ -274,6 +274,21 @@ percentCompleted !== 100){
                 </Link>
               </Button>
 
+              <Button
+                variant="ghost"
+                size="sm"
+                className={`relative h-10 px-4 text-sm font-medium transition-all duration-300 hover:bg-gradient-to-r hover:from-accent/30 hover:to-accent/10 hover:text-accent-foreground hover:shadow-lg hover:shadow-accent/10 data-[state=active]:bg-gradient-to-r data-[state=active]:from-primary/10 data-[state=active]:to-primary/5 data-[state=active]:text-primary ${isActive("/student/submissions")
+                  ? "bg-gradient-to-r from-primary/10 to-primary/5 text-primary shadow-md"
+                  : ""
+                  }`}
+                asChild
+              >
+                {/* @ts-ignore */}
+                <Link to="/student/submissions">
+                  <span className="relative z-10">My Submissions</span>
+                </Link>
+              </Button>
+
             </div>
           </div>
 

--- a/frontend/src/types/student-question.types.ts
+++ b/frontend/src/types/student-question.types.ts
@@ -22,6 +22,8 @@ export type StudentQuestionStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
 export interface StudentQuestionListItem {
   _id: string;
   segmentId: string;
+  courseId?: string;
+  courseVersionId?: string;
   questionText: string;
   options: {text: string}[];
   correctOptionIndex: number;


### PR DESCRIPTION
## Summary

Closes the student-side loop opened by PRs #1024 (submission), #1027 (review), and #1028 (surfacing). Today teachers have full UI but students submit into a void — they can't see their own submissions or know when a teacher acts. This PR addresses both.

- **In-app notifications.** When a teacher transitions a student MCQ submission to `APPROVED` or `REJECTED` (via the review queue, segment panel, or the edit dialog's 'Save and Approve'), the student gets a notification in the existing bell-icon dropdown and `/student/notifications` page. Two new notification types: `mcq_submission_approved`, `mcq_submission_rejected`. No changes to the notification UI — types are picked up automatically.
- **My Submissions page** at `/student/submissions` — read-only list of the logged-in student's own submissions across all courses. Status filter (`PENDING` / `APPROVED` / `REJECTED` / `ALL`), correct-option highlight, rejection reasons inline, submitted/reviewed dates.
- **Nav entry** in the student top-level layout after 'Announcements'.

## Out of scope (deferred)

- Email notifications (in-app only; existing notification infra is in-app-only).
- Notification on content-only edits (would be noisy when teachers refine wording without status change).
- Per-segment 'my submissions' drilldown.
- Showing the student which quiz the approved MCQ now appears in.
- Notification 'revoked' on a status flip back to PENDING.

## Test plan

- [ ] As teacher T, **approve** student S's PENDING submission via the review queue. Verify db.notifications.find for the student returns a doc of type mcq_submission_approved with the right courseId, courseVersionId, extra.studentQuestionId, extra.segmentId.
- [ ] As teacher T, **reject** S's next submission with reason 'duplicate question'. Verify the notification type is mcq_submission_rejected and extra.rejectionReason matches.
- [ ] As teacher T, click **Edit → Save and Approve** on a third submission. A mcq_submission_approved notification is fired (atomic flow).
- [ ] As teacher T, click **Edit → Save** (no status change) on a fourth submission. **No notification** fires.
- [ ] As student S, log in. Notification bell shows new unread badges. Click bell → see the MCQ notifications.
- [ ] As S, click 'My Submissions' in the top nav → page loads, shows all of S's submissions across all courses with statuses + dates + rejection reasons.
- [ ] Status filter switches PENDING / APPROVED / REJECTED / ALL correctly.
- [ ] Backend: curl GET .../student-questions/me?status=ALL returns only S's submissions (scoped to authenticated user).
- [ ] Backend: status filter PENDING returns only PENDING rows; APPROVED returns only APPROVED, etc.
- [ ] Backend: a different student S2's call returns only S2's submissions (proper user scoping).
- [ ] Backend: if NotificationService throws (e.g. DB hiccup), the status update still succeeds — the error is logged but does not block.
- [ ] Regression: existing notifications (ejection, reinstatement, appeal_*) still work — just extending the type enum.
- [ ] Regression: PR #1024 submission flow still works.
- [ ] Regression: PR #1027 review queue actions still work.
- [ ] Regression: PR #1028 approved MCQs still surface in quiz attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)