### PR TITLE
fix: restore stopItemTracking call in stopItem to resolve video & article completion errors

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -2307,7 +2307,7 @@ class ProgressService extends BaseService {
            * stopItemTracking should ideally be idempotent.
            * If already stopped, do not hard-fail unless your business logic requires it.
            */
-          stoppedWatchTime = await this.progressRepository.getWatchTimeById(
+          stoppedWatchTime = await this.progressRepository.stopItemTracking(
             watchItemId,
             session,
           );


### PR DESCRIPTION
This PR fixes two critical student progression bugs introduced in a recent refactor:
1. **"Failed to stop video"** toast notification when students completely watch a video.
2. **"You must spend more time reading this article to proceed"** toast notification when students read articles/blogs (even after spending significant time).

### Root Cause
In commit `e937cee09`, the `/stop` (`stopItem`) endpoint in `ProgressService.ts` was modified to use `getWatchTimeById` instead of `stopItemTracking` to fetch the watch time record. 

Because `getWatchTimeById` is a read-only query, the final `endTime` of the watch session was **never written/saved** to the database when the student stopped or finished the video/article. 

As a result:
- The backend had to rely entirely on the frontend's 15-second background interval (`upsertWatchTime`) to set the `endTime`.
- If the interval didn't run (e.g. video/article finished in under 15 seconds), or if the browser throttled/suspended the background execution of the interval (due to tab switching or inactivity), the database `endTime` remained `null`.
- During validation, the missing `endTime` caused `isValidWatchTime` to fail the sanity check and throw an `Invalid watch time` error.
- For videos, this resulted in the "Failed to stop video" warning.
- For articles/blogs, this fell back to the "You must spend more time reading this article to proceed" warning.

### Solution
Restored the call to `this.progressRepository.stopItemTracking(watchItemId, session)` in [ProgressService.ts](file:///d:/programm3d/vibe/backend/src/modules/users/services/ProgressService.ts#L2310-L2314). This ensures the final `endTime` is immediately written to the database when `/stop` is called, satisfying the sanity checks and correctly marking items as complete.

---

## Verification
- Verified compilation and build are successful using `pnpm run build` in the backend directory.
- Pre-commit linting and staging checks passed successfully.