### PR TITLE
fix: resolve course linear progression and payload validation errors

### DIFF
--- a/frontend/src/app/pages/student/components/FeedbackForm.tsx
+++ b/frontend/src/app/pages/student/components/FeedbackForm.tsx
@@ -88,7 +88,7 @@ const FeedbackForm = ({
           itemId: currentCourse.itemId,
           moduleId: currentCourse.moduleId ?? '',
           sectionId: currentCourse.sectionId ?? '',
-          cohortId: currentCourse.cohortId ?? '',
+          cohortId: currentCourse.cohortId || undefined,
         }
       });
     }
@@ -129,7 +129,7 @@ const FeedbackForm = ({
       courseId: currentCourse?.courseId || "",
       courseVersionId: currentCourse?.versionId || "",
       // isSkipped: false,
-      cohortId: currentCourse?.cohortId ?? '',
+      cohortId: currentCourse?.cohortId || undefined,
     };
 
 
@@ -152,7 +152,7 @@ const FeedbackForm = ({
             itemId: currentCourse!.itemId ?? "",
             moduleId: currentCourse!.moduleId ?? "",
             sectionId: currentCourse!.sectionId ?? "",
-            cohortId: currentCourse!.cohortId ?? '',
+            cohortId: currentCourse!.cohortId || undefined,
           },
         });
       }
@@ -182,7 +182,7 @@ const FeedbackForm = ({
         itemId: currentCourse!.itemId ?? '',
         moduleId: currentCourse!.moduleId ?? '',
         sectionId: currentCourse!.sectionId ?? '',
-        cohortId: currentCourse!.cohortId ?? '',
+        cohortId: currentCourse!.cohortId || undefined,
       }
     });
     onNext()

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -212,7 +212,8 @@ export default function CoursePage() {
         sectionId,
         itemId,
         cohortId: COHORT_ID,
-        cohortName: COHORT_NAME
+        cohortName: COHORT_NAME,
+        watchItemId: null
       });
     }
   }, [setCurrentCourse]);

--- a/frontend/src/components/Item-container.tsx
+++ b/frontend/src/components/Item-container.tsx
@@ -48,6 +48,7 @@ const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, 
     switch (itemType) {
       case 'video':
         return <Video
+          key={item._id.toString()}
           URL={item.details?.URL ? item.details.URL : ''}
           startTime={item.details?.startTime ? item.details.startTime : ''}
           endTime={item.details?.endTime ? item.details.endTime : ''}
@@ -72,6 +73,7 @@ const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, 
 
       case 'quiz':
         return <Quiz
+          key={item._id.toString()}
           ref={quizRef}
           questionBankRefs={item.details?.questionBankRefs || []}
           passThreshold={item.details?.passThreshold || 0}
@@ -110,6 +112,7 @@ const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, 
       case 'article':
       case 'blog':
         return <Article
+          key={item._id.toString()}
           ref={articleRef}
           content={item.details?.content || ''}
           estimatedReadTimeInMinutes={item.details?.estimatedReadTimeInMinutes || ''}
@@ -123,6 +126,7 @@ const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, 
 
       case 'project':
         return <ProjectItem
+          key={item._id.toString()}
           item={{
             _id: item._id,
             name: item.name,
@@ -137,6 +141,7 @@ const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, 
         />;
       case 'feedback':
         return <FeedbackForm
+          key={item._id.toString()}
           title={item.name}
           description={item.description}
           isOptional={item.isOptional}
@@ -148,7 +153,7 @@ const ItemContainer = forwardRef<ItemContainerRef, ItemContainerProps>(({ item, 
           isAlreadyWatched={item.isAlreadyWatched || false}
           completedItemIdsRef={completedItemIdsRef}
           previousItem = {previousItem}
-        />
+        />;
 
       default:
         return (

--- a/frontend/src/components/article.tsx
+++ b/frontend/src/components/article.tsx
@@ -100,7 +100,7 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
                     itemId: currentCourse.itemId,
                     moduleId: currentCourse.moduleId ?? '',
                     sectionId: currentCourse.sectionId ?? '',
-                    cohortId: currentCourse.cohortId ?? '',
+                    cohortId: currentCourse.cohortId || undefined,
                 }
             });
         }
@@ -123,7 +123,7 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
                         itemId: currentCourse.itemId,
                         moduleId: currentCourse.moduleId ?? '',
                         sectionId: currentCourse.sectionId ?? '',
-                        cohortId: currentCourse.cohortId ?? '',
+                        cohortId: currentCourse.cohortId || undefined,
                     }
                 });
             }
@@ -187,7 +187,7 @@ const Article = forwardRef<ArticleRef, ArticleProps>(({ content, estimatedReadTi
                 body: {
                     watchItemId: currentCourse.watchItemId!,
                     itemId: currentCourse.itemId!,
-                    cohortId: currentCourse.cohortId ?? undefined,
+                    cohortId: currentCourse.cohortId || undefined,
                 }
             } as any);
         }, 15000); // every 15 seconds

--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -391,7 +391,7 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
                 sectionId: currentCourse!.sectionId ?? '',
                 seekForwardEnabled,
                 nextItemId,
-                cohortId: currentCourse!.cohortId ?? '',
+                cohortId: currentCourse!.cohortId || undefined,
               },
             });
           }
@@ -598,7 +598,7 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
           itemId: currentCourse.itemId,
           moduleId: currentCourse.moduleId ?? '',
           sectionId: currentCourse.sectionId ?? '',
-          cohortId: currentCourse.cohortId ?? '',
+          cohortId: currentCourse.cohortId || undefined,
         }
       });
     }
@@ -621,7 +621,7 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
         body: {
           watchItemId: watchItemIdRef.current!,
           itemId: currentCourse?.itemId!,
-          cohortId: currentCourse?.cohortId ?? undefined,
+          cohortId: currentCourse?.cohortId || undefined,
         }
       } as any);
     }, 15000); // every 15 seconds


### PR DESCRIPTION
# PR Title
`fix: resolve linear course progression locks and watch time validation failures`

## Description
This Pull Request resolves a critical bug where students enrolled in courses with linear progression enabled would encounter a "Lesson Locked" notification even after fully completing a lesson (video, article, quiz, or feedback form). It also fixes the recurring `400 Bad Request` validation errors on the tracking payload caused by empty `cohortId` strings.

## Root Cause Analysis
1. **Lesson Locked (Stale Tracking State):** 
   When a student transitioned between items of the same type (e.g., from one Video to another Video), React's default reconciliation engine reused the same component instance. Because of this, internal lifecycle refs (`itemStartedRef`, `startRequestSentRef`) and event listeners did not reset, preventing tracking from re-initiating for the new lesson and leaving the student locked out of the next lesson.
2. **Payload Validation Errors (`400 Bad Request`):** 
   When a student is not enrolled in a cohort, the frontend used nullish coalescing (`cohortId ?? ''`) to send `cohortId: ""` in the watch-time update payload. The backend schema strictly validates `cohortId` with `@IsMongoId()`, which fails on empty strings.

---

## Key Changes

### 1. Component Reset via Unique Keys
* **File modified:** [Item-container.tsx](file:///d:/programm3d/vibe/frontend/src/components/Item-container.tsx)
* **Change:** Added a unique `key={item._id.toString()}` to dynamic lesson components (`Video`, `Quiz`, `Article`, `ProjectItem`, and `FeedbackForm`).
* **Impact:** Forces React to completely unmount the previous component and mount a clean instance upon navigation, resetting all tracking refs and re-initializing the tracking lifecycle correctly.

### 2. State Isolation on Navigation
* **File modified:** [course-page.tsx](file:///d:/programm3d/vibe/frontend/src/app/pages/student/course-page.tsx)
* **Change:** Set `watchItemId: null` during course navigation transitions.
* **Impact:** Prevents stale watch-time tracking identifiers from leaking across lessons.

### 3. Payload Cohort ID Sanitation
* **Files modified:** 
  * [article.tsx](file:///d:/programm3d/vibe/frontend/src/components/article.tsx)
  * [video.tsx](file:///d:/programm3d/vibe/frontend/src/components/video.tsx)
  * [FeedbackForm.tsx](file:///d:/programm3d/vibe/frontend/src/app/pages/student/components/FeedbackForm.tsx)
* **Change:** Replaced `cohortId ?? ''` / `cohortId ?? undefined` with logical OR `cohortId || undefined`.
* **Impact:** Empty string/falsy values are converted to `undefined`, which gets stripped out during `JSON.stringify` serialization. This ensures the key is omitted entirely from the payload (satisfying the backend `@IsOptional()` rule) rather than being sent as an invalid empty string.

---

## Verification & Testing
* **Compilation:** Executed `npm run compile` to run TypeScript compiler verification. The frontend builds cleanly with zero errors or warnings.
* **Tracking Workflow:** 
  - Verified that the `startItem` api endpoint is triggered successfully with unique `watchItemId`s on consecutive same-type lesson transitions.
  - Verified that the backend no longer logs `400 Bad Request` validation errors for students outside of cohort configurations.