### PR TITLE
Fix/announcement formatting and xss

### DIFF
--- a/frontend/src/components/announcements/AnnouncementItem.tsx
+++ b/frontend/src/components/announcements/AnnouncementItem.tsx
@@ -115,7 +115,7 @@ export function AnnouncementItem({ announcement, isInstructor, isAdmin, onEdit, 
             </CardHeader>
 
             <CardContent className="pb-3 text-sm leading-relaxed whitespace-pre-line text-muted-foreground/90">
-                <div dangerouslySetInnerHTML={{ __html: announcement.content }} />
+                <div>{announcement.content}</div>
             </CardContent>
 
             {announcement.attachments && announcement.attachments.length > 0 && (

--- a/frontend/src/components/announcements/NewAnnouncementsPopup.tsx
+++ b/frontend/src/components/announcements/NewAnnouncementsPopup.tsx
@@ -84,10 +84,9 @@ export function NewAnnouncementsPopup() {
                   </Badge>
                 )}
               </div>
-              <div
-                className="text-sm text-muted-foreground prose prose-sm max-w-none dark:prose-invert"
-                dangerouslySetInnerHTML={{ __html: a.content }}
-              />
+              <div className="text-sm leading-relaxed whitespace-pre-line text-muted-foreground">
+                {a.content}
+              </div>
               <p className="text-[11px] text-muted-foreground/70">
                 {a.instructorName ? `${a.instructorName} · ` : ""}
                 {new Date(a.createdAt).toLocaleString()}


### PR DESCRIPTION
The new-announcement popup styled bodies with prose (white-space: normal), collapsing authored newlines into one block. Switched to whitespace-pre-line to match the working list view, so formatting is preserved. Also replaced dangerouslySetInnerHTML with plain-text rendering in both display components — bodies are plain text from a textarea, so raw HTML was an unnecessary XSS vector; output is visually identical.