### PR TITLE
fix: re-fetch user after googleSignup in getCurrentUserFromToken

### DIFF
--- a/backend/src/modules/auth/services/FirebaseAuthService.ts
+++ b/backend/src/modules/auth/services/FirebaseAuthService.ts
@@ -78,7 +78,7 @@ export class FirebaseAuthService extends BaseService implements IAuthService {
     const decodedToken = await this.auth.verifyIdToken(token);
     const firebaseUID = decodedToken.uid;
     // Retrieve the user from our database using the Firebase UID
-    const user = await this.userRepository.findByFirebaseUID(firebaseUID);
+    let user = await this.userRepository.findByFirebaseUID(firebaseUID);
     if (!user) {
       // get user data from Firebase
       try {
@@ -92,8 +92,9 @@ export class FirebaseAuthService extends BaseService implements IAuthService {
           firstName: firebaseUser.displayName?.split(' ')[0] || '',
           lastName: firebaseUser.displayName?.split(' ')[1] || '',
         };
-        const createdUser = await this.googleSignup(userData, token);
-        if (!createdUser) {
+        await this.googleSignup(userData, token);
+        user = await this.userRepository.findByFirebaseUID(firebaseUID);
+        if (!user) {
           throw new InternalServerError('Failed to create the user');
         }
       } catch (error) {


### PR DESCRIPTION
When a new user logs in and no database record is found, getCurrentUserFromToken calls googleSignup to create one. Previously the user variable was never updated after signup, causing a null reference crash on user._id. Fixed by changing const user to let user and re-fetching after googleSignup completes. This also reduces the chance of duplicate user documents being created from request retries caused by the crash.