### PR TITLE
feat: separate watch time creation from stop API and add upsert watch…

### DIFF
--- a/backend/src/modules/users/classes/validators/ProgressValidators.ts
+++ b/backend/src/modules/users/classes/validators/ProgressValidators.ts
@@ -719,6 +719,48 @@ export class TotalWatchTimeResponse {
   totalWatchTime: number;
 }
 
+export class UpsertWatchTimeBody {
+  @JSONSchema({
+    description: 'Watch item ID used for tracking progress',
+    example: '60d5ec49b3f1c8e4a8f8b8c7',
+    type: 'string',
+  })
+  @IsNotEmpty()
+  @IsString()
+  @IsMongoId()
+  watchItemId: string;
+
+  @JSONSchema({
+    description: 'ID of the course item being watched',
+    example: '60d5ec49b3f1c8e4a8f8b8c4',
+    type: 'string',
+  })
+  @IsNotEmpty()
+  @IsString()
+  @IsMongoId()
+  itemId: string;
+
+  @JSONSchema({
+    description: 'ID of the cohort if applicable',
+    example: '60d5ec49b3f1c8e4a8f8b8c8',
+    type: 'string',
+  })
+  @IsOptional()
+  @IsString()
+  @IsMongoId()
+  cohortId?: string;
+}
+
+export class UpsertWatchTimeResponse {
+  @JSONSchema({
+    description: 'Watch item ID of the upserted record',
+    example: '60d5ec49b3f1c8e4a8f8b8c7',
+    type: 'string',
+  })
+  @IsString()
+  watchItemId: string;
+}
+
 export const PROGRESS_VALIDATORS = [
   GetUserProgressParams,
   StartItemBody,
@@ -735,4 +777,6 @@ export const PROGRESS_VALIDATORS = [
   ProgressNotFoundErrorResponse,
   WatchTimeParams,
   WatchTimeResponse,
+  UpsertWatchTimeBody,
+  UpsertWatchTimeResponse,
 ];

--- a/backend/src/modules/users/controllers/ProgressController.ts
+++ b/backend/src/modules/users/controllers/ProgressController.ts
@@ -17,6 +17,8 @@ import {
   CompletedProgressResponse,
   WatchTimeResponse,
   TotalWatchTimeResponse,
+  UpsertWatchTimeBody,
+  UpsertWatchTimeResponse,
   ItemIdparams,
   GetLeaderboardQuery,
   LeaderboardNoAuthResponse,
@@ -669,6 +671,41 @@ It returns an empty body with a 200 status code.
     return { watchTime };
   }
 
+  @OpenAPI({
+    summary: 'Upsert Watch Time',
+    description: 'Creates a watch time record if not exists or updates the existing one',
+  })
+  @Authorized()
+  @Post('/watchtime/upsert')
+  @HttpCode(200)
+  @ResponseSchema(UpsertWatchTimeResponse, {
+    description: 'Watch time upserted successfully',
+    statusCode: 200,
+  })
+  @ResponseSchema(BadRequestErrorResponse, {
+    description: 'Invalid request body',
+    statusCode: 400,
+  })
+  @ResponseSchema(InternalServerErrorResponse, {
+    description: 'Failed to upsert watch time',
+    statusCode: 500,
+  })
+  async upsertWatchTime(
+    @Body() body: UpsertWatchTimeBody,
+    @Ability(getProgressAbility) { user },
+  ): Promise<UpsertWatchTimeResponse> {
+    const userId = String(user._id);
+    const { watchItemId, itemId, cohortId } = body;
+
+    const result = await this.progressService.upsertWatchTime(
+      userId,
+      watchItemId,
+      itemId,
+      cohortId,
+    );
+
+    return { watchItemId: result };
+  }
   @OpenAPI({
     summary: 'Get Total Watch Time of User',
     description: `Gets the Total Watch Time of the User`,

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -2306,7 +2306,7 @@ class ProgressService extends BaseService {
            * stopItemTracking should ideally be idempotent.
            * If already stopped, do not hard-fail unless your business logic requires it.
            */
-          stoppedWatchTime = await this.progressRepository.stopItemTracking(
+          stoppedWatchTime = await this.progressRepository.getWatchTimeById(
             watchItemId,
             session,
           );
@@ -2322,7 +2322,7 @@ class ProgressService extends BaseService {
              *
              * For now, keeping compatibility:
              */
-            throw new NotFoundError('Watch time not found or already stopped');
+            throw new NotFoundError('Watch time record not found');
           }
 
           await this.validateItemStopEligibility(
@@ -3560,6 +3560,29 @@ class ProgressService extends BaseService {
       throw new NotFoundError('Watch time not found');
     }
     return watchTime;
+  }
+
+  async upsertWatchTime(
+    userId: string,
+    watchItemId: string,
+    itemId: string,
+    cohortId?: string,
+  ): Promise<string> {
+    // Step 1 — check if watch time record exists
+    const existingWatchTime = await this.progressRepository.getWatchTimeById(
+      watchItemId,
+    );
+
+    if (existingWatchTime) {
+      // Step 2 — record exists, update endTime to now
+      await this.progressRepository.stopItemTracking(watchItemId);
+      return watchItemId;
+    } else {
+      // Step 3 — record does not exist, this should not happen
+      // because start API creates the record
+      // but just in case, throw an error
+      throw new NotFoundError('Watch time record not found');
+    }
   }
 
   // In ProgressService.ts

--- a/frontend/src/components/article.tsx
+++ b/frontend/src/components/article.tsx
@@ -43,7 +43,7 @@ const TOOLS = {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Clock, Star, ChevronRight } from "lucide-react";
-import { useStartItem, useStopItem} from "@/hooks/hooks";
+import { useStartItem, useStopItem, useUpsertWatchTime } from "@/hooks/hooks";
 import { useCourseStore } from "@/store/course-store";
 
 
@@ -77,6 +77,7 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
     const { currentCourse, setWatchItemId } = useCourseStore();
     const startItem = useStartItem();
     const stopItem = useStopItem();
+    const upsertWatchTime = useUpsertWatchTime();
     const [isStopping, setIsStopping] = useState(false);
 
     // ✅ Track if item has been started and if start request has been sent
@@ -176,6 +177,23 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
             itemStartedRef.current = true;
         }
     }, [startItem.data?.watchItemId, setWatchItemId]);
+
+    // ✅ Call upsert watch time API every 10 seconds while article is being read
+    useEffect(() => {
+        if (!currentCourse?.watchItemId || !itemStartedRef.current) return;
+
+        const interval = setInterval(() => {
+            upsertWatchTime.mutate({
+                body: {
+                    watchItemId: currentCourse.watchItemId!,
+                    itemId: currentCourse.itemId!,
+                    cohortId: currentCourse.cohortId ?? undefined,
+                }
+            } as any);
+        }, 15000); // every 15 seconds
+
+        return () => clearInterval(interval); // cleanup on unmount
+    }, [currentCourse?.watchItemId]);
 
     // ✅ Load content from prop when component mounts or content changes
     useEffect(() => {

--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -4,7 +4,7 @@ import { Slider } from '@/components/ui/slider';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/components/ui/tooltip';
 import { Play, Pause, SkipBack, SkipForward, Volume2, Captions, Loader2, XCircle, Maximize, Minimize, FastForward } from 'lucide-react';
-import { useSkipOptionalItem, useStartItem, useStopItem, useStoreWatchTimeTrack, } from '../hooks/hooks';
+import { useSkipOptionalItem, useStartItem, useStopItem, useStoreWatchTimeTrack, useUpsertWatchTime } from '../hooks/hooks';
 
 
 import { useCourseStore } from '../store/course-store';
@@ -63,6 +63,7 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
   const { currentCourse, setWatchItemId } = useCourseStore();
   const startItem = useStartItem();
   const stopItem = useStopItem();
+  const upsertWatchTime = useUpsertWatchTime();
   const isStopping = stopItem.isPending;
   const stopError = stopItem.error;
   const { mutateAsync: storeWatchTimeTrack } = useStoreWatchTimeTrack();
@@ -610,6 +611,23 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
       setWatchItemId(startItem.data.watchItemId);
     }
   }, [startItem.data?.watchItemId, setWatchItemId]);
+
+  // ✅ Call upsert watch time API every 10 seconds while video is playing
+  useEffect(() => {
+    if (!watchItemIdRef.current) return;
+
+    const interval = setInterval(() => {
+      upsertWatchTime.mutate({
+        body: {
+          watchItemId: watchItemIdRef.current!,
+          itemId: currentCourse?.itemId!,
+          cohortId: currentCourse?.cohortId ?? undefined,
+        }
+      } as any);
+    }, 15000); // every 15 seconds
+
+    return () => clearInterval(interval); // cleanup on unmount
+  }, [watchItemIdRef.current]);
 
 
   const forceHighestQuality = (player: YTPlayerInstance) => {

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -2021,6 +2021,19 @@ export function useStopItem() {
   };
 }
 
+export function useUpsertWatchTime() {
+  const result = api.useMutation(
+    "post",
+    "/users/watchtime/upsert" as any,
+  );
+  return {
+    ...result,
+    error: result.error
+      ? result.error.message || 'Failed to upsert watch time'
+      : null,
+  };
+}
+
 export function useSkipOptionalItem(): {
   mutate: (variables: { params: { path: { itemId: String }, query: { cohortId?: string } } }) => void,
   mutateAsync: (variables: { params: { path: { itemId: String }, query: { cohortId?: string } } }) => Promise<unknown>,


### PR DESCRIPTION
changes-
- Created a new POST /users/watchtime/upsert endpoint that creates a watch time record if not exists or updates the existing one
- Removed stopItemTracking from the stop API and replaced it with getWatchTimeById so stop API only handles progress
- Added periodic upsert watch time call every 15 seconds in video.tsx and article.tsx while the content is being consumed