### PR TITLE
fix: avoid section drift when fetching the selected item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ e2e/test-results/
 e2e/screenshots/
 e2e/playwright-report/
 e2e/*.txt
+
+# Local Claude agents
+.github/agents/debugger.agent.md

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -296,7 +296,13 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
 
   // Fetch individual item details when an item is selected
   // Don't fetch during navigation to prevent race condition with stopItem
-  const shouldFetchItem = Boolean(selectedItemId && COURSE_ID && VERSION_ID && !isNavigatingToNext);
+  // Bind the item fetch to the IDs that actually identify the selected item.
+  // activeSectionInfo drifts when the user expands another section in the sidebar
+  // (toggleSection) — using it here sent mismatched (moduleId, sectionId, itemId)
+  // triples that made the backend's previous-item check fail with ForbiddenError.
+  const shouldFetchItem = Boolean(
+    selectedItemId && selectedModuleId && selectedSectionId && COURSE_ID && VERSION_ID && !isNavigatingToNext
+  );
   const {
     data: itemData,
     isLoading: itemLoading,
@@ -306,8 +312,8 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
     shouldFetchItem ? COURSE_ID : '',
     shouldFetchItem ? VERSION_ID : '',
     shouldFetchItem ? selectedItemId! : '',
-    shouldFetchItem ? activeSectionInfo!.moduleId : '',
-    shouldFetchItem ? activeSectionInfo!.sectionId : '',
+    shouldFetchItem ? selectedModuleId! : '',
+    shouldFetchItem ? selectedSectionId! : '',
     shouldFetchItem ? COHORT_ID : ''
   );
   // State to track previous valid item for reverting


### PR DESCRIPTION
shouldFetchItem and the useItemDetails call were keyed off activeSectionInfo, which drifts when the user expands another section in the sidebar (toggleSection). That sent a mismatched (moduleId, sectionId, itemId) triple to the backend whose previous-item check then rejected the fetch with ForbiddenError.

Bind the fetch to selectedModuleId / selectedSectionId instead so the IDs always identify the item that was actually selected.

