### PR TITLE
Feat/face photo on demand

### DIFF
--- a/backend/src/modules/anomalies/controllers/AnomalyController.ts
+++ b/backend/src/modules/anomalies/controllers/AnomalyController.ts
@@ -19,7 +19,10 @@ import { BadRequestErrorResponse, InternalServerErrorResponse } from '#shared/mi
 import { ANOMALIES_TYPES } from '../types.js';
 import { audioUploadOptions, imageUploadOptions } from '../classes/validators/fileUploadOptions.js';
 import { AnomalyData, AnomalyIdParams, CourseAnomaliesQuery, DeleteAnomalyBody, GetAnomalyParams, GetCourseAnomalyParams, GetItemAnomalyParams, GetUserAnomalyParams, NewAnomalyData, StatsQueryParams } from '../classes/validators/AnomalyValidators.js';
-import { AnomalyDataResponse, AnomalyStats, FileType } from '../classes/transformers/Anomaly.js';
+import { AnomalyDataResponse, AnomalyStats, AnomalyType, FileType } from '../classes/transformers/Anomaly.js';
+import { SETTING_TYPES } from '#root/modules/setting/types.js';
+import { CourseSettingService } from '#root/modules/setting/services/CourseSettingService.js';
+import { ProctoringComponent } from '#root/shared/database/interfaces/ISettingRepository.js';
 import { PaginationQuery } from '#root/shared/index.js';
 import { Ability } from '#root/shared/functions/AbilityDecorator.js';
 import { getAnomalyAbility } from '../abilities/anomalyAbilities.js';
@@ -36,6 +39,7 @@ import { UserNotFoundErrorResponse } from '#root/modules/users/classes/index.js'
 export class AnomalyController {
   constructor(
     @inject(ANOMALIES_TYPES.AnomalyService) private anomalyService: AnomalyService,
+    @inject(SETTING_TYPES.CourseSettingService) private courseSettingService: CourseSettingService,
   ) {}
 
   @OpenAPI({
@@ -68,7 +72,20 @@ export class AnomalyController {
     // if (!ability.can('create', anomalyRes)) {
     //   throw new ForbiddenError('You do not have permission to create an anomaly');
     // }
-    
+
+    if (body.type === AnomalyType.FACE_RECOGNITION) {
+      const courseSetting = await this.courseSettingService.readCourseSettings(
+        courseId.toString(),
+        versionId.toString(),
+      );
+      const detector = courseSetting?.settings?.proctors?.detectors?.find(
+        d => d.detectorName === ProctoringComponent.FACERECOGNITION,
+      );
+      if (!detector?.settings?.enabled) {
+        throw new ForbiddenError('Face recognition is disabled for this course');
+      }
+    }
+
     return this.anomalyService.recordAnomaly(userId, body, file, FileType.IMAGE);
   }
 

--- a/backend/src/modules/auth/classes/validators/AuthValidators.ts
+++ b/backend/src/modules/auth/classes/validators/AuthValidators.ts
@@ -132,6 +132,39 @@ class GoogleSignUpBody {
   })
   @IsOptional()
   lastName?: string;
+
+  @JSONSchema({
+    title: 'Role',
+    description: 'Selected role at signup time. Students must also provide profileImage and faceEmbedding for proctoring.',
+    example: 'student',
+    type: 'string',
+  })
+  @IsOptional()
+  @IsString()
+  role?: string;
+
+  @JSONSchema({
+    title: 'Profile Image',
+    description: 'Student profile image as a data URL or remote URL. Required for student role.',
+    example: 'data:image/jpeg;base64,/9j/4AAQSk...',
+    type: 'string',
+  })
+  @IsOptional()
+  @IsString()
+  profileImage?: string;
+
+  @JSONSchema({
+    title: 'Face Embedding',
+    description: '128-length face embedding generated from the registration image. Required for student role.',
+    type: 'array',
+    items: {
+      type: 'number',
+    },
+  })
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, {each: true})
+  faceEmbedding?: number[];
 }
 
 class VerifySignUpProviderBody {

--- a/backend/src/modules/auth/services/FirebaseAuthService.ts
+++ b/backend/src/modules/auth/services/FirebaseAuthService.ts
@@ -7,7 +7,7 @@ import {
 import {IAuthService} from '#auth/interfaces/IAuthService.js';
 import {GLOBAL_TYPES} from '#root/types.js';
 import {injectable, inject} from 'inversify';
-import {InternalServerError} from 'routing-controllers';
+import {BadRequestError, InternalServerError} from 'routing-controllers';
 import admin from 'firebase-admin';
 import {IUser} from '#root/shared/interfaces/models.js';
 import {BaseService} from '#root/shared/classes/BaseService.js';
@@ -249,11 +249,22 @@ export class FirebaseAuthService extends BaseService implements IAuthService {
       };
     }
 
+    // Face photo is optional at signup. Students who enter a course that
+    // requires face recognition will be redirected to complete their face
+    // registration before proctoring can start.
+    if (body.faceEmbedding && body.faceEmbedding.length !== 128) {
+      throw new BadRequestError(
+        'Face embedding must be exactly 128 numbers.',
+      );
+    }
+
     const user: Partial<IUser> = {
       firebaseUID: firebaseUID,
       email: body.email,
       firstName: body.firstName,
       lastName: body.lastName,
+      profileImage: body.profileImage,
+      faceEmbedding: body.faceEmbedding,
       roles: 'user',
     };
 

--- a/backend/src/modules/users/classes/validators/UserValidators.ts
+++ b/backend/src/modules/users/classes/validators/UserValidators.ts
@@ -1,5 +1,5 @@
 import { IUser } from '#root/shared/interfaces/models.js';
-import {IsNotEmpty, IsString, IsEmail, IsOptional} from 'class-validator';
+import {IsNotEmpty, IsString, IsEmail, IsOptional, IsArray, IsNumber, ArrayMinSize, ArrayMaxSize} from 'class-validator';
 import {JSONSchema} from 'class-validator-jsonschema';
 import { ObjectId } from 'mongodb';
 
@@ -163,6 +163,28 @@ export class EditUserBody{
   @IsString()
   @IsOptional()
   city?: string;
+}
+
+export class UpdateFaceReferenceBody {
+  @JSONSchema({
+    description: 'Profile image as a data URL or remote URL',
+    example: 'data:image/jpeg;base64,/9j/4AAQSk...',
+    type: 'string',
+  })
+  @IsString()
+  @IsNotEmpty()
+  profileImage: string;
+
+  @JSONSchema({
+    description: '128-length face embedding generated from the registration image',
+    type: 'array',
+    items: {type: 'number'},
+  })
+  @IsArray()
+  @ArrayMinSize(128)
+  @ArrayMaxSize(128)
+  @IsNumber({}, {each: true})
+  faceEmbedding: number[];
 }
 
 /**

--- a/backend/src/modules/users/controllers/UserController.ts
+++ b/backend/src/modules/users/controllers/UserController.ts
@@ -14,6 +14,7 @@ import {
   Patch,
   Authorized,
   CurrentUser,
+  QueryParam,
 } from 'routing-controllers';
 import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 import {
@@ -27,6 +28,9 @@ import { EnrollmentService } from '#users/services/EnrollmentService.js';
 import { AUTH_TYPES } from '#root/modules/auth/types.js';
 import { IAuthService } from '#root/modules/auth/interfaces/IAuthService.js';
 import { IUser } from '#root/shared/interfaces/models.js';
+import { SETTING_TYPES } from '#root/modules/setting/types.js';
+import { CourseSettingService } from '#root/modules/setting/services/CourseSettingService.js';
+import { ProctoringComponent } from '#root/shared/database/interfaces/ISettingRepository.js';
 
 @OpenAPI({
   tags: ['Users'],
@@ -43,6 +47,9 @@ export class UserController {
 
     @inject(USERS_TYPES.EnrollmentService)
     private readonly enrollmentService: EnrollmentService,
+
+    @inject(SETTING_TYPES.CourseSettingService)
+    private readonly courseSettingService: CourseSettingService,
   ) { }
 
   @OpenAPI({
@@ -105,12 +112,16 @@ export class UserController {
 
   @OpenAPI({
     summary: 'Get the current user face reference',
-    description: 'Returns the authenticated user label and stored profile image for face comparison.',
+    description: 'Returns the authenticated user label and stored profile image for face comparison. When courseId and versionId are supplied, the face embedding is only returned if the course has face recognition enabled.',
   })
   @Authorized()
   @Get('/me/face-reference')
   @HttpCode(200)
-  async getCurrentUserFaceReference(@Req() req: any): Promise<{
+  async getCurrentUserFaceReference(
+    @Req() req: any,
+    @QueryParam('courseId') courseId?: string,
+    @QueryParam('versionId') versionId?: string,
+  ): Promise<{
     label: string;
     profileImage: string | null;
     faceEmbedding: number[] | null;
@@ -118,10 +129,22 @@ export class UserController {
     const token = req.headers.authorization?.split(' ')[1];
     const user = await this.authService.getCurrentUserFromToken(token);
 
+    let faceRecognitionAllowed = true;
+    if (courseId && versionId) {
+      const courseSetting = await this.courseSettingService.readCourseSettings(
+        courseId,
+        versionId,
+      );
+      const detector = courseSetting?.settings?.proctors?.detectors?.find(
+        d => d.detectorName === ProctoringComponent.FACERECOGNITION,
+      );
+      faceRecognitionAllowed = detector?.settings?.enabled ?? false;
+    }
+
     return {
       label: `${user.firstName || ''} ${user.lastName || ''}`.trim() || user.email,
       profileImage: user.profileImage || null,
-      faceEmbedding: user.faceEmbedding || null,
+      faceEmbedding: faceRecognitionAllowed ? (user.faceEmbedding || null) : null,
     };
   }
 

--- a/backend/src/modules/users/controllers/UserController.ts
+++ b/backend/src/modules/users/controllers/UserController.ts
@@ -21,6 +21,7 @@ import {
   EditUserBody,
   GetUserParams,
   GetUserResponse,
+  UpdateFaceReferenceBody,
   UserNotFoundErrorResponse,
 } from '../classes/validators/UserValidators.js';
 import { UserEnrollmentStatisticsResponse } from '../classes/validators/EnrollmentValidators.js';
@@ -146,6 +147,25 @@ export class UserController {
       profileImage: user.profileImage || null,
       faceEmbedding: faceRecognitionAllowed ? (user.faceEmbedding || null) : null,
     };
+  }
+
+  @OpenAPI({
+    summary: 'Set or replace the current user face reference',
+    description: 'Stores a profile image and 128-length face embedding on the current user. Used when a student adds their face after initial signup.',
+  })
+  @Authorized()
+  @Patch('/me/face-reference')
+  @OnUndefined(200)
+  async updateCurrentUserFaceReference(
+    @Req() req: any,
+    @Body() body: UpdateFaceReferenceBody,
+  ): Promise<void> {
+    const token = req.headers.authorization?.split(' ')[1];
+    const user = await this.authService.getCurrentUserFromToken(token);
+    await this.userService.editUser(user._id!.toString(), {
+      profileImage: body.profileImage,
+      faceEmbedding: body.faceEmbedding,
+    });
   }
 
   @OpenAPI({

--- a/frontend/src/components/Auth/AuthPage.tsx
+++ b/frontend/src/components/Auth/AuthPage.tsx
@@ -1,4 +1,4 @@
-import { loginWithGoogle, loginWithEmail } from "@/lib/firebase";
+import { loginWithGoogle, loginWithEmail, auth } from "@/lib/firebase";
 import { useAuthStore } from "@/store/auth-store";
 import { useNavigate } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
@@ -49,6 +49,13 @@ export default function AuthPage({ role }: AuthPageProps) {
   const [studentPhotoFile, setStudentPhotoFile] = useState<File | null>(null);
   const [isCameraOpen, setIsCameraOpen] = useState(false);
   const [cameraError, setCameraError] = useState("");
+  const [googleSignupPending, setGoogleSignupPending] = useState<{
+    idToken: string;
+    email: string;
+    firstName: string;
+    lastName: string;
+  } | null>(null);
+
   const videoCaptureRef = useRef<HTMLVideoElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
@@ -276,23 +283,40 @@ export default function AuthPage({ role }: AuthPageProps) {
       setLoading(true);
       setFormErrors({});
       const result = await loginWithGoogle();
-      // Check if the user is new
+      const chosenRole = activeRole;
+
       if (result._tokenResponse.isNewUser) {
-        // If new user, set the default role to student
-        setActiveRole("student");
+        if (chosenRole === "student") {
+          // Students need a face photo for proctoring. Defer the backend POST
+          // until they've captured or uploaded one.
+          resetStudentPhoto();
+          setGoogleSignupPending({
+            idToken: result._tokenResponse.idToken,
+            email: result.user.email || "",
+            firstName: result._tokenResponse.firstName || "",
+            lastName: result._tokenResponse.lastName || "",
+          });
+          return;
+        }
+
+        // Non-student roles (teacher) skip the photo step.
         const backendUrl = `${import.meta.env.VITE_BASE_URL}/auth/signup/google/`;
         const response = await fetch(backendUrl, {
-          method: 'POST',
+          method: "POST",
           headers: {
             Authorization: `Bearer ${result._tokenResponse.idToken}`,
-            'Content-Type': 'application/json'
+            "Content-Type": "application/json",
           },
           body: JSON.stringify({
             email: result.user.email,
             firstName: result._tokenResponse.firstName,
             lastName: result._tokenResponse.lastName,
+            role: chosenRole,
           }),
         });
+        if (!response.ok) {
+          throw new Error(`Signup failed with status ${response.status}`);
+        }
       }
 
       // Set user in store
@@ -300,7 +324,7 @@ export default function AuthPage({ role }: AuthPageProps) {
         uid: result.user.uid,
         email: result.user.email || "",
         name: result.user.displayName || "",
-        role: activeRole, // Use the selected role from tabs
+        role: chosenRole,
         avatar: result.user.photoURL || "",
       });
 
@@ -311,7 +335,7 @@ export default function AuthPage({ role }: AuthPageProps) {
       if (redirectUrl) {
         navigate({ to: redirectUrl });
       } else {
-        navigate({ to: `/${activeRole}` });
+        navigate({ to: `/${chosenRole}` });
       }
     } catch (error) {
       console.error("Google Login Failed", error);
@@ -319,6 +343,88 @@ export default function AuthPage({ role }: AuthPageProps) {
         ...formErrors,
         auth: "Failed to sign in with Google. Please try again."
       });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const finishGoogleSignup = async (
+    profileImage?: string,
+    faceEmbedding?: number[],
+  ) => {
+    if (!googleSignupPending) return;
+
+    const backendUrl = `${import.meta.env.VITE_BASE_URL}/auth/signup/google/`;
+    const response = await fetch(backendUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${googleSignupPending.idToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: googleSignupPending.email,
+        firstName: googleSignupPending.firstName,
+        lastName: googleSignupPending.lastName,
+        role: "student",
+        ...(profileImage ? { profileImage } : {}),
+        ...(faceEmbedding ? { faceEmbedding } : {}),
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`Signup failed with status ${response.status}`);
+    }
+
+    const fbUser = auth.currentUser;
+    setUser({
+      uid: fbUser?.uid || "",
+      email: fbUser?.email || googleSignupPending.email,
+      name:
+        fbUser?.displayName ||
+        `${googleSignupPending.firstName} ${googleSignupPending.lastName}`.trim(),
+      role: "student",
+      avatar: fbUser?.photoURL || "",
+    });
+
+    setGoogleSignupPending(null);
+    resetStudentPhoto();
+
+    const searchParams = new URLSearchParams(window.location.search);
+    const redirectUrl = searchParams.get("redirect");
+    navigate({ to: redirectUrl || "/student" });
+  };
+
+  const skipGoogleSignupPhoto = async () => {
+    try {
+      setLoading(true);
+      setCameraError("");
+      await finishGoogleSignup();
+    } catch (error: any) {
+      console.error("Google signup (skip photo) failed", error);
+      setCameraError(error?.message || "Unable to complete signup. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const completeGoogleSignup = async () => {
+    if (!googleSignupPending) return;
+    if (!studentPhotoFile) {
+      setCameraError("Please capture or upload a clear face photo, or use Skip for now.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setCameraError("");
+
+      const profileImage = await convertFileToDataUrl(studentPhotoFile);
+      const faceEmbedding = await generateFaceEmbedding(studentPhotoFile);
+      await finishGoogleSignup(profileImage, faceEmbedding);
+    } catch (error: any) {
+      console.error("Google signup completion failed", error);
+      setCameraError(
+        error?.message || "Unable to complete signup. Please try again.",
+      );
     } finally {
       setLoading(false);
     }
@@ -435,18 +541,12 @@ export default function AuthPage({ role }: AuthPageProps) {
       return;
     }
 
-    if (activeRole === "student" && !studentPhotoFile) {
-      setFormErrors({
-        ...formErrors,
-        auth: "Student registration requires a clear face photo for verification.",
-      });
-      return;
-    }
-
     try {
       setLoading(true);
       setFormErrors({});
 
+      // Face photo is optional at signup; students can add it later when
+      // they enter a course that requires face recognition.
       const profileImage =
         activeRole === "student" && studentPhotoFile
           ? await convertFileToDataUrl(studentPhotoFile)
@@ -944,9 +1044,10 @@ export default function AuthPage({ role }: AuthPageProps) {
                       {activeRole === "student" && (
                         <div className="space-y-3 rounded-xl border border-border/60 bg-muted/20 p-4">
                           <div className="space-y-1">
-                            <Label className="font-medium">Student Photo</Label>
+                            <Label className="font-medium">Student Photo (optional)</Label>
                             <p className="text-xs text-muted-foreground">
-                              Add a clear face photo using your webcam or by uploading an image.
+                              Optional now. You can add a face photo here, or do it later
+                              when entering a proctored course that requires it.
                             </p>
                           </div>
 
@@ -1114,6 +1215,130 @@ export default function AuthPage({ role }: AuthPageProps) {
           </div>
         </div>
       </div>
+
+      {googleSignupPending && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <Card className="w-full max-w-lg">
+            <CardHeader>
+              <CardTitle>Add a face photo (optional)</CardTitle>
+              <CardDescription>
+                Hi {googleSignupPending.firstName || googleSignupPending.email}. You can
+                add a face photo now for proctored courses, or skip and add it later
+                when you enter a course that requires it.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-3 rounded-xl border border-border/60 bg-muted/20 p-4">
+                {!studentPhotoPreview ? (
+                  <div className="space-y-3">
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <Button type="button" className="flex-1" onClick={openCamera}>
+                        <Camera className="mr-2 h-4 w-4" />
+                        Use webcam
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="flex-1"
+                        onClick={() => fileInputRef.current?.click()}
+                      >
+                        <Upload className="mr-2 h-4 w-4" />
+                        Upload photo
+                      </Button>
+                    </div>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={handleStudentPhotoUpload}
+                    />
+                    {isCameraOpen && (
+                      <div className="space-y-3 rounded-lg border border-border p-3">
+                        <video
+                          ref={videoCaptureRef}
+                          autoPlay
+                          muted
+                          playsInline
+                          className="h-56 w-full rounded-lg bg-slate-950 object-cover"
+                        />
+                        <div className="flex flex-col gap-2 sm:flex-row">
+                          <Button type="button" className="flex-1" onClick={capturePhoto}>
+                            <Camera className="mr-2 h-4 w-4" />
+                            Capture photo
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            className="flex-1"
+                            onClick={() => {
+                              setIsCameraOpen(false);
+                              stopCameraStream();
+                            }}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    <img
+                      src={studentPhotoPreview}
+                      alt="Student preview"
+                      className="h-56 w-full rounded-lg object-cover"
+                    />
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="flex-1"
+                        onClick={openCamera}
+                      >
+                        <RefreshCcw className="mr-2 h-4 w-4" />
+                        Retake
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="flex-1 text-red-600 hover:text-red-700"
+                        onClick={resetStudentPhoto}
+                      >
+                        <X className="mr-2 h-4 w-4" />
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+                )}
+                {cameraError && (
+                  <p className="text-xs text-destructive">{cameraError}</p>
+                )}
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col gap-2 sm:flex-row">
+              <Button
+                type="button"
+                variant="outline"
+                className="flex-1"
+                onClick={skipGoogleSignupPhoto}
+                disabled={loading}
+              >
+                Skip for now
+              </Button>
+              <Button
+                type="button"
+                className="flex-1"
+                onClick={completeGoogleSignup}
+                disabled={loading || !studentPhotoFile}
+              >
+                {loading ? "Finishing…" : "Submit and continue"}
+              </Button>
+            </CardFooter>
+          </Card>
+        </div>
+      )}
+
     </div>
   );
 }

--- a/frontend/src/components/Auth/AuthPage.tsx
+++ b/frontend/src/components/Auth/AuthPage.tsx
@@ -56,6 +56,9 @@ export default function AuthPage({ role }: AuthPageProps) {
     lastName: string;
   } | null>(null);
 
+  const completeFaceMode =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("completeFace") === "1";
   const videoCaptureRef = useRef<HTMLVideoElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
@@ -406,6 +409,51 @@ export default function AuthPage({ role }: AuthPageProps) {
     }
   };
 
+  const saveFaceReference = async () => {
+    if (!studentPhotoFile) {
+      setCameraError("Please capture or upload a clear face photo to continue.");
+      return;
+    }
+    try {
+      setLoading(true);
+      setCameraError("");
+
+      const profileImage = await convertFileToDataUrl(studentPhotoFile);
+      const faceEmbedding = await generateFaceEmbedding(studentPhotoFile);
+
+      const authToken = localStorage.getItem("firebase-auth-token");
+      if (!authToken) {
+        throw new Error("Please sign in again to save your face photo.");
+      }
+
+      const response = await fetch(
+        `${import.meta.env.VITE_BASE_URL}/users/me/face-reference`,
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ profileImage, faceEmbedding }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to save face photo (status ${response.status})`);
+      }
+
+      resetStudentPhoto();
+
+      const searchParams = new URLSearchParams(window.location.search);
+      const redirectUrl = searchParams.get("redirect");
+      navigate({ to: redirectUrl || `/${user?.role || "student"}` });
+    } catch (error: any) {
+      console.error("Failed to save face reference", error);
+      setCameraError(error?.message || "Unable to save your face photo. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const completeGoogleSignup = async () => {
     if (!googleSignupPending) return;
     if (!studentPhotoFile) {
@@ -627,6 +675,11 @@ export default function AuthPage({ role }: AuthPageProps) {
     const searchParams = new URLSearchParams(window.location.search);
     const redirectUrl = searchParams.get("redirect");
 
+    if (completeFaceMode) {
+      // Stay on the page so the logged-in user can add their face photo.
+      return;
+    }
+
     if (isAuthenticated && user) {
       if (redirectUrl) {
         navigate({ to: redirectUrl });
@@ -639,7 +692,7 @@ export default function AuthPage({ role }: AuthPageProps) {
         }
       }
     }
-  }, [isAuthenticated, user, navigate]);
+  }, [isAuthenticated, user, navigate, completeFaceMode]);
 
   useEffect(() => {
     if (!isCameraOpen || !mediaStreamRef.current || !videoCaptureRef.current) {
@@ -1339,6 +1392,118 @@ export default function AuthPage({ role }: AuthPageProps) {
         </div>
       )}
 
+      {completeFaceMode && isAuthenticated && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <Card className="w-full max-w-lg">
+            <CardHeader>
+              <CardTitle>Face photo required</CardTitle>
+              <CardDescription>
+                The course you are entering requires face recognition. Please capture
+                or upload a clear face photo to continue.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-3 rounded-xl border border-border/60 bg-muted/20 p-4">
+                {!studentPhotoPreview ? (
+                  <div className="space-y-3">
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <Button type="button" className="flex-1" onClick={openCamera}>
+                        <Camera className="mr-2 h-4 w-4" />
+                        Use webcam
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="flex-1"
+                        onClick={() => fileInputRef.current?.click()}
+                      >
+                        <Upload className="mr-2 h-4 w-4" />
+                        Upload photo
+                      </Button>
+                    </div>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={handleStudentPhotoUpload}
+                    />
+                    {isCameraOpen && (
+                      <div className="space-y-3 rounded-lg border border-border p-3">
+                        <video
+                          ref={videoCaptureRef}
+                          autoPlay
+                          muted
+                          playsInline
+                          className="h-56 w-full rounded-lg bg-slate-950 object-cover"
+                        />
+                        <div className="flex flex-col gap-2 sm:flex-row">
+                          <Button type="button" className="flex-1" onClick={capturePhoto}>
+                            <Camera className="mr-2 h-4 w-4" />
+                            Capture photo
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            className="flex-1"
+                            onClick={() => {
+                              setIsCameraOpen(false);
+                              stopCameraStream();
+                            }}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    <img
+                      src={studentPhotoPreview}
+                      alt="Student preview"
+                      className="h-56 w-full rounded-lg object-cover"
+                    />
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="flex-1"
+                        onClick={openCamera}
+                      >
+                        <RefreshCcw className="mr-2 h-4 w-4" />
+                        Retake
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="flex-1 text-red-600 hover:text-red-700"
+                        onClick={resetStudentPhoto}
+                      >
+                        <X className="mr-2 h-4 w-4" />
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+                )}
+                {cameraError && (
+                  <p className="text-xs text-destructive">{cameraError}</p>
+                )}
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Button
+                type="button"
+                className="w-full"
+                onClick={saveFaceReference}
+                disabled={loading || !studentPhotoFile}
+              >
+                {loading ? "Saving…" : "Save and continue"}
+              </Button>
+            </CardFooter>
+          </Card>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ai/FaceDetectors.tsx
+++ b/frontend/src/components/ai/FaceDetectors.tsx
@@ -46,7 +46,7 @@ const isLookingAway = (face: Face): boolean => {
   return false;
 };
 
-const FaceDetectors: React.FC<FaceDetectorsProps> = ({ setIsFocused, faces, videoRef, onRecognitionResult, onDebugInfoUpdate, onMismatchChange }) => {
+const FaceDetectors: React.FC<FaceDetectorsProps> = ({ setIsFocused, faces, videoRef, onRecognitionResult, onDebugInfoUpdate, onMismatchChange, settings }) => {
 
   useEffect(() => {
     const isFocused = true;
@@ -66,14 +66,16 @@ const FaceDetectors: React.FC<FaceDetectorsProps> = ({ setIsFocused, faces, vide
 
   return (
     <>
-      {/* Face Recognition Component */}
-      <FaceRecognitionComponent
-        faces={faces}
-        videoRef={videoRef}
-        onRecognitionResult={onRecognitionResult}
-        onDebugInfoUpdate={onDebugInfoUpdate}
-        onMismatchChange={onMismatchChange}
-      />
+      {settings?.isFaceRecognitionEnabled && (
+        <FaceRecognitionComponent
+          faces={faces}
+          videoRef={videoRef}
+          onRecognitionResult={onRecognitionResult}
+          onDebugInfoUpdate={onDebugInfoUpdate}
+          onMismatchChange={onMismatchChange}
+          enabled={settings.isFaceRecognitionEnabled}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/components/ai/FaceRecognitionComponent.tsx
+++ b/frontend/src/components/ai/FaceRecognitionComponent.tsx
@@ -49,6 +49,7 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
   onRecognitionResult,
   onDebugInfoUpdate,
   onMismatchChange,
+  enabled = true,
 }) => {
   const [isReady, setIsReady] = useState(false);
 
@@ -86,7 +87,13 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
       throw new Error('No auth token available for face reference lookup.');
     }
 
-    const response = await fetch(`${import.meta.env.VITE_BASE_URL}/users/me/face-reference`, {
+    const course = courseStore.currentCourse;
+    const params = new URLSearchParams();
+    if (course?.courseId) params.set('courseId', course.courseId);
+    if (course?.versionId) params.set('versionId', course.versionId);
+    const query = params.toString() ? `?${params.toString()}` : '';
+
+    const response = await fetch(`${import.meta.env.VITE_BASE_URL}/users/me/face-reference${query}`, {
       headers: {
         Authorization: `Bearer ${authToken}`,
       },
@@ -97,7 +104,7 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
     }
 
     return response.json();
-  }, []);
+  }, [courseStore.currentCourse]);
 
   const createMismatchSnapshot = useCallback(async () => {
     const video = videoRef.current;
@@ -156,6 +163,10 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
   }, []);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     let isMounted = true;
 
     const initialize = async () => {
@@ -222,7 +233,7 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
     return () => {
       isMounted = false;
     };
-  }, [fetchFaceReference, updateDebugInfo]);
+  }, [enabled, fetchFaceReference, updateDebugInfo]);
 
   const processRecognition = useCallback(async () => {
     const referenceEmbedding = referenceEmbeddingRef.current;
@@ -354,7 +365,7 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
   ]);
 
   useEffect(() => {
-    if (!isReady) {
+    if (!enabled || !isReady) {
       return;
     }
 
@@ -363,7 +374,7 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
     }, VERIFY_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
-  }, [isReady, processRecognition]);
+  }, [enabled, isReady, processRecognition]);
 
   return null;
 };

--- a/frontend/src/components/ai/FaceRecognitionComponent.tsx
+++ b/frontend/src/components/ai/FaceRecognitionComponent.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as faceapi from '@vladmandic/face-api';
+import { useNavigate } from '@tanstack/react-router';
+import { toast } from 'sonner';
 
 import { useReportAnomalyImage } from '@/hooks/hooks';
 import { useCourseStore } from '@/store/course-store';
@@ -55,6 +57,8 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
 
   const reportImage = useReportAnomalyImage();
   const courseStore = useCourseStore();
+  const navigate = useNavigate();
+  const missingEmbeddingRedirectedRef = useRef(false);
   const referenceEmbeddingRef = useRef<number[] | null>(null);
   const referenceLabelRef = useRef('registered-user');
   const matchCountRef = useRef(0);
@@ -198,7 +202,16 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
         const normalizedEmbedding = normalizeEmbedding(reference.faceEmbedding);
 
         if (!normalizedEmbedding || normalizedEmbedding.length !== EMBEDDING_LENGTH) {
-          throw new Error('Stored face embedding is invalid. Please register again.');
+          if (!missingEmbeddingRedirectedRef.current) {
+            missingEmbeddingRedirectedRef.current = true;
+            const redirectTo = typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/';
+            toast.error('This course requires a face photo. Please add one to continue.');
+            navigate({
+              to: '/auth',
+              search: { completeFace: '1', redirect: redirectTo } as any,
+            });
+          }
+          return;
         }
 
         referenceEmbeddingRef.current = normalizedEmbedding;
@@ -233,7 +246,7 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
     return () => {
       isMounted = false;
     };
-  }, [enabled, fetchFaceReference, updateDebugInfo]);
+  }, [enabled, fetchFaceReference, navigate, updateDebugInfo]);
 
   const processRecognition = useCallback(async () => {
     const referenceEmbedding = referenceEmbeddingRef.current;

--- a/frontend/src/components/floating-video.tsx
+++ b/frontend/src/components/floating-video.tsx
@@ -1301,7 +1301,7 @@ const lastCalledRef = useRef<number>(0);
           </div>
         )} */}
         {/* )} */}
-        {!isCollapsed && recognizedFaces.length > 0 && (
+        {isFaceRecognitionEnabled && !isCollapsed && recognizedFaces.length > 0 && (
           <FaceRecognitionOverlay
             recognitions={recognizedFaces}
             videoRef={videoRef}
@@ -1379,7 +1379,7 @@ const lastCalledRef = useRef<number>(0);
                         )}
 
                         {/* Face Recognition Results */}
-                        {recognizedFaces.length > 0 && (
+                        {isFaceRecognitionEnabled && recognizedFaces.length > 0 && (
                           <div>Recognized:
                             {recognizedFaces.map((face, index) => (
                               <span key={index} className={face.isMatch ? "text-green-400" : "text-yellow-400"}>

--- a/frontend/src/types/ai.types.ts
+++ b/frontend/src/types/ai.types.ts
@@ -68,6 +68,7 @@ export interface FaceRecognitionComponentProps {
   onRecognitionResult?: (recognitions: FaceRecognition[]) => void;
   onDebugInfoUpdate?: (debugInfo: FaceRecognitionDebugInfo) => void;
   onMismatchChange?: (hasMismatch: boolean) => void;
+  enabled?: boolean;
 }
 
 export interface FaceRecognitionOverlayProps {


### PR DESCRIPTION
## Summary

Makes the student face photo capture **optional at signup** and moves the hard requirement to **course-entry time**, only when the course has face recognition enabled.

Builds on top of #1030 (which gated the recognition pipeline behind the per-course setting).

## What changes for the user

- **Email signup** — the face photo section is now labelled "(optional)". Students can skip it and proceed.
- **Google signup** — new student accounts get a modal after the Google popup with two choices: *Skip for now* or *Submit and continue*. Teachers signing up via Google never see the modal.
- **Course entry** — when a student opens a proctored course (face recognition setting ON) but has no embedding on file, a toast appears and they're redirected to `/auth?completeFace=1&redirect=<original-path>`. The AuthPage renders a focused capture overlay; on submit, their embedding is saved via a new endpoint and they're sent back to the course.
- **Existing students with no embedding** — the same redirect flow catches them the first time they enter a proctored course.

## Commits in this PR

1. **`feat: make signup face photo optional`** — drops the hard block in `handleEmailSignup`; adds the Skip/Submit modal to `handleGoogleLogin`. `GoogleSignUpBody` accepts optional `role`/`profileImage`/`faceEmbedding`; `googleSignup()` persists them when present.

2. **`feat: add PATCH /users/me/face-reference endpoint`** — new endpoint backed by the existing `UserService.editUser` write path. Validates `profileImage` is non-empty and `faceEmbedding` is exactly 128 numbers.

3. **`feat: prompt for face capture at proctored course entry`** — `FaceRecognitionComponent` now toasts and navigates to AuthPage's new `completeFace` mode when initialised against a missing embedding (only fires when `enabled === true` 
