### PR TITLE
Fix/invite notification case insensitive email

### DIFF
--- a/backend/src/bootstrap/loadModules.ts
+++ b/backend/src/bootstrap/loadModules.ts
@@ -69,3 +69,12 @@ export const getContainer = (): Container => {
   }
   return container;
 };
+
+/**
+ * Test seam: register an externally-built container as the global one so that
+ * service-locator lookups via getContainer() resolve against it. Only intended
+ * for tests that assemble their own container instead of loadAppModules('all').
+ */
+export const setContainer = (testContainer: Container): void => {
+  container = testContainer;
+};

--- a/backend/src/modules/setting/controllers/CourseSettingController.ts
+++ b/backend/src/modules/setting/controllers/CourseSettingController.ts
@@ -34,6 +34,9 @@ import {
   OutComeStatus,
 } from '#root/modules/auditTrails/interfaces/IAuditTrails.js';
 import {ObjectId} from 'mongodb';
+import {getContainer} from '#root/bootstrap/loadModules.js';
+import {USERS_TYPES} from '#root/modules/users/types.js';
+import type {ProgressService} from '#root/modules/users/services/ProgressService.js';
 
 @OpenAPI({
   tags: ['Course Setting'],
@@ -211,6 +214,33 @@ export class CourseSettingController {
     );
 
     return {success: result};
+  }
+
+  @Authorized()
+  @Post('/:courseId/:versionId/follow-up-invite/backfill')
+  @HttpCode(200)
+  @ResponseSchema(BadRequestErrorResponse, {
+    description: 'Bad Request Error',
+    statusCode: 400,
+  })
+  async backfillFollowUpInvites(
+    @Params() params: ReadCourseSettingParams,
+  ): Promise<{
+    completed: number;
+    alreadyEnrolled: number;
+    missingEmail: number;
+    invited: number;
+  }> {
+    // Re-sends the configured follow-up invite to every student who already
+    // completed this (source) course version but isn't yet enrolled in the
+    // target course — e.g. students who finished before the invite was set up.
+    const {courseId, versionId} = params;
+
+    const progressService = getContainer().get<ProgressService>(
+      USERS_TYPES.ProgressService,
+    );
+
+    return progressService.backfillFollowUpInvites(courseId, versionId);
   }
 
   // This method removes proctoring settings for a course version.

--- a/backend/src/modules/setting/tests/CourseSettingController.backfill.test.ts
+++ b/backend/src/modules/setting/tests/CourseSettingController.backfill.test.ts
@@ -1,0 +1,284 @@
+import 'reflect-metadata';
+import Express from 'express';
+import {
+  RoutingControllersOptions,
+  useContainer,
+  useExpressServer,
+} from 'routing-controllers';
+import { describe, it, expect, beforeAll } from 'vitest';
+import request from 'supertest';
+import { faker } from '@faker-js/faker';
+import type { Collection } from 'mongodb';
+import { ObjectId } from 'mongodb';
+import { Container } from 'inversify';
+import { InversifyAdapter } from '#root/inversify-adapter.js';
+import { sharedContainerModule } from '#root/container.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import type { ICourseRepository } from '#root/shared/index.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import { IProgress, IEnrollment, IUser, ItemType } from '#shared/interfaces/models.js';
+import { setContainer } from '#root/bootstrap/loadModules.js';
+import {
+  settingContainerModule,
+  settingModuleControllers,
+} from '../index.js';
+import { usersContainerModule } from '#root/modules/users/container.js';
+import { coursesContainerModule } from '#root/modules/courses/container.js';
+import { authContainerModule } from '#root/modules/auth/container.js';
+import { quizzesContainerModule } from '#root/modules/quizzes/container.js';
+import { projectsContainerModule } from '#root/modules/projects/container.js';
+import { notificationsContainerModule } from '#root/modules/notifications/container.js';
+import { hpSystemContainerModule } from '#root/modules/hpSystem/container.js';
+import { anomaliesContainerModule } from '#root/modules/anomalies/container.js';
+import { courseRegistrationContainerModule } from '#root/modules/courseRegistration/container.js';
+import { reportsContainerModule } from '#root/modules/reports/container.js';
+import { ejectionPolicyContainerModule } from '#root/modules/ejectionPolicy/container.js';
+import { emotionsContainerModule } from '#root/modules/emotions/container.js';
+import { genAIContainerModule } from '#root/modules/genAI/container.js';
+import { studentQuestionsContainerModule } from '#root/modules/studentQuestions/container.js';
+import { announcementsContainerModule } from '#root/modules/announcements/container.js';
+import { auditTrailsContainerModule } from '#root/modules/auditTrails/container.js';
+
+/**
+ * Integration tests for the follow-up invite *backfill* endpoint
+ * (POST /setting/course-setting/:courseId/:versionId/follow-up-invite/backfill).
+ *
+ * The backfill re-sends the configured follow-up invite to every student who
+ * already completed the source course version but isn't yet enrolled in the
+ * target course — covering students who finished before the invite was set up.
+ *
+ * Everything is seeded directly through repositories / the DB (Firebase auth and
+ * the @Ability-protected course endpoints aren't available in tests). The target
+ * version is given a module → section → items-group → video item so it satisfies
+ * the content checks the invite flow performs for STUDENT invites.
+ */
+describe('CourseSettingController — follow-up invite backfill', () => {
+  let app: any;
+  let courseRepo: ICourseRepository;
+  let progressCollection: Collection<IProgress>;
+  let enrollmentCollection: Collection<IEnrollment>;
+  let usersCollection: Collection<IUser>;
+  let itemsGroupCollection: Collection<any>;
+  let videosCollection: Collection<any>;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    const container = new Container();
+    await container.load(
+      settingContainerModule,
+      usersContainerModule,
+      coursesContainerModule,
+      quizzesContainerModule,
+      projectsContainerModule,
+      notificationsContainerModule,
+      hpSystemContainerModule,
+      anomaliesContainerModule,
+      courseRegistrationContainerModule,
+      reportsContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+      authContainerModule,
+      sharedContainerModule,
+    );
+    const inversifyAdapter = new InversifyAdapter(container);
+    useContainer(inversifyAdapter);
+    // The backfill resolves ProgressService/InviteService via getContainer(), so
+    // register this container as the global one.
+    setContainer(container);
+
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
+    courseRepo = container.get<ICourseRepository>(GLOBAL_TYPES.CourseRepo);
+    progressCollection = await db.getCollection<IProgress>('progress');
+    enrollmentCollection = await db.getCollection<IEnrollment>('enrollment');
+    usersCollection = await db.getCollection<IUser>('users');
+    itemsGroupCollection = await db.getCollection('itemsGroup');
+    videosCollection = await db.getCollection('videos');
+
+    app = Express();
+    const options: RoutingControllersOptions = {
+      controllers: settingModuleControllers as Function[],
+      authorizationChecker: async () => true,
+      defaultErrorHandler: true,
+      validation: true,
+    };
+    useExpressServer(app, options);
+  }, 900000);
+
+  // Insert a user straight into the DB (no Firebase round-trip).
+  async function seedUser(): Promise<{ userId: string; email: string }> {
+    const _id = new ObjectId();
+    const email = faker.internet.email().toLowerCase();
+    await usersCollection.insertOne({
+      _id,
+      email,
+      firstName: faker.person.firstName().replace(/[^a-zA-Z]/g, ''),
+      lastName: faker.person.lastName().replace(/[^a-zA-Z]/g, ''),
+      roles: 'user',
+    } as unknown as IUser);
+    return { userId: _id.toString(), email };
+  }
+
+  // Seed a course + version whose first section has a single (video) item, so
+  // the invite flow's content validation for STUDENT invites passes.
+  async function seedContentCompleteVersion(): Promise<{
+    courseId: string;
+    versionId: string;
+  }> {
+    const now = new Date();
+    const course = await courseRepo.create({
+      name: `course-${new ObjectId().toString()}`,
+      description: 'seeded course',
+      versions: [],
+      instructors: [],
+      createdAt: now,
+      updatedAt: now,
+    } as any);
+    const courseId = (course!._id as any).toString();
+
+    const version = await courseRepo.createVersion({
+      courseId: course!._id,
+      version: 'v1',
+      description: 'seeded version',
+      modules: [],
+      createdAt: now,
+      updatedAt: now,
+    } as any);
+    const versionId = (version!._id as any).toString();
+
+    // A video item + an items-group referencing it.
+    const videoId = new ObjectId();
+    await videosCollection.insertOne({
+      _id: videoId,
+      name: 'seeded video',
+      isDeleted: false,
+      createdAt: now,
+      updatedAt: now,
+    } as any);
+
+    const itemsGroupId = new ObjectId();
+    const sectionId = new ObjectId();
+    await itemsGroupCollection.insertOne({
+      _id: itemsGroupId,
+      sectionId,
+      isDeleted: false,
+      items: [
+        { _id: videoId, type: ItemType.VIDEO, order: 'a', isHidden: false },
+      ],
+      createdAt: now,
+      updatedAt: now,
+    } as any);
+
+    // Attach a module → section → items-group to the version.
+    await (courseRepo as any).addModulesToVersion(versionId, [
+      {
+        moduleId: new ObjectId(),
+        name: 'Module 1',
+        description: 'seeded module',
+        order: 'a',
+        isHidden: false,
+        sections: [
+          {
+            sectionId,
+            name: 'Section 1',
+            description: 'seeded section',
+            order: 'a',
+            itemsGroupId,
+            isHidden: false,
+          },
+        ],
+      },
+    ]);
+
+    return { courseId, versionId };
+  }
+
+  // Mark a user as having completed a course version (without going through the
+  // completion endpoint, which would itself fire the live follow-up invite).
+  async function markCompleted(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+  ): Promise<void> {
+    await progressCollection.insertOne({
+      userId: new ObjectId(userId),
+      courseId: new ObjectId(courseId),
+      courseVersionId: new ObjectId(courseVersionId),
+      currentModule: new ObjectId(),
+      currentSection: new ObjectId(),
+      currentItem: new ObjectId(),
+      completed: true,
+      completedAt: new Date(),
+    } as IProgress);
+  }
+
+  async function enrollActive(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+  ): Promise<void> {
+    await enrollmentCollection.insertOne({
+      userId: new ObjectId(userId),
+      courseId: new ObjectId(courseId),
+      courseVersionId: new ObjectId(courseVersionId),
+      role: 'STUDENT',
+      status: 'ACTIVE',
+      enrollmentDate: new Date(),
+      percentCompleted: 0,
+    } as IEnrollment);
+  }
+
+  const backfillUrl = (courseId: string, versionId: string) =>
+    `/setting/course-setting/${courseId}/${versionId}/follow-up-invite/backfill`;
+  const followUpUrl = (courseId: string, versionId: string) =>
+    `/setting/course-setting/${courseId}/${versionId}/follow-up-invite`;
+
+  // Generous timeout: these tests do many sequential round-trips to a remote
+  // Mongo (seeding courses/users/progress + the backfill transaction).
+  const TEST_TIMEOUT = 30000;
+
+  it('returns 400 when the source has no enabled follow-up invite', async () => {
+    const source = await seedContentCompleteVersion();
+    await request(app)
+      .post(backfillUrl(source.courseId, source.versionId))
+      .expect(400);
+  }, TEST_TIMEOUT);
+
+  it('invites past completers who are not yet enrolled, and skips enrolled ones', async () => {
+    const source = await seedContentCompleteVersion();
+    const target = await seedContentCompleteVersion();
+
+    // Configure the follow-up invite: completing `source` invites to `target`.
+    await request(app)
+      .put(followUpUrl(source.courseId, source.versionId))
+      .send({
+        enabled: true,
+        courseId: target.courseId,
+        courseVersionId: target.versionId,
+      })
+      .expect(200);
+
+    // Two completers not enrolled in the target → should be invited.
+    const userA = await seedUser();
+    const userB = await seedUser();
+    // One completer already enrolled in the target → should be skipped.
+    const userC = await seedUser();
+
+    await markCompleted(userA.userId, source.courseId, source.versionId);
+    await markCompleted(userB.userId, source.courseId, source.versionId);
+    await markCompleted(userC.userId, source.courseId, source.versionId);
+    await enrollActive(userC.userId, target.courseId, target.versionId);
+
+    const res = await request(app)
+      .post(backfillUrl(source.courseId, source.versionId))
+      .expect(200);
+
+    expect(res.body.completed).toBe(3);
+    expect(res.body.alreadyEnrolled).toBe(1);
+    expect(res.body.invited).toBe(2);
+  }, TEST_TIMEOUT);
+});

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -2641,6 +2641,104 @@ class ProgressService extends BaseService {
     }
   }
 
+  /**
+   * Backfill the follow-up invite for every student who already *completed* the
+   * source course version but never received the invite (because they finished
+   * before it was configured). Invites are only sent to students who are not
+   * already actively enrolled in the target course; pending-invite de-duplication
+   * is handled by InviteService, so this is safe to re-run.
+   *
+   * @returns a summary of how many completers were found, skipped, and invited.
+   */
+  async backfillFollowUpInvites(
+    courseId: string,
+    courseVersionId: string,
+  ): Promise<{
+    completed: number;
+    alreadyEnrolled: number;
+    missingEmail: number;
+    invited: number;
+  }> {
+    const courseSettings =
+      await this.getCourseSettingService().readCourseSettings(
+        courseId,
+        courseVersionId,
+      );
+
+    const followUp = courseSettings?.settings?.followUpInvite;
+    if (
+      !followUp ||
+      !followUp.enabled ||
+      !followUp.courseId ||
+      !followUp.courseVersionId
+    ) {
+      throw new BadRequestError(
+        'This course version has no enabled follow-up invite to backfill.',
+      );
+    }
+
+    const targetCourseId = followUp.courseId.toString();
+    const targetVersionId = followUp.courseVersionId.toString();
+    const targetCohortId = followUp.cohortId?.toString();
+    const role = (followUp.role as EnrollmentRole) ?? 'STUDENT';
+
+    const completedUserIds =
+      await this.progressRepository.getCompletedUserIdsForCourseVersion(
+        courseId,
+        courseVersionId,
+      );
+
+    let alreadyEnrolled = 0;
+    let missingEmail = 0;
+    const emailSet = new Set<string>();
+
+    for (const userId of completedUserIds) {
+      // Skip students who are already onboarded to the target course version.
+      const enrollment = await this.enrollmentRepo.findActiveEnrollment(
+        userId,
+        targetCourseId,
+        targetVersionId,
+        targetCohortId,
+      );
+      if (enrollment) {
+        alreadyEnrolled++;
+        continue;
+      }
+
+      const user = await this.userRepo.findById(userId);
+      if (!user?.email) {
+        missingEmail++;
+        continue;
+      }
+      emailSet.add(user.email.toLowerCase().trim());
+    }
+
+    const summary = {
+      completed: completedUserIds.length,
+      alreadyEnrolled,
+      missingEmail,
+      invited: emailSet.size,
+    };
+
+    if (emailSet.size === 0) {
+      return summary;
+    }
+
+    const inviteService = getContainer().get<InviteService>(
+      NOTIFICATIONS_TYPES.InviteService,
+    );
+
+    // InviteService de-dupes pending invites internally, so re-runs are safe.
+    await inviteService.inviteUserToCourse(
+      Array.from(emailSet).map(email => ({email, role})),
+      targetCourseId,
+      targetVersionId,
+      targetCohortId,
+    );
+
+    return summary;
+  }
+
   private validateProgressPosition(
     progress: IProgress,
     moduleId: string,

--- a/backend/src/shared/database/providers/mongo/repositories/InviteRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/InviteRepository.ts
@@ -128,7 +128,7 @@ export class InviteRepository {
     await this.init(); // Ensure collection is initialized
 
     const invites = await this.inviteCollection
-      .find({email}, {session})
+      .find({email: email.toLowerCase().trim()}, {session})
       .toArray();
 
     return invites.map(invite => ({
@@ -146,7 +146,7 @@ export class InviteRepository {
     await this.init();
 
     await this.inviteCollection.updateMany(
-      {email: email, isNewUser: true},
+      {email: email.toLowerCase().trim(), isNewUser: true},
       {$set: {isNewUser: false}},
       {session},
     );
@@ -159,7 +159,7 @@ export class InviteRepository {
     await this.init(); // Ensure collection is initialized
 
     const invites = await this.inviteCollection
-      .find({email, inviteStatus: 'PENDING'}, {session})
+      .find({email: email.toLowerCase().trim(), inviteStatus: 'PENDING'}, {session})
       .toArray();
 
     return invites.map(invite => ({

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -771,6 +771,31 @@ class ProgressRepository {
       currentItem: progress.currentItem?.toString(),
     }));
   }
+  /**
+   * Returns the distinct user IDs that have *completed* a given course version,
+   * across all cohorts. Used to backfill follow-up invites for students who
+   * finished the source course before the follow-up invite was configured.
+   */
+  async getCompletedUserIdsForCourseVersion(
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<string[]> {
+    await this.init();
+    const userIds = await this.progressCollection.distinct(
+      'userId',
+      {
+        courseId: { $in: [new ObjectId(courseId), courseId] },
+        courseVersionId: { $in: [new ObjectId(courseVersionId), courseVersionId] },
+        completed: true,
+      },
+      { session },
+    );
+    return userIds
+      .map((id: unknown) => (id ? id.toString() : ''))
+      .filter((id): id is string => id.length > 0);
+  }
+
   async deleteUserProgressByVersionIds(
     courseVersionIds: ObjectId[],
     session?: ClientSession,

--- a/frontend/src/components/EditProctoringModal.tsx
+++ b/frontend/src/components/EditProctoringModal.tsx
@@ -163,9 +163,13 @@ export function ProctoringModal({
           )
           const followUp = result.settings?.followUpInvite;
           setFollowUpEnabled(followUp?.enabled ?? false)
-          setFollowUpCourseId(followUp?.courseId ? followUp.courseId.toString() : "")
-          setFollowUpVersionId(followUp?.courseVersionId ? followUp.courseVersionId.toString() : "")
-          setFollowUpCohortId(followUp?.cohortId ? followUp.cohortId.toString() : "")
+          // ObjectIds arrive from the API as buffer objects, so normalize them
+          // the same way the dropdown options are (normalizeId/bufferToHex).
+          // Using a raw .toString() here yields "[object Object]", which never
+          // matches a <SelectItem> value, leaving the dropdowns blank on reload.
+          setFollowUpCourseId(normalizeId(followUp?.courseId))
+          setFollowUpVersionId(normalizeId(followUp?.courseVersionId))
+          setFollowUpCohortId(normalizeId(followUp?.cohortId))
         }
       } catch (err) {
         console.error("Failed to fetch proctoring settings:", err)

--- a/frontend/src/components/EditProctoringModal.tsx
+++ b/frontend/src/components/EditProctoringModal.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
-import { useCourseVersionById, useEditProctoringSettings, useGetProcotoringSettings, useUpdateFollowUpInvite, useUserEnrollments } from "@/hooks/hooks"
+import { useBackfillFollowUpInvites, useCourseVersionById, useEditProctoringSettings, useGetProcotoringSettings, useUpdateFollowUpInvite, useUserEnrollments } from "@/hooks/hooks"
 import { bufferToHex } from "@/utils/helpers"
 import { useEffect, useMemo, useState } from "react"
 import { Label } from "./ui/label"
@@ -85,6 +85,7 @@ export function ProctoringModal({
   const { editSettings, loading, error } = useEditProctoringSettings()
   const { getSettings, settingLoading, settingError } = useGetProcotoringSettings();
   const { updateFollowUpInvite, loading: followUpLoading } = useUpdateFollowUpInvite();
+  const { backfillFollowUpInvites, loading: backfillLoading } = useBackfillFollowUpInvites();
 
   const allComponents = Object.values(ProctoringComponent)
   const [detectors, setDetectors] = useState(
@@ -222,6 +223,22 @@ export function ProctoringModal({
     } catch(error: any) {
       // Show the backend's actionable message when available (e.g. cohort prompt).
       toast.error(error?.message || "Failed to update settings!")
+    }
+  }
+
+  // Re-send the follow-up invite to students who already completed this course
+  // before the invite was configured. Uses the *saved* follow-up config, so the
+  // instructor should save any pending changes first.
+  const handleBackfill = async () => {
+    try {
+      const summary = await backfillFollowUpInvites(courseId, courseVersionId)
+      const skipped = summary.alreadyEnrolled + summary.missingEmail
+      toast.success(
+        `Invited ${summary.invited} past completer${summary.invited === 1 ? "" : "s"}.` +
+          (skipped > 0 ? ` Skipped ${skipped} (already enrolled or no email).` : ""),
+      )
+    } catch (error: any) {
+      toast.error(error?.message || "Failed to send invites to past completers.")
     }
   }
 
@@ -495,6 +512,32 @@ export function ProctoringModal({
                                 ))}
                               </SelectContent>
                             </Select>
+                          </div>
+                        )}
+
+                        {/* Backfill: invite students who already completed this
+                            course before the follow-up invite was configured. */}
+                        {!isNew && (
+                          <div className="space-y-1 pt-1">
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              size="sm"
+                              className="w-full"
+                              disabled={backfillLoading}
+                              onClick={handleBackfill}
+                            >
+                              {backfillLoading ? (
+                                <>
+                                  <Loader2 className="h-3 w-3 animate-spin" /> Sending invites…
+                                </>
+                              ) : (
+                                "Invite past completers"
+                              )}
+                            </Button>
+                            <p className="text-xs text-muted-foreground">
+                              Sends the saved follow-up invite to students who already finished this course and aren't enrolled yet. Save any changes first.
+                            </p>
                           </div>
                         )}
                       </div>

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -2251,6 +2251,55 @@ export function useUpdateFollowUpInvite() {
   return { updateFollowUpInvite, loading, error };
 }
 
+// POST /setting/course-setting/{courseId}/{versionId}/follow-up-invite/backfill
+// Re-sends the configured follow-up invite to every student who already
+// completed this (source) course version but isn't yet enrolled in the target
+// course — e.g. students who finished before the follow-up invite was set up.
+export function useBackfillFollowUpInvites() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const backfillFollowUpInvites = async (
+    courseId: string,
+    versionId: string,
+  ): Promise<{
+    completed: number;
+    alreadyEnrolled: number;
+    missingEmail: number;
+    invited: number;
+  }> => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/setting/course-setting/${courseId}/${versionId}/follow-up-invite/backfill`;
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        throw new Error(data?.message || `Failed to backfill follow-up invites: ${res.status}`);
+      }
+
+      return data;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { backfillFollowUpInvites, loading, error };
+}
+
 // Accept (or reject) a course invite from within the app. Hits the local
 // backend accept endpoint (the backend-provided acceptUrl points at APP_URL,
 // which may be a different/staging host, so we build it from our own base).


### PR DESCRIPTION
Fix: student not receiving course invite notification (case-sensitive email match)

Students with a mixed-case account email (e.g. Shubhdixit@jklu.edu.in) never saw their course invites in notifications. Invites are stored with a lowercased email, but the pending-invite lookups queried using the account email as-stored, so the match failed.

Normalizes the email with .toLowerCase().trim() in findPendingInvitesByEmail, findInvitesByEmail, and updateUserToNotNewUser so invites surface regardless of email casing.

No re-invite needed — existing invites now match once deployed.
No email behavior changed (sending stays disabled, as intended).