### PR TITLE
Feat/follow up course invite

### DIFF
--- a/backend/src/modules/anomalies/classes/validators/AnomalyValidators.ts
+++ b/backend/src/modules/anomalies/classes/validators/AnomalyValidators.ts
@@ -7,7 +7,10 @@ import {
   IsString,
 } from 'class-validator';
 import {JSONSchema} from 'class-validator-jsonschema';
-import {AnomalyType, FileType, IAnomalyData} from '../../index.js';
+// Import directly from the defining transformer rather than the module barrel
+// to avoid a circular dependency (the barrel re-exports controllers that pull
+// these validators back in, leaving AnomalyType undefined at eval time).
+import {AnomalyType, FileType, IAnomalyData} from '../transformers/Anomaly.js';
 import {ObjectId} from 'mongodb';
 import {
   SortOrder,

--- a/backend/src/modules/notifications/classes/validators/InviteValidators.ts
+++ b/backend/src/modules/notifications/classes/validators/InviteValidators.ts
@@ -1,4 +1,5 @@
 import {Course} from '#root/modules/courses/classes/index.js';
+import {appConfig} from '#root/config/app.js';
 import {
   EnrollmentRole,
   ID,
@@ -272,6 +273,17 @@ class InviteResult {
   @ValidateNested()
   course?: Course;
 
+  @JSONSchema({
+    description:
+      'Exclusive link the user can open to accept this invite and enrol',
+    type: 'string',
+    example:
+      'https://app.example.com/api/notifications/invite/60c72b2f9b1e8d3f4c8b4567',
+  })
+  @IsString()
+  @IsOptional()
+  acceptUrl?: string;
+
   constructor(
     inviteId: ObjectId | string,
     email: string,
@@ -291,6 +303,9 @@ class InviteResult {
     this.courseId = courseId;
     this.courseVersionId = courseVersionId;
     this.cohortId = cohortId;
+    if (inviteId) {
+      this.acceptUrl = `${appConfig.url}${appConfig.routePrefix}/notifications/invite/${inviteId.toString()}`;
+    }
     if (inviteStatus == 'ACCEPTED' && acceptedAt) {
       this.acceptedAt = acceptedAt;
     }

--- a/backend/src/modules/setting/classes/transformers/CourseSetting.ts
+++ b/backend/src/modules/setting/classes/transformers/CourseSetting.ts
@@ -305,7 +305,11 @@ import {
 } from '#shared/constants/transformerConstants.js';
 import {ID} from '#shared/index.js';
 import {ProctoringComponent} from '#shared/database/index.js';
-import {ICourseSetting, IDetectorSettings} from '#shared/interfaces/models.js';
+import {
+  ICourseSetting,
+  IDetectorSettings,
+  EnrollmentRole,
+} from '#shared/interfaces/models.js';
 import {JSONSchema} from 'class-validator-jsonschema';
 import {CreateCourseSettingBody} from '../index.js';
 import {ObjectId} from 'mongodb';
@@ -430,6 +434,13 @@ class CourseSetting implements ICourseSetting {
       uiSchema?: any;
       isActive?: boolean;
     };
+    followUpInvite?: {
+      enabled: boolean;
+      courseId?: ID;
+      courseVersionId?: ID;
+      cohortId?: ID;
+      role?: EnrollmentRole;
+    };
   };
 
   constructor(courseSettingsBody?: CreateCourseSettingBody) {
@@ -464,6 +475,17 @@ class CourseSetting implements ICourseSetting {
         uiSchema: courseSettingsBody?.settings?.registration?.uiSchema,
         isActive: courseSettingsBody?.settings?.registration?.isActive ?? true,
       },
+      followUpInvite: courseSettingsBody?.settings?.followUpInvite
+        ? {
+            enabled:
+              courseSettingsBody.settings.followUpInvite.enabled ?? false,
+            courseId: courseSettingsBody.settings.followUpInvite.courseId,
+            courseVersionId:
+              courseSettingsBody.settings.followUpInvite.courseVersionId,
+            cohortId: courseSettingsBody.settings.followUpInvite.cohortId,
+            role: courseSettingsBody.settings.followUpInvite.role,
+          }
+        : {enabled: false, courseId: undefined, courseVersionId: undefined},
     };
   }
 }

--- a/backend/src/modules/setting/classes/validators/CourseSettingValidators.ts
+++ b/backend/src/modules/setting/classes/validators/CourseSettingValidators.ts
@@ -28,6 +28,7 @@ import {
   ISettings,
   IUserSetting,
   ITimeSlot,
+  EnrollmentRole,
 } from '#shared/interfaces/models.js';
 import {JSONSchema} from 'class-validator-jsonschema';
 import {ProctoringComponent} from '#root/shared/database/interfaces/ISettingRepository.js';
@@ -132,6 +133,38 @@ export class AuditingDto {
   timestamp: string;
 }
 
+export class FollowUpInviteSchema {
+  @IsBoolean()
+  @JSONSchema({
+    description:
+      'Whether completing this course auto-creates an invite to the follow-up course',
+  })
+  enabled: boolean;
+
+  @IsOptional()
+  @IsMongoId()
+  @IsString()
+  @JSONSchema({description: 'Follow-up course ID'})
+  courseId?: ID;
+
+  @IsOptional()
+  @IsMongoId()
+  @IsString()
+  @JSONSchema({description: 'Follow-up course version ID'})
+  courseVersionId?: ID;
+
+  @IsOptional()
+  @IsMongoId()
+  @IsString()
+  @JSONSchema({description: 'Optional cohort within the follow-up course'})
+  cohortId?: ID;
+
+  @IsOptional()
+  @IsString()
+  @JSONSchema({description: 'Role to enroll the student as (defaults to STUDENT)'})
+  role?: EnrollmentRole;
+}
+
 export class SettingsDto {
   @ValidateNested()
   @Type(() => ProctoringSettingsDto)
@@ -217,6 +250,16 @@ export class SettingsDto {
     type: 'object',
   })
   timeslots?: TimeSlotSchema;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => FollowUpInviteSchema)
+  @JSONSchema({
+    description:
+      'Follow-up invite: course the student is invited to on completion',
+    type: 'object',
+  })
+  followUpInvite?: FollowUpInviteSchema;
 
   @IsOptional()
   @ValidateNested({each: true})
@@ -472,6 +515,57 @@ export class RemoveCourseProctoringBody {
   @IsNotEmpty()
   @IsEnum(ProctoringComponent)
   detectorName: ProctoringComponent;
+}
+
+// Body for configuring the follow-up invite on a course version. When a
+// student completes this course version, an exclusive invite to the configured
+// follow-up course is created automatically.
+export class UpdateFollowUpInviteBody {
+  @IsDefined()
+  @IsBoolean()
+  @JSONSchema({
+    description:
+      'Whether completing this course should auto-create an invite to the follow-up course',
+  })
+  enabled: boolean;
+
+  @IsOptional()
+  @IsMongoId()
+  @IsString()
+  @JSONSchema({
+    title: 'Follow-up Course ID',
+    description: 'ID of the course to invite the student to on completion',
+    example: '60d5ec49b3f1c8e4a8f8b8c3',
+  })
+  courseId?: string;
+
+  @IsOptional()
+  @IsMongoId()
+  @IsString()
+  @JSONSchema({
+    title: 'Follow-up Course Version ID',
+    description: 'ID of the follow-up course version',
+    example: '60d5ec49b3f1c8e4a8f8b8c1',
+  })
+  courseVersionId?: string;
+
+  @IsOptional()
+  @IsMongoId()
+  @IsString()
+  @JSONSchema({
+    title: 'Follow-up Cohort ID',
+    description: 'Optional cohort within the follow-up course',
+    example: '60d5ec49b3f1c8e4a8f8b8c2',
+  })
+  cohortId?: string;
+
+  @IsOptional()
+  @IsString()
+  @JSONSchema({
+    description: 'Role to enroll the student as (defaults to STUDENT)',
+    example: 'STUDENT',
+  })
+  role?: string;
 }
 
 // This class represents the validation schema for creating user settings.

--- a/backend/src/modules/setting/controllers/CourseSettingController.ts
+++ b/backend/src/modules/setting/controllers/CourseSettingController.ts
@@ -23,6 +23,7 @@ import {
   ReadCourseSettingParams,
   SettingNotFoundErrorResponse,
   UpdateCourseSettingResponse,
+  UpdateFollowUpInviteBody,
 } from '../classes/index.js';
 import {BadRequestErrorResponse, IUser} from '#root/shared/index.js';
 import {AuditTrailsHandler} from '#root/shared/middleware/auditTrails.js';
@@ -171,6 +172,43 @@ export class CourseSettingController {
         status: OutComeStatus.SUCCESS,
       },
     });
+
+    return {success: result};
+  }
+
+  @Authorized()
+  @Put('/:courseId/:versionId/follow-up-invite')
+  @HttpCode(200)
+  @ResponseSchema(UpdateCourseSettingResponse, {
+    description: 'Follow-up invite settings updated successfully',
+  })
+  @ResponseSchema(BadRequestErrorResponse, {
+    description: 'Bad Request Error',
+    statusCode: 400,
+  })
+  @ResponseSchema(SettingNotFoundErrorResponse, {
+    description: 'Setting Not Found Error',
+    statusCode: 404,
+  })
+  async updateFollowUpInvite(
+    @Params() params: ReadCourseSettingParams,
+    @Body() body: UpdateFollowUpInviteBody,
+  ): Promise<{success: boolean}> {
+    // Configures which follow-up course a student is invited to when they
+    // complete this (source) course version.
+    const {courseId, versionId} = params;
+
+    const result = await this.courseSettingService.updateFollowUpInvite(
+      courseId,
+      versionId,
+      {
+        enabled: body.enabled,
+        courseId: body.courseId,
+        courseVersionId: body.courseVersionId,
+        cohortId: body.cohortId,
+        role: body.role,
+      },
+    );
 
     return {success: result};
   }

--- a/backend/src/modules/setting/services/CourseSettingService.ts
+++ b/backend/src/modules/setting/services/CourseSettingService.ts
@@ -20,6 +20,7 @@ import {
   ISettingRepository,
   ICourseRepository,
 } from '#shared/index.js';
+import {ISettings} from '#shared/interfaces/models.js';
 import {getISTFormattedTimestamp} from '#root/utils/toISOFormat.js';
 import {ClientSession, ObjectId} from 'mongodb';
 
@@ -340,6 +341,124 @@ class CourseSettingService extends BaseService {
    * @param courseVersionId - The ID of the course version
    * @returns False if linear progression field is false, true otherwise
    */
+  /**
+   * Configures the follow-up invite for a course version. When a student
+   * completes this (source) course version, an exclusive invite to the
+   * configured follow-up course is created automatically.
+   * @param courseId - The source course ID
+   * @param courseVersionId - The source course version ID
+   * @param followUpInvite - The follow-up invite configuration
+   * @returns True if the update was acknowledged
+   * @throws NotFoundError if the target course/version doesn't exist
+   * @throws ForbiddenError if the target course version is archived
+   */
+  async updateFollowUpInvite(
+    courseId: string,
+    courseVersionId: string,
+    followUpInvite: {
+      enabled: boolean;
+      courseId?: string;
+      courseVersionId?: string;
+      cohortId?: string;
+      role?: string;
+    },
+  ): Promise<boolean> {
+    // Ensure a fully-formed settings document exists for the source version
+    // (runs in its own transaction) before we patch the follow-up field.
+    await this.readCourseSettings(courseId, courseVersionId);
+
+    return this._withTransaction(async session => {
+      const sourceVersionStatus =
+        await this.courseRepo.getCourseVersionStatus(courseVersionId);
+      if (sourceVersionStatus === 'archived') {
+        throw new ForbiddenError(
+          "This course version is inactive, you can't update settings",
+        );
+      }
+
+      // Validate the target (follow-up) course/version when enabling.
+      if (followUpInvite.enabled) {
+        if (!followUpInvite.courseId || !followUpInvite.courseVersionId) {
+          throw new BadRequestError(
+            'Follow-up course and version are required when enabling the follow-up invite.',
+          );
+        }
+
+        const targetCourse = await this.courseRepo.read(
+          followUpInvite.courseId,
+          session,
+        );
+        if (!targetCourse) {
+          throw new NotFoundError(
+            `Follow-up course with ID ${followUpInvite.courseId} not found.`,
+          );
+        }
+
+        const targetVersion = await this.courseRepo.readVersion(
+          followUpInvite.courseVersionId,
+          session,
+        );
+        if (!targetVersion) {
+          throw new NotFoundError(
+            `Follow-up course version with ID ${followUpInvite.courseVersionId} not found.`,
+          );
+        }
+
+        const targetVersionStatus =
+          await this.courseRepo.getCourseVersionStatus(
+            followUpInvite.courseVersionId,
+          );
+        if (targetVersionStatus === 'archived') {
+          throw new ForbiddenError(
+            "Can't set an archived course version as the follow-up course.",
+          );
+        }
+
+        // If the follow-up version uses cohorts, a cohort is required so
+        // students can be enrolled into one. Surface this at configuration
+        // time (prompt the instructor) rather than failing silently on
+        // completion. Mirrors InviteService.inviteUserToCourse.
+        const targetCohorts = targetVersion.cohorts ?? [];
+        if (targetCohorts.length > 0) {
+          if (!followUpInvite.cohortId) {
+            throw new BadRequestError(
+              'The follow-up course version has cohorts. Please select a cohort for students to be enrolled into.',
+            );
+          }
+          const isValidCohort = targetCohorts.some(
+            c => c.toString() === followUpInvite.cohortId!.toString(),
+          );
+          if (!isValidCohort) {
+            throw new BadRequestError(
+              'Invalid cohort. The selected cohort does not exist in the follow-up course version.',
+            );
+          }
+        }
+      }
+
+      const result = await this.settingsRepo.updateFollowUpInvite(
+        courseId,
+        courseVersionId,
+        {
+          enabled: followUpInvite.enabled,
+          courseId: followUpInvite.courseId,
+          courseVersionId: followUpInvite.courseVersionId,
+          cohortId: followUpInvite.cohortId,
+          role: followUpInvite.role as ISettings['followUpInvite']['role'],
+        },
+        session,
+      );
+
+      if (!result) {
+        throw new InternalServerError(
+          'Failed to update follow-up invite settings. Please try again later.',
+        );
+      }
+
+      return result.acknowledged || false;
+    });
+  }
+
   async isLinearProgressionEnabled(
     courseId: string,
     courseVersionId: string,

--- a/backend/src/modules/setting/tests/CourseSettingController.test.ts
+++ b/backend/src/modules/setting/tests/CourseSettingController.test.ts
@@ -1,0 +1,239 @@
+import 'reflect-metadata';
+import Express from 'express';
+import {
+  RoutingControllersOptions,
+  useContainer,
+  useExpressServer,
+} from 'routing-controllers';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import { ObjectId } from 'mongodb';
+import { Container } from 'inversify';
+import { InversifyAdapter } from '#root/inversify-adapter.js';
+import { sharedContainerModule } from '#root/container.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import type { ICourseRepository, ISettingRepository } from '#root/shared/index.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {
+  settingContainerModule,
+  settingModuleControllers,
+} from '../index.js';
+import { usersContainerModule } from '#root/modules/users/container.js';
+import { quizzesContainerModule } from '#root/modules/quizzes/container.js';
+import { projectsContainerModule } from '#root/modules/projects/container.js';
+import { notificationsContainerModule } from '#root/modules/notifications/container.js';
+import { hpSystemContainerModule } from '#root/modules/hpSystem/container.js';
+import { anomaliesContainerModule } from '#root/modules/anomalies/container.js';
+import { courseRegistrationContainerModule } from '#root/modules/courseRegistration/container.js';
+import { reportsContainerModule } from '#root/modules/reports/container.js';
+import { ejectionPolicyContainerModule } from '#root/modules/ejectionPolicy/container.js';
+import { emotionsContainerModule } from '#root/modules/emotions/container.js';
+import { genAIContainerModule } from '#root/modules/genAI/container.js';
+import { studentQuestionsContainerModule } from '#root/modules/studentQuestions/container.js';
+import { announcementsContainerModule } from '#root/modules/announcements/container.js';
+import { auditTrailsContainerModule } from '#root/modules/auditTrails/container.js';
+import { authContainerModule } from '#root/modules/auth/container.js';
+
+/**
+ * Integration tests for the follow-up invite settings endpoint
+ * (PUT /setting/course-setting/:courseId/:versionId/follow-up-invite).
+ *
+ * Courses/versions/cohorts are seeded directly through the repository instead
+ * of the HTTP course-creation endpoints, since those require Firebase auth
+ * (the endpoint under test does not). This keeps the test self-contained.
+ */
+describe('CourseSettingController — follow-up invite', () => {
+  let app: any;
+  let courseRepo: ICourseRepository;
+  let settingRepo: ISettingRepository;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    const container = new Container();
+    await container.load(
+      settingContainerModule,
+      usersContainerModule,
+      quizzesContainerModule,
+      projectsContainerModule,
+      notificationsContainerModule,
+      hpSystemContainerModule,
+      anomaliesContainerModule,
+      courseRegistrationContainerModule,
+      reportsContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+      authContainerModule,
+      sharedContainerModule,
+    );
+    const inversifyAdapter = new InversifyAdapter(container);
+    useContainer(inversifyAdapter);
+
+    // Establish the DB connection the repositories rely on.
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
+
+    courseRepo = container.get<ICourseRepository>(GLOBAL_TYPES.CourseRepo);
+    settingRepo = container.get<ISettingRepository>(GLOBAL_TYPES.SettingRepo);
+
+    app = Express();
+    const options: RoutingControllersOptions = {
+      controllers: settingModuleControllers as Function[],
+      authorizationChecker: async () => true,
+      defaultErrorHandler: true,
+      validation: true,
+    };
+    useExpressServer(app, options);
+  }, 900000);
+
+  // Seed a course + version (optionally with cohorts) straight into the DB.
+  async function seedCourseVersion(
+    cohortNames: string[] = [],
+  ): Promise<{ courseId: string; versionId: string; cohortIds: string[] }> {
+    const now = new Date();
+    const course = await courseRepo.create({
+      name: `course-${new ObjectId().toString()}`,
+      description: 'seeded course',
+      versions: [],
+      instructors: [],
+      createdAt: now,
+      updatedAt: now,
+    } as any);
+    const courseId = (course!._id as any).toString();
+
+    const version = await courseRepo.createVersion({
+      courseId: course!._id,
+      version: 'v1',
+      description: 'seeded version',
+      modules: [],
+      createdAt: now,
+      updatedAt: now,
+    } as any);
+    const versionId = (version!._id as any).toString();
+
+    let cohortIds: string[] = [];
+    if (cohortNames.length) {
+      const ids = await courseRepo.createCohorts(courseId, versionId, cohortNames, 0);
+      await courseRepo.addCohortsToVersion(versionId, ids);
+      cohortIds = ids.map(id => id.toString());
+    }
+
+    return { courseId, versionId, cohortIds };
+  }
+
+  let sourceCourseId: string;
+  let sourceVersionId: string;
+  let targetCourseId: string;
+  let targetVersionId: string;
+
+  beforeEach(async () => {
+    const source = await seedCourseVersion();
+    sourceCourseId = source.courseId;
+    sourceVersionId = source.versionId;
+
+    const target = await seedCourseVersion();
+    targetCourseId = target.courseId;
+    targetVersionId = target.versionId;
+  });
+
+  const followUpUrl = (courseId: string, versionId: string) =>
+    `/setting/course-setting/${courseId}/${versionId}/follow-up-invite`;
+
+  it('enables a follow-up invite to a valid target course (no cohorts) and persists it', async () => {
+    const res = await request(app)
+      .put(followUpUrl(sourceCourseId, sourceVersionId))
+      .send({
+        enabled: true,
+        courseId: targetCourseId,
+        courseVersionId: targetVersionId,
+      })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+
+    // Verify persistence via the repository (the HTTP response serializes
+    // nested ObjectIds opaquely, so assert against the stored document).
+    const stored = await settingRepo.readCourseSettings(sourceCourseId, sourceVersionId);
+    const followUp = (stored as any)?.settings?.followUpInvite;
+    expect(followUp?.enabled).toBe(true);
+    expect(followUp?.courseId?.toString()).toBe(targetCourseId);
+    expect(followUp?.courseVersionId?.toString()).toBe(targetVersionId);
+  });
+
+  it('rejects enabling without a target course/version (400)', async () => {
+    await request(app)
+      .put(followUpUrl(sourceCourseId, sourceVersionId))
+      .send({ enabled: true })
+      .expect(400);
+  });
+
+  it('returns 404 when the target course does not exist', async () => {
+    await request(app)
+      .put(followUpUrl(sourceCourseId, sourceVersionId))
+      .send({
+        enabled: true,
+        courseId: new ObjectId().toString(),
+        courseVersionId: new ObjectId().toString(),
+      })
+      .expect(404);
+  });
+
+  it('rejects enabling when the target version has cohorts but none is selected (400)', async () => {
+    const target = await seedCourseVersion(['Cohort A', 'Cohort B']);
+
+    await request(app)
+      .put(followUpUrl(sourceCourseId, sourceVersionId))
+      .send({
+        enabled: true,
+        courseId: target.courseId,
+        courseVersionId: target.versionId,
+        // cohortId intentionally omitted
+      })
+      .expect(400);
+  });
+
+  it('enables when the target version has cohorts and a valid cohort is selected (200)', async () => {
+    const target = await seedCourseVersion(['Cohort A', 'Cohort B']);
+
+    const res = await request(app)
+      .put(followUpUrl(sourceCourseId, sourceVersionId))
+      .send({
+        enabled: true,
+        courseId: target.courseId,
+        courseVersionId: target.versionId,
+        cohortId: target.cohortIds[0],
+      })
+      .expect(200);
+    expect(res.body.success).toBe(true);
+
+    const stored = await settingRepo.readCourseSettings(sourceCourseId, sourceVersionId);
+    const followUp = (stored as any)?.settings?.followUpInvite;
+    expect(followUp?.enabled).toBe(true);
+    expect(followUp?.cohortId?.toString()).toBe(target.cohortIds[0]);
+  });
+
+  it('disables the follow-up invite without requiring a target (200)', async () => {
+    await request(app)
+      .put(followUpUrl(sourceCourseId, sourceVersionId))
+      .send({
+        enabled: true,
+        courseId: targetCourseId,
+        courseVersionId: targetVersionId,
+      })
+      .expect(200);
+
+    const res = await request(app)
+      .put(followUpUrl(sourceCourseId, sourceVersionId))
+      .send({ enabled: false })
+      .expect(200);
+    expect(res.body.success).toBe(true);
+
+    const getRes = await request(app)
+      .get(`/setting/course-setting/${sourceCourseId}/${sourceVersionId}`)
+      .expect(200);
+    expect(getRes.body.settings?.followUpInvite?.enabled).toBe(false);
+  });
+});

--- a/backend/src/modules/setting/tests/CourseSettingService.test.ts
+++ b/backend/src/modules/setting/tests/CourseSettingService.test.ts
@@ -1,0 +1,212 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BadRequestError, ForbiddenError, NotFoundError } from 'routing-controllers';
+import { CourseSettingService } from '../services/CourseSettingService.js';
+
+/**
+ * Unit tests for CourseSettingService.updateFollowUpInvite — the per-course
+ * "follow-up invite" configuration that, on course completion, auto-invites a
+ * student to a follow-up course. These tests focus on the validation branches,
+ * especially the cohort-required path (the case where the follow-up course
+ * version uses cohorts and a cohort must be selected at configuration time).
+ *
+ * The DB is bypassed by stubbing BaseService._withTransaction so no MongoDB
+ * connection is required.
+ */
+
+const SOURCE_COURSE = 'c1';
+const SOURCE_VERSION = 'v1';
+const TARGET_COURSE = 'c2';
+const TARGET_VERSION = 'v2';
+
+function makeService(opts: {
+  targetCohorts?: string[];
+  targetCourseExists?: boolean;
+  targetVersionExists?: boolean;
+  targetVersionStatus?: 'active' | 'archived';
+  sourceVersionStatus?: 'active' | 'archived';
+} = {}) {
+  const {
+    targetCohorts = [],
+    targetCourseExists = true,
+    targetVersionExists = true,
+    targetVersionStatus = 'active',
+    sourceVersionStatus = 'active',
+  } = opts;
+
+  const settingsRepo = {
+    // Existing settings doc so readCourseSettings() doesn't try to create one.
+    readCourseSettings: vi.fn().mockResolvedValue({
+      courseId: SOURCE_COURSE,
+      courseVersionId: SOURCE_VERSION,
+      settings: { proctors: { detectors: [] } },
+    }),
+    updateFollowUpInvite: vi.fn().mockResolvedValue({ acknowledged: true }),
+    createCourseSettings: vi.fn(),
+  };
+
+  const courseRepo = {
+    read: vi.fn().mockResolvedValue(
+      targetCourseExists ? { _id: TARGET_COURSE, name: 'Target Course' } : null,
+    ),
+    readVersion: vi.fn().mockResolvedValue(
+      targetVersionExists
+        ? { _id: TARGET_VERSION, cohorts: targetCohorts }
+        : null,
+    ),
+    getCourseVersionStatus: vi.fn().mockImplementation((versionId: string) =>
+      Promise.resolve(
+        versionId === SOURCE_VERSION ? sourceVersionStatus : targetVersionStatus,
+      ),
+    ),
+  };
+
+  const db = {} as any;
+  const svc = new CourseSettingService(
+    settingsRepo as any,
+    courseRepo as any,
+    db,
+  );
+
+  // Run transaction callbacks immediately with a dummy session — no real DB.
+  vi.spyOn(svc as any, '_withTransaction').mockImplementation((fn: any) =>
+    fn({}),
+  );
+
+  return { svc, settingsRepo, courseRepo };
+}
+
+describe('CourseSettingService.updateFollowUpInvite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists the config when the target course has no cohorts', async () => {
+    const { svc, settingsRepo } = makeService({ targetCohorts: [] });
+
+    const result = await svc.updateFollowUpInvite(SOURCE_COURSE, SOURCE_VERSION, {
+      enabled: true,
+      courseId: TARGET_COURSE,
+      courseVersionId: TARGET_VERSION,
+    });
+
+    expect(result).toBe(true);
+    expect(settingsRepo.updateFollowUpInvite).toHaveBeenCalledOnce();
+    expect(settingsRepo.updateFollowUpInvite.mock.calls[0][2]).toMatchObject({
+      enabled: true,
+      courseId: TARGET_COURSE,
+      courseVersionId: TARGET_VERSION,
+    });
+  });
+
+  it('rejects enabling when the target version has cohorts but no cohort is selected', async () => {
+    const { svc, settingsRepo } = makeService({ targetCohorts: ['cohortA', 'cohortB'] });
+
+    await expect(
+      svc.updateFollowUpInvite(SOURCE_COURSE, SOURCE_VERSION, {
+        enabled: true,
+        courseId: TARGET_COURSE,
+        courseVersionId: TARGET_VERSION,
+        // cohortId intentionally omitted
+      }),
+    ).rejects.toThrowError(/cohort/i);
+
+    expect(settingsRepo.updateFollowUpInvite).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid cohort that does not belong to the target version', async () => {
+    const { svc, settingsRepo } = makeService({ targetCohorts: ['cohortA', 'cohortB'] });
+
+    await expect(
+      svc.updateFollowUpInvite(SOURCE_COURSE, SOURCE_VERSION, {
+        enabled: true,
+        courseId: TARGET_COURSE,
+        courseVersionId: TARGET_VERSION,
+        cohortId: 'not-a-real-cohort',
+      }),
+    ).rejects.toThrowError(BadRequestError);
+
+    expect(settingsRepo.updateFollowUpInvite).not.toHaveBeenCalled();
+  });
+
+  it('persists the config when a valid cohort is selected', async () => {
+    const { svc, settingsRepo } = makeService({ targetCohorts: ['cohortA', 'cohortB'] });
+
+    const result = await svc.updateFollowUpInvite(SOURCE_COURSE, SOURCE_VERSION, {
+      enabled: true,
+      courseId: TARGET_COURSE,
+      courseVersionId: TARGET_VERSION,
+      cohortId: 'cohortB',
+    });
+
+    expect(result).toBe(true);
+    expect(settingsRepo.updateFollowUpInvite.mock.calls[0][2]).toMatchObject({
+      enabled: true,
+      cohortId: 'cohortB',
+    });
+  });
+
+  it('requires a target course and version when enabling', async () => {
+    const { svc, settingsRepo } = makeService();
+
+    await expect(
+      svc.updateFollowUpInvite(SOURCE_COURSE, SOURCE_VERSION, {
+        enabled: true,
+        // no courseId / courseVersionId
+      }),
+    ).rejects.toThrowError(BadRequestError);
+
+    expect(settingsRepo.updateFollowUpInvite).not.toHaveBeenCalled();
+  });
+
+  it('throws when the target course version does not exist', async () => {
+    const { svc } = makeService({ targetVersionExists: false });
+
+    await expect(
+      svc.updateFollowUpInvite(SOURCE_COURSE, SOURCE_VERSION, {
+        enabled: true,
+        courseId: TARGET_COURSE,
+        courseVersionId: TARGET_VERSION,
+      }),
+    ).rejects.toThrowError(NotFoundError);
+  });
+
+  it('refuses an archived target course version', async () => {
+    const { svc } = makeService({ targetVersionStatus: 'archived' });
+
+    await expect(
+      svc.updateFollowUpInvite(SOURCE_COURSE, SOURCE_VERSION, {
+        enabled: true,
+        courseId: TARGET_COURSE,
+        courseVersionId: TARGET_VERSION,
+      }),
+    ).rejects.toThrowError(ForbiddenError);
+  });
+
+  it('disables without validating a target (no cohort needed)', async () => {
+    const { svc, settingsRepo, courseRepo } = makeService();
+
+    const result = await svc.updateFollowUpInvite(SOURCE_COURSE, SOURCE_VERSION, {
+      enabled: false,
+    });
+
+    expect(result).toBe(true);
+    // Target validation is skipped entirely when disabling.
+    expect(courseRepo.read).not.toHaveBeenCalled();
+    expect(settingsRepo.updateFollowUpInvite.mock.calls[0][2]).toMatchObject({
+      enabled: false,
+    });
+  });
+
+  it('blocks updates when the source course version is archived', async () => {
+    const { svc } = makeService({ sourceVersionStatus: 'archived' });
+
+    await expect(
+      svc.updateFollowUpInvite(SOURCE_COURSE, SOURCE_VERSION, {
+        enabled: true,
+        courseId: TARGET_COURSE,
+        courseVersionId: TARGET_VERSION,
+      }),
+    ).rejects.toThrowError(ForbiddenError);
+  });
+});

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -13,6 +13,7 @@ import {
   IBlogDetails,
   ICurrentProgressPath,
   IEnrollment,
+  EnrollmentRole,
 } from '#root/shared/interfaces/models.js';
 import { GLOBAL_TYPES } from '#root/types.js';
 import { ProgressRepository } from '#shared/database/providers/mongo/repositories/ProgressRepository.js';
@@ -47,6 +48,8 @@ import { GetCurrentProgressPathResponse } from '../classes/dtos/GetCurrentProgre
 import { SETTING_TYPES } from '#root/modules/setting/types.js';
 import { CourseSettingService } from '#root/modules/setting/index.js';
 import { getContainer } from '#root/bootstrap/loadModules.js';
+import { NOTIFICATIONS_TYPES } from '#root/modules/notifications/types.js';
+import type { InviteService } from '#root/modules/notifications/services/InviteService.js';
 
 const GURU_SETU_COURSE_ID = '6981df886e100cfe04f9c4ad';
 const GURU_SETU_VERSION_ID = '6981df886e100cfe04f9c4ae';
@@ -2292,6 +2295,12 @@ class ProgressService extends BaseService {
       );
     }
 
+    // Whether the course was already completed before this call, so we only
+    // fire the follow-up invite on the false->true transition (not on replays
+    // of the last item).
+    const wasAlreadyCompleted = progress.completed === true;
+    let justCompleted = false;
+
     await this._withTransaction(async session => {
       let shouldCountCurrentItemAsCompleted = false;
       let stoppedWatchTime: any = null;
@@ -2573,7 +2582,71 @@ class ProgressService extends BaseService {
         cohortId,
         session,
       );
+
+      justCompleted = newProgress.completed === true && !wasAlreadyCompleted;
     });
+
+    // Best-effort: when the student just completed this course, create an
+    // exclusive invite to the configured follow-up course. Runs outside the
+    // completion transaction and must never break completion.
+    if (justCompleted) {
+      await this.triggerFollowUpInvite(userId, courseId, courseVersionId);
+    }
+  }
+
+  /**
+   * If this course version has a follow-up invite configured, create an
+   * exclusive invite to the target course for the completing student. The
+   * underlying invite creation dedupes pending invites and skips already-
+   * enrolled users, so this is safe to call on every completion.
+   */
+  private async triggerFollowUpInvite(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+  ): Promise<void> {
+    try {
+      const courseSettings = await this.getCourseSettingService().readCourseSettings(
+        courseId,
+        courseVersionId,
+      );
+
+      const followUp = courseSettings?.settings?.followUpInvite;
+      if (
+        !followUp ||
+        !followUp.enabled ||
+        !followUp.courseId ||
+        !followUp.courseVersionId
+      ) {
+        return;
+      }
+
+      const user = await this.userRepo.findById(userId);
+      if (!user?.email) {
+        return;
+      }
+
+      const inviteService = getContainer().get<InviteService>(
+        NOTIFICATIONS_TYPES.InviteService,
+      );
+
+      // The created invite is automatically surfaced to the student as an
+      // actionable notification card in their notification bell (InviteDropdown
+      // lists pending invites), in addition to the completion-screen card and
+      // the dashboard banner — so no separate notification record is needed.
+      await inviteService.inviteUserToCourse(
+        [{email: user.email, role: (followUp.role as EnrollmentRole) ?? 'STUDENT'}],
+        followUp.courseId.toString(),
+        followUp.courseVersionId.toString(),
+        followUp.cohortId?.toString(),
+      );
+    } catch (error) {
+      // Never let follow-up invite failures break course completion.
+      console.error(
+        `Failed to create follow-up invite for user ${userId} after completing course ${courseId}/${courseVersionId}:`,
+        error,
+      );
+    }
   }
 
   private validateProgressPosition(

--- a/backend/src/shared/database/interfaces/ISettingRepository.ts
+++ b/backend/src/shared/database/interfaces/ISettingRepository.ts
@@ -123,6 +123,23 @@ export interface ISettingRepository {
   ): Promise<UpdateResult | null>;
 
   /**
+   * Sets the follow-up invite configuration for a course version. When a student
+   * completes this course version, an exclusive invite to the configured
+   * follow-up course is created automatically.
+   * @param courseId - The ID of the (source) course
+   * @param courseVersionId - The ID of the (source) course version
+   * @param followUpInvite - The follow-up invite configuration
+   * @param session - Optional MongoDB session for transactions
+   * @returns Update result or null if update failed
+   */
+  updateFollowUpInvite(
+    courseId: string,
+    courseVersionId: string,
+    followUpInvite: ISettings['followUpInvite'],
+    session?: ClientSession,
+  ): Promise<UpdateResult | null>;
+
+  /**
    * Creates new user settings.
    * @param userSettings - The user settings to create
    * @param session - Optional MongoDB session for transactions

--- a/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
@@ -461,6 +461,45 @@ export class SettingRepository implements ISettingRepository {
     return result;
   }
 
+  async updateFollowUpInvite(
+    courseId: string,
+    courseVersionId: string,
+    followUpInvite: ISettings['followUpInvite'],
+    session?: ClientSession,
+  ): Promise<UpdateResult | null> {
+    await this.init();
+
+    const normalized = followUpInvite
+      ? {
+          enabled: !!followUpInvite.enabled,
+          courseId: followUpInvite.courseId
+            ? new ObjectId(followUpInvite.courseId.toString())
+            : undefined,
+          courseVersionId: followUpInvite.courseVersionId
+            ? new ObjectId(followUpInvite.courseVersionId.toString())
+            : undefined,
+          cohortId: followUpInvite.cohortId
+            ? new ObjectId(followUpInvite.cohortId.toString())
+            : undefined,
+          role: followUpInvite.role,
+        }
+      : {enabled: false};
+
+    const result = await this.courseSettingsCollection.updateOne(
+      {
+        courseId: new ObjectId(courseId),
+        courseVersionId: new ObjectId(courseVersionId),
+      },
+      {
+        $set: {
+          'settings.followUpInvite': normalized,
+        },
+      },
+      {upsert: true, session},
+    );
+    return result;
+  }
+
   async updateRegistrationSchemas(
     courseId: string,
     versionId: string,

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -418,6 +418,10 @@ export interface IEnrollment {
   cohortId?: ID;
   policyAcknowledgedAt?: Date;
   policyReacknowledgementRequired?: boolean;
+  ethicsConsentSignedAt?: Date; // doubles as the "Date" on the consent form
+  ethicsConsentSignature?: string; // the participant name the student typed
+  ethicsConsentVersion?: string; // lets us force re-consent if the text changes
+  ethicsAdditionalImageConsent?: boolean; // optional "use for future research" checkbox
   isEjected?: boolean;
   ejectionHistory?: Array<{
     ejectedAt: Date;
@@ -602,6 +606,15 @@ export interface ISettings {
   timeslots?: {
     isActive: boolean;
     slots: ITimeSlot[];
+  };
+  // When a student completes this course version, automatically create an
+  // exclusive invite to the configured follow-up course.
+  followUpInvite?: {
+    enabled: boolean;
+    courseId?: string | ObjectId; // target (follow-up) course
+    courseVersionId?: string | ObjectId; // target course version
+    cohortId?: string | ObjectId; // optional cohort in the target course
+    role?: EnrollmentRole; // defaults to 'STUDENT'
   };
   // jsonSchema?: any;
   // uiSchema?: any;

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -14,7 +14,7 @@ import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { ThemeToggle } from "@/components/theme-toggle";
-import { useCourseVersionById, useUserProgress, useItemsBySectionId, useItemById, useProctoringSettings, useGetProcotoringSettings, useSubmitFlag, enqueueNavigation, useSkipOptionalItem, useRecalculateStudentProgress } from "@/hooks/hooks";
+import { useCourseVersionById, useUserProgress, useItemsBySectionId, useItemById, useProctoringSettings, useGetProcotoringSettings, useSubmitFlag, enqueueNavigation, useSkipOptionalItem, useRecalculateStudentProgress, useInvites, useAcceptInvite } from "@/hooks/hooks";
 import { useAuthStore } from "@/store/auth-store";
 import { useCourseStore } from "@/store/course-store";
 import { Link, Navigate, useRouter } from "@tanstack/react-router";
@@ -110,6 +110,10 @@ export default function CoursePage() {
   const [isFlagSubmitted, setIsFlagSubmitted] = useState(false);
   const [isSkippingItem, setIsSkippingItem] = useState(false);
   const [courseJustCompleted, setCourseJustCompleted] = useState(false);
+  // Follow-up invite unlocked by completing this course (shown as a claim card).
+  const [followUpInvite, setFollowUpInvite] = useState<any | null>(null);
+  const { getInvites: getPendingInvites } = useInvites();
+  const { acceptInvite: acceptFollowUpInvite } = useAcceptInvite();
   const { mutateAsync: submitFlagAsyncMutate, isPending } = useSubmitFlag();
   const { mutateAsync: skipItemAsync, isPending: isSkipping } = useSkipOptionalItem();
   const { mutateAsync: recalculateStudentProgressAsync } = useRecalculateStudentProgress();
@@ -1263,7 +1267,26 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
               requestAnimationFrame(frame);
             };
             frame();
-            setTimeout(() => router.navigate({ to: "/student" }), 3500);
+
+            // Check for an exclusive follow-up invite unlocked by completing
+            // this course. If one exists, show a claim card instead of the
+            // usual auto-redirect so the student can act on it.
+            try {
+              const inviteRes = await getPendingInvites();
+              const invites = inviteRes?.invites ?? [];
+              const unlocked = invites.find(
+                (inv: any) =>
+                  inv?.inviteStatus === "PENDING" &&
+                  inv?.courseId?.toString() !== COURSE_ID?.toString(),
+              );
+              if (unlocked) {
+                setFollowUpInvite(unlocked);
+              } else {
+                setTimeout(() => router.navigate({ to: "/student" }), 3500);
+              }
+            } catch {
+              setTimeout(() => router.navigate({ to: "/student" }), 3500);
+            }
           }
 
           // Recalcualate and update the progress % and completed items count properly
@@ -1574,13 +1597,15 @@ const handleGoToNextItem = async () => {
 
   useEffect(() => {
   if (!courseJustCompleted) return;
+  // Don't auto-redirect when there's a follow-up invite to claim.
+  if (followUpInvite) return;
 
   const timer = setTimeout(() => {
     router.navigate({ to: "/student" });
   }, 3500);
 
   return () => clearTimeout(timer);
-}, [courseJustCompleted, router]);
+}, [courseJustCompleted, followUpInvite, router]);
 
   useEffect(() => {
     refetchVersion();
@@ -1680,6 +1705,58 @@ return false;
 
   return (
     <>
+      {/* Exclusive follow-up invite unlocked by completing this course */}
+      <Dialog
+        open={!!followUpInvite}
+        onOpenChange={(open) => {
+          if (!open) {
+            setFollowUpInvite(null);
+            router.navigate({ to: "/student" });
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-lg w-[calc(100%-2rem)] max-w-full text-center">
+          <DialogHeader>
+            <DialogTitle className="text-xl font-extrabold">
+              🎉 You've unlocked a new course!
+            </DialogTitle>
+          </DialogHeader>
+          <p className="text-base text-foreground mt-2 mb-6">
+            Congratulations on completing this course. You've earned an exclusive
+            spot in{" "}
+            <span className="font-semibold">
+              {followUpInvite?.course?.name ?? "the next course"}
+            </span>
+            . Claim it now to get started.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Button
+              className="font-semibold"
+              onClick={async () => {
+                const inviteId = followUpInvite?.inviteId?.toString();
+                if (!inviteId) return;
+                try {
+                  await acceptFollowUpInvite(inviteId, "ACCEPT");
+                  window.location.assign("/student");
+                } catch {
+                  /* keep the card open so they can retry */
+                }
+              }}
+            >
+              Claim my spot
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setFollowUpInvite(null);
+                router.navigate({ to: "/student" });
+              }}
+            >
+              Maybe later
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
       <Dialog open={showProctorDialog} onOpenChange={(open) => {
         if (!open) {
           router.navigate({ to: '/student' });

--- a/frontend/src/app/pages/student/dashboard.tsx
+++ b/frontend/src/app/pages/student/dashboard.tsx
@@ -15,6 +15,8 @@ import { cn } from "@/utils/utils";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CourseCard } from "@/components/course/CourseCard";
 import { CourseListCard } from "@/components/course/CourseListCard";
+import { FollowUpInvitesBanner } from "@/components/course/FollowUpInvitesBanner";
+import { NewAnnouncementsPopup } from "@/components/announcements/NewAnnouncementsPopup";
 import { BookOpen, TrendingUp, LayoutGrid, List } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -147,6 +149,8 @@ function DashboardContent() {
 
   return (
     <>
+      {/* Auto-popup any announcements the student hasn't seen yet */}
+      <NewAnnouncementsPopup />
       <div className="container mx-auto px-0 sm:px-6 lg:px-8 xl:px-0 py-6 flex flex-col lg:flex-row gap-6 transition-all duration-300">
         <main className="flex-1 w-full space-y-8">
           {/* Greeting and Stat Cards Section */}
@@ -171,6 +175,9 @@ function DashboardContent() {
               />
             </div>
           </div>
+
+          {/* Exclusive follow-up course invites unlocked by completing a course */}
+          <FollowUpInvitesBanner />
 
           <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6 w-full">
             <TabsList className="w-full md:w-fit flex h-auto p-1 bg-slate-100/80 dark:bg-slate-800/50 rounded-full border border-slate-200/50 dark:border-slate-700/50 overflow-x-auto scrollbar-hide">

--- a/frontend/src/components/EditProctoringModal.tsx
+++ b/frontend/src/components/EditProctoringModal.tsx
@@ -6,14 +6,22 @@ import {
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
-import { useCourseVersionById, useEditProctoringSettings, useGetProcotoringSettings } from "@/hooks/hooks"
-import { useEffect, useState } from "react"
+import { useCourseVersionById, useEditProctoringSettings, useGetProcotoringSettings, useUpdateFollowUpInvite, useUserEnrollments } from "@/hooks/hooks"
+import { bufferToHex } from "@/utils/helpers"
+import { useEffect, useMemo, useState } from "react"
 import { Label } from "./ui/label"
 import { Separator } from "./ui/separator"
 import { Switch } from "./ui/switch"
 import { toast } from "sonner"
 import { ChevronDown, Loader2 } from "lucide-react"
 import { Input } from "./ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select"
 
 enum ProctoringComponent {
   CAMERAMICRO = 'cameraMic',
@@ -24,6 +32,28 @@ enum ProctoringComponent {
   VIRTUALBACKGROUNDDETECTION = 'virtualBackgroundDetection',
   RIGHTCLICKDISABLED = 'rightClickDisabled',
   FACERECOGNITION = 'faceRecognition',
+}
+
+// Throw-safe id conversion: ObjectIds may serialize as a hex string or a
+// buffer-like object depending on the endpoint. Never throw (a throw here would
+// break the whole dropdown list).
+const normalizeId = (value: any): string => {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  try {
+    return bufferToHex(value);
+  } catch {
+    const s = value?.toString?.();
+    return s && s !== "[object Object]" ? s : "";
+  }
+};
+
+// Resolves a course version's faculty-entered name/number for display in the
+// dropdown. The enrollments payload only carries version IDs, so each option
+// fetches its own version (react-query caches, so this is cheap).
+function VersionLabel({ versionId }: { versionId: string }) {
+  const { data } = useCourseVersionById(versionId, true);
+  return <>{data?.version ?? `Version ${versionId.slice(-6)}`}</>;
 }
 
 const labelMap: Record<string, string> = {
@@ -54,6 +84,7 @@ export function ProctoringModal({
 }) {
   const { editSettings, loading, error } = useEditProctoringSettings()
   const { getSettings, settingLoading, settingError } = useGetProcotoringSettings();
+  const { updateFollowUpInvite, loading: followUpLoading } = useUpdateFollowUpInvite();
 
   const allComponents = Object.values(ProctoringComponent)
   const [detectors, setDetectors] = useState(
@@ -68,6 +99,52 @@ export function ProctoringModal({
   const [enableRandomize, setEnableRandomize] = useState<boolean>(false);
   const [crowdsourcedQuestionSubmissionEnabled, setCrowdsourcedQuestionSubmissionEnabled] = useState(false);
   const { data: courseVersion, isLoading: versionLoading } = useCourseVersionById(courseVersionId || "")
+
+  // Follow-up invite: when a student completes this course, auto-create an
+  // exclusive invite to the configured follow-up course.
+  const [followUpEnabled, setFollowUpEnabled] = useState(false);
+  const [followUpCourseId, setFollowUpCourseId] = useState("");
+  const [followUpVersionId, setFollowUpVersionId] = useState("");
+  const [followUpCohortId, setFollowUpCohortId] = useState<string>("");
+  const { data: followUpVersion, isLoading: followUpVersionLoading } =
+    useCourseVersionById(followUpVersionId || "", !!followUpVersionId);
+  const followUpCohorts = followUpVersion?.cohortDetails ?? [];
+  const followUpRequiresCohort = followUpEnabled && followUpCohorts.length > 0;
+
+  // Courses the instructor teaches — used to populate the follow-up dropdowns
+  // (so they never deal with raw IDs). The basic enrollments endpoint reliably
+  // lists the instructor's courses (same source as the dashboard) along with
+  // each course's active version IDs. Version *names* are resolved per-version
+  // via <VersionLabel> (see component) since the enrollments payload only
+  // carries version IDs.
+  const { data: basicEnrollments } = useUserEnrollments(
+    1,
+    100,
+    open,
+    "",
+    "INSTRUCTOR",
+    "active",
+  );
+
+  // De-duplicate the instructor's courses into { id, name, versionIds }.
+  const followUpCourseOptions = useMemo(() => {
+    const byId = new Map<string, { id: string; name: string; versionIds: string[] }>();
+    for (const e of basicEnrollments?.enrollments ?? []) {
+      const id = normalizeId(e.courseId);
+      if (!id || byId.has(id)) continue;
+      const versionIds = ((e.course as any)?.versions ?? [])
+        .map((v: any) => normalizeId(v))
+        .filter(Boolean);
+      byId.set(id, {
+        id,
+        name: (e.course as any)?.name ?? "Untitled course",
+        versionIds,
+      });
+    }
+    return Array.from(byId.values()).filter(c => c.id);
+  }, [basicEnrollments]);
+  const followUpVersionIds =
+    followUpCourseOptions.find(c => c.id === followUpCourseId)?.versionIds ?? [];
 
   useEffect(() => {
     const fetchSettings = async () => {
@@ -84,6 +161,11 @@ export function ProctoringModal({
           setCrowdsourcedQuestionSubmissionEnabled(
             result.settings?.crowdsourcedQuestionSubmissionEnabled ?? false,
           )
+          const followUp = result.settings?.followUpInvite;
+          setFollowUpEnabled(followUp?.enabled ?? false)
+          setFollowUpCourseId(followUp?.courseId ? followUp.courseId.toString() : "")
+          setFollowUpVersionId(followUp?.courseVersionId ? followUp.courseVersionId.toString() : "")
+          setFollowUpCohortId(followUp?.cohortId ? followUp.cohortId.toString() : "")
         }
       } catch (err) {
         console.error("Failed to fetch proctoring settings:", err)
@@ -104,15 +186,38 @@ export function ProctoringModal({
   }
 
   const handleSubmit = async () => {
+    // Validate the follow-up invite configuration up front so misconfiguration
+    // is surfaced to the instructor before anything is saved.
+    if (followUpEnabled) {
+      if (!followUpCourseId.trim() || !followUpVersionId.trim()) {
+        toast.error("Please select the follow-up course and version.")
+        return
+      }
+      if (followUpRequiresCohort && !followUpCohortId) {
+        toast.error("The follow-up course uses cohorts. Please select a cohort.")
+        return
+      }
+    }
+
     try {
       const result = await editSettings(courseId, courseVersionId, detectors, isNew, linearProgressionEnabled, seekForwardEnabled, isPublic, hpSystemEnabled, baseHp, enableRandomize, crowdsourcedQuestionSubmissionEnabled)
+
+      // Persist the follow-up invite configuration (separate endpoint).
+      await updateFollowUpInvite(courseId, courseVersionId, {
+        enabled: followUpEnabled,
+        courseId: followUpEnabled ? followUpCourseId.trim() : undefined,
+        courseVersionId: followUpEnabled ? followUpVersionId.trim() : undefined,
+        cohortId: followUpEnabled && followUpCohortId ? followUpCohortId : undefined,
+      })
+
       if (result != undefined) {
         onSuccess?.();
         onClose();
       }
       toast.success("Settings updated!")
-    } catch(error) {
-      toast.error("Failed to update settings!")
+    } catch(error: any) {
+      // Show the backend's actionable message when available (e.g. cohort prompt).
+      toast.error(error?.message || "Failed to update settings!")
     }
   }
 
@@ -293,6 +398,104 @@ export function ProctoringModal({
                       />
                     </div>
                   </div>
+
+                  {/* Follow-up course invite */}
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between space-x-3">
+                      <div className="space-y-1">
+                        <Label className="text-sm font-medium">Follow-up Course Invite</Label>
+                        <p className="text-xs text-muted-foreground">Send an exclusive invite to another course when a student completes this one.</p>
+                      </div>
+                      <Switch
+                        checked={followUpEnabled}
+                        onCheckedChange={() => setFollowUpEnabled(prev => !prev)}
+                      />
+                    </div>
+
+                    {followUpEnabled && (
+                      <div className="space-y-3 pl-2 border-l-2 border-border">
+                        <div className="space-y-1">
+                          <Label className="text-xs font-medium">Follow-up Course</Label>
+                          <Select
+                            value={followUpCourseId}
+                            onValueChange={(v) => {
+                              setFollowUpCourseId(v)
+                              // Reset version + cohort when the course changes.
+                              setFollowUpVersionId("")
+                              setFollowUpCohortId("")
+                            }}
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select a course" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {followUpCourseOptions.map((c) => (
+                                <SelectItem key={c.id} value={c.id}>
+                                  {c.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="space-y-1">
+                          <Label className="text-xs font-medium">Follow-up Version</Label>
+                          <Select
+                            value={followUpVersionId}
+                            onValueChange={(v) => {
+                              setFollowUpVersionId(v)
+                              // Reset cohort when the target version changes.
+                              setFollowUpCohortId("")
+                            }}
+                            disabled={!followUpCourseId}
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder={followUpCourseId ? "Select a version" : "Select a course first"} />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {followUpVersionIds.map((vid: string) => (
+                                <SelectItem key={vid} value={vid}>
+                                  <VersionLabel versionId={vid} />
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+
+                        {followUpVersionLoading && followUpVersionId && (
+                          <p className="text-xs text-muted-foreground flex items-center gap-1">
+                            <Loader2 className="h-3 w-3 animate-spin" /> Loading course version…
+                          </p>
+                        )}
+
+                        {/* Prompt the instructor for a cohort when the target version uses cohorts */}
+                        {followUpRequiresCohort && (
+                          <div className="space-y-1">
+                            <Label className="text-xs font-medium">
+                              Cohort <span className="text-destructive">*</span>
+                            </Label>
+                            <p className="text-xs text-muted-foreground">
+                              This course uses cohorts. Select which cohort students should join.
+                            </p>
+                            <Select
+                              value={followUpCohortId}
+                              onValueChange={(v) => setFollowUpCohortId(v)}
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select a cohort" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {followUpCohorts.map((c: any) => (
+                                  <SelectItem key={c.id} value={c.id}>
+                                    {c.name}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </div>
               )}
             </div>
@@ -304,8 +507,8 @@ export function ProctoringModal({
             <Button type="button" variant="secondary" onClick={onClose}>
               Cancel
             </Button>
-            <Button type="submit" disabled={loading}>
-              {loading ? "Saving..." : "Save"}
+            <Button type="submit" disabled={loading || followUpLoading}>
+              {loading || followUpLoading ? "Saving..." : "Save"}
             </Button>
           </div>
         </form>

--- a/frontend/src/components/announcements/NewAnnouncementsPopup.tsx
+++ b/frontend/src/components/announcements/NewAnnouncementsPopup.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Megaphone } from "lucide-react";
+import { useAnnouncements } from "@/hooks/announcement-hooks";
+import type { Announcement } from "@/types/announcement.types";
+
+// Shared with useNewAnnouncementIndicator so dismissing the popup also clears
+// the "new announcements" dot on the bell.
+const STORAGE_KEY = "announcements-last-seen";
+
+/**
+ * Auto-opening popup that surfaces announcements created since the student last
+ * saw them. Renders on dashboard entry; dismissing marks everything up to now
+ * as seen so it won't reappear until a newer announcement arrives.
+ */
+export function NewAnnouncementsPopup() {
+  // studentMode=true → GET /announcements/student
+  const { data, isLoading } = useAnnouncements(
+    undefined,
+    undefined,
+    undefined,
+    true,
+  );
+  const [open, setOpen] = useState(false);
+
+  const newAnnouncements = useMemo(() => {
+    const lastSeen = parseInt(localStorage.getItem(STORAGE_KEY) || "0", 10);
+    const list = (data as Announcement[] | undefined) ?? [];
+    return list
+      .filter((a) => !a.isHidden && !a.isDeleted)
+      .filter((a) => new Date(a.createdAt).getTime() > lastSeen)
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+  }, [data]);
+
+  useEffect(() => {
+    if (!isLoading && newAnnouncements.length > 0) {
+      setOpen(true);
+    }
+  }, [isLoading, newAnnouncements.length]);
+
+  const dismiss = () => {
+    localStorage.setItem(STORAGE_KEY, Date.now().toString());
+    // Let the bell indicator refresh its "hasNew" state.
+    window.dispatchEvent(new Event("refresh-announcements"));
+    setOpen(false);
+  };
+
+  if (newAnnouncements.length === 0) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => (!o ? dismiss() : setOpen(o))}>
+      <DialogContent className="sm:max-w-lg w-[calc(100%-2rem)] max-w-full max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-lg font-extrabold">
+            <Megaphone className="h-5 w-5 text-primary" />
+            {newAnnouncements.length > 1
+              ? `${newAnnouncements.length} new announcements`
+              : "New announcement"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {newAnnouncements.map((a) => (
+            <div
+              key={a._id}
+              className="rounded-lg border border-border p-3 space-y-2"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <h3 className="font-semibold leading-tight">{a.title}</h3>
+                {a.courseName && (
+                  <Badge variant="secondary" className="shrink-0 text-[10px]">
+                    {a.courseName}
+                  </Badge>
+                )}
+              </div>
+              <div
+                className="text-sm text-muted-foreground prose prose-sm max-w-none dark:prose-invert"
+                dangerouslySetInnerHTML={{ __html: a.content }}
+              />
+              <p className="text-[11px] text-muted-foreground/70">
+                {a.instructorName ? `${a.instructorName} · ` : ""}
+                {new Date(a.createdAt).toLocaleString()}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={dismiss} className="font-semibold">
+            Got it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/course/FollowUpInvitesBanner.tsx
+++ b/frontend/src/components/course/FollowUpInvitesBanner.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import { useInvites, useAcceptInvite } from "@/hooks/hooks";
+import { Button } from "@/components/ui/button";
+import { Sparkles, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+/**
+ * Persistent banner shown on the student dashboard listing any pending course
+ * invites (e.g. the exclusive follow-up course unlocked on completing another
+ * course). Stays until the student claims or the invite is otherwise resolved.
+ */
+export function FollowUpInvitesBanner() {
+  const { getInvites } = useInvites();
+  const { acceptInvite, loading: accepting } = useAcceptInvite();
+  const [invites, setInvites] = useState<any[]>([]);
+  const [claimingId, setClaimingId] = useState<string | null>(null);
+
+  const handleClaim = async (inviteId: string) => {
+    setClaimingId(inviteId);
+    try {
+      await acceptInvite(inviteId, "ACCEPT");
+      toast.success("You're enrolled! Redirecting to your courses…");
+      // Reload so the new enrollment shows and this invite drops off.
+      window.location.assign("/student");
+    } catch {
+      toast.error("Couldn't claim your spot. Please try again.");
+      setClaimingId(null);
+    }
+  };
+
+  useEffect(() => {
+    let active = true;
+    getInvites()
+      .then((res) => {
+        if (!active) return;
+        const pending = (res?.invites ?? []).filter(
+          (i: any) => i?.inviteStatus === "PENDING",
+        );
+        setInvites(pending);
+      })
+      .catch(() => {
+        /* silently ignore — banner is optional */
+      });
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!invites.length) return null;
+
+  return (
+    <div className="space-y-3">
+      {invites.map((inv) => (
+        <div
+          key={inv.inviteId?.toString()}
+          className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 rounded-lg border border-primary/30 bg-primary/5 p-4"
+        >
+          <div className="flex items-start gap-3">
+            <Sparkles className="h-5 w-5 text-primary mt-0.5 shrink-0" />
+            <div>
+              <p className="font-semibold">🎉 Continue your journey</p>
+              <p className="text-sm text-muted-foreground">
+                You've earned an exclusive spot in{" "}
+                <span className="font-medium text-foreground">
+                  {inv.course?.name ?? "a new course"}
+                </span>
+                . Claim it to get started.
+              </p>
+            </div>
+          </div>
+          <Button
+            className="font-semibold shrink-0"
+            disabled={accepting && claimingId === inv.inviteId?.toString()}
+            onClick={() => handleClaim(inv.inviteId?.toString())}
+          >
+            {accepting && claimingId === inv.inviteId?.toString() ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-1" /> Claiming…
+              </>
+            ) : (
+              "Claim my spot"
+            )}
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -2186,6 +2186,95 @@ export function useEditProctoringSettings() {
   return { editSettings, loading, error };
 }
 
+// PUT /setting/course-setting/{courseId}/{versionId}/follow-up-invite
+// Configures the exclusive follow-up course a student is invited to when they
+// complete this (source) course version.
+export function useUpdateFollowUpInvite() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateFollowUpInvite = async (
+    courseId: string,
+    versionId: string,
+    followUpInvite: {
+      enabled: boolean;
+      courseId?: string;
+      courseVersionId?: string;
+      cohortId?: string;
+      role?: string;
+    },
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/setting/course-setting/${courseId}/${versionId}/follow-up-invite`;
+
+      const res = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+        body: JSON.stringify(followUpInvite),
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        // Surface the backend's actionable message (e.g. "please select a cohort").
+        throw new Error(data?.message || `Failed to update follow-up invite: ${res.status}`);
+      }
+
+      return data;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { updateFollowUpInvite, loading, error };
+}
+
+// Accept (or reject) a course invite from within the app. Hits the local
+// backend accept endpoint (the backend-provided acceptUrl points at APP_URL,
+// which may be a different/staging host, so we build it from our own base).
+export function useAcceptInvite() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const acceptInvite = async (
+    inviteId: string,
+    action: 'ACCEPT' | 'REJECTED' = 'ACCEPT',
+  ) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/notifications/invite/${inviteId}?action=${action}`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to process invite: ${res.status}`);
+      }
+      return true;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { acceptInvite, loading, error };
+}
+
 export function useSubmitStudentQuestion(): {
   submitQuestion: (
     courseId: string,


### PR DESCRIPTION
Summary
Lets an instructor link a course to a follow-up course: when a student completes the source course, the system auto-creates an exclusive invite to the next course and surfaces it in-app. Also adds an auto-popup for unseen announcements on the student dashboard.

Fully generic/per-course — not hardcoded to any specific pairing (e.g. Fundamentals of AI → MERN Stack).

How it works
Configure — instructor enables "Follow-up Course Invite" on the source course version and picks the target course/version (+ cohort if required). Stored as ISettings.followUpInvite.
Trigger — on the student's completed: false → true transition (ProgressService.stopItem), a best-effort invite to the target course is created (idempotent; never blocks completion).
Deliver & claim — the student sees it in three places (completion-screen card, persistent dashboard banner, notification bell); claiming accepts the invite and enrolls them.
Backend
ISettings.followUpInvite config + transformer/validator
PUT /setting/course-setting/:courseId/:versionId/follow-up-invite endpoint + service + repository; validates the target exists/active and requires a cohort when the target version uses cohorts
ProgressService completion hook → InviteService.inviteUserToCourse (deduped)
InviteResult enriched with acceptUrl
Fixed a latent circular import in AnomalyValidators (enum imported from its source file instead of the barrel)
Tests: 9 unit + 6 integration covering the endpoint and validation (incl. the cohort-required path)
Frontend
Instructor: "Follow-up Course Invite" section in course settings — course/version dropdowns (names, not IDs) + a required cohort prompt
Student: claim card on completion, persistent dashboard banner, and the existing invite notification card; claim hits the local invite-accept endpoint and enrolls
Announcements: auto-popup of unseen announcements on dashboard entry, sharing the bell's announcements-last-seen state
Testing
Backend: pnpm vitest run src/modules/setting/tests/ → 15 passing
Backend + frontend type-check clean (tsc --noEmit)
Manual: configure follow-up → complete source course → claim from card/banner/bell