### PR TITLE
fix: add cameraIntegrity message and remove instant pause on minor an…

### DIFF
--- a/frontend/src/components/floating-video.tsx
+++ b/frontend/src/components/floating-video.tsx
@@ -590,7 +590,6 @@ const lastCalledRef = useRef<number>(0);
 
       // Condition 1: If speaking is detected (only if voice detection is enabled)
       if (isSpeaking === "Yes" && isVoiceDetectionEnabled) {
-        setPauseVid(true);
         setAnomalies([...anomalies, "voiceDetection"]);
         newPenaltyType = "Speaking";
         newPenaltyPoints += 1;
@@ -602,7 +601,6 @@ const lastCalledRef = useRef<number>(0);
           // No faces detected - this might be normal during initialization
           // Only penalize if we're sure the camera is active and should see a face
           if (isVideoActive && readyToDetect) {
-            setPauseVid(true); // Just pause, don't rewind
             setAnomalies([...anomalies, "faceCountDetection"]);
             newPenaltyType = "No Face Detected";
             newPenaltyPoints += 1;
@@ -634,7 +632,6 @@ const lastCalledRef = useRef<number>(0);
 
       // Condition 5: Registered face does not match current camera frame
       if (hasFaceRecognitionMismatch && isFaceRecognitionEnabled) {
-        setPauseVid(true);
         setAnomalies([...anomalies, "faceRecognition"]);
         newPenaltyType = "Face Recognition";
         newPenaltyPoints += 2;

--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -1545,6 +1545,12 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
                               </div>
 
                             ) : <></>}
+                            
+                            {anomalies?.includes("cameraIntegrity") ? (
+                              <div style={{ marginBottom: 6 }}>
+                                <strong>Camera issue detected. Please check your camera.</strong>
+                              </div>
+                            ) : <></>}
 
                           </span>
 


### PR DESCRIPTION
Root Cause
Two issues found:

1. The `cameraIntegrity` anomaly type had no message defined in the warning overlay — so the box rendered blank when that check fired.

2. Voice, no-face, and face-recognition anomalies were calling `setPauseVid(true)` instantly on a single bad frame (the detection loop runs every 100ms). So a student briefly looking away or a momentary camera miss would immediately pause the video and show the warning.

 Fix
1. Added missing message for `cameraIntegrity` in `video.tsx` so the warning box always shows text.

2. Removed instant `setPauseVid(true)` from voice, no-face, and face-recognition conditions. These now accumulate penalty points and only pause via the existing `>= 20` counter (~2 seconds of sustained anomaly). Multiple faces detection still pauses instantly as it is a more serious violation.