### PR TITLE
fix: replace ref dependency with state in upsert watch time useEffect…

### DIFF
--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -612,10 +612,9 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
     }
   }, [startItem.data?.watchItemId, setWatchItemId]);
 
-  // ✅ Call upsert watch time API every 10 seconds while video is playing
+ // ✅ Call upsert watch time API every 15 seconds while video is playing
   useEffect(() => {
-    if (!watchItemIdRef.current) return;
-
+    if (!startItem.data?.watchItemId || !playing) return;
     const interval = setInterval(() => {
       upsertWatchTime.mutate({
         body: {
@@ -625,9 +624,8 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
         }
       } as any);
     }, 15000); // every 15 seconds
-
     return () => clearInterval(interval); // cleanup on unmount
-  }, [watchItemIdRef.current]);
+  }, [startItem.data?.watchItemId, playing]);
 
 
   const forceHighestQuality = (player: YTPlayerInstance) => {


### PR DESCRIPTION
Replaced watchItemIdRef.current in the dependency array with 
  startItem.data?.watchItemId which is actual React state
- Added playing guard so interval only fires while video is actively playing
- Interval now correctly fires once every 15 seconds and cleans up 
  on pause, navigation, and unmount