### PR TITLE
fix(progress): allow students to complete articles without a minimum …

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -10,7 +10,6 @@ import {
   IWatchTime,
   IProgress,
   IVideoDetails,
-  IBlogDetails,
   ICurrentProgressPath,
   IEnrollment,
   EnrollmentRole,
@@ -1433,16 +1432,9 @@ class ProgressService extends BaseService {
         return adjustedDuration >= minimumRequired;
 
       case 'BLOG':
-        const blogDetails = item.details as IBlogDetails;
-        // Estimated read time is in minutes
-        const readTimeSeconds =
-          (blogDetails.estimatedReadTimeInMinutes || 1) * 60;
-
-        // Require at least 10% of estimated time OR 10 seconds
-        // This stops instant click-throughs but doesn't punish fast readers
-        const minReadTime = Math.min(readTimeSeconds * 0.1, 10);
-
-        return adjustedDuration >= minReadTime;
+        // No minimum reading time for articles. Students can proceed to the
+        // next lesson whenever they click Next, and the item is marked complete.
+        return true;
 
       default:
         return true;


### PR DESCRIPTION
Students were blocked from finishing articles when they clicked Next Lesson too quickly. The BLOG case in isValidWatchTime required the article to stay open for at least min(estimatedReadTime × 10%, 10s); below that, the backend threw Invalid watch time, so stopItem failed — the lesson never advanced and the item was never marked complete.

This removes the minimum-read-time gate for BLOG items. Now clicking Next Lesson always stops the item, marks it complete, and advances.

VIDEO watch-time enforcement is unchanged
Dropped the now-unused IBlogDetails import