### PR TITLE
fix: remove ethics consent check from video pause condition

### DIFF
--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -2407,7 +2407,7 @@ return false;
                         setAttemptId={setAttemptId}
                         rewindVid={rewindVid}
                         readyToDetect={readyToDetect}
-                        pauseVid={pauseVid || !consentSatisfied || showProctorDialog}
+                        pauseVid={pauseVid || showProctorDialog}
                         displayNextLesson={false}
                         setQuizPassed={setQuizPassed}
                         anomalies={anomalies}


### PR DESCRIPTION
fix: removed !consentSatisfied from the pauseVid condition so 
all students can watch videos normally. Consent form to be added back 
properly in a future PR.