### PR TITLE
Fix/follow up invite cohort backfill

### DIFF
--- a/backend/src/modules/setting/controllers/CourseSettingController.ts
+++ b/backend/src/modules/setting/controllers/CourseSettingController.ts
@@ -228,6 +228,7 @@ export class CourseSettingController {
   ): Promise<{
     completed: number;
     alreadyEnrolled: number;
+    alreadyInvited: number;
     missingEmail: number;
     invited: number;
   }> {

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -49,6 +49,7 @@ import { CourseSettingService } from '#root/modules/setting/index.js';
 import { getContainer } from '#root/bootstrap/loadModules.js';
 import { NOTIFICATIONS_TYPES } from '#root/modules/notifications/types.js';
 import type { InviteService } from '#root/modules/notifications/services/InviteService.js';
+import type { InviteRepository } from '#shared/database/providers/mongo/repositories/InviteRepository.js';
 
 const GURU_SETU_COURSE_ID = '6981df886e100cfe04f9c4ad';
 const GURU_SETU_VERSION_ID = '6981df886e100cfe04f9c4ae';
@@ -2676,6 +2677,7 @@ class ProgressService extends BaseService {
   ): Promise<{
     completed: number;
     alreadyEnrolled: number;
+    alreadyInvited: number;
     missingEmail: number;
     invited: number;
   }> {
@@ -2713,16 +2715,25 @@ class ProgressService extends BaseService {
       );
 
     let alreadyEnrolled = 0;
+    let alreadyInvited = 0;
     let missingEmail = 0;
     const emailSet = new Set<string>();
 
+    const inviteRepo = getContainer().get<InviteRepository>(
+      NOTIFICATIONS_TYPES.InviteRepo,
+    );
+
     for (const userId of completedUserIds) {
       // Skip students who are already onboarded to the target course version.
+      // COHORT-AGNOSTIC on purpose: anyone already actively enrolled in the target
+      // course must not be re-invited, no matter which cohort they're in (or if the
+      // configured follow-up cohort no longer exists). Passing the configured cohort
+      // here is what re-invited already-enrolled learners when that cohort had been
+      // deleted and their live enrollment was cohortless.
       const enrollment = await this.enrollmentRepo.findActiveEnrollment(
         userId,
         targetCourseId,
         targetVersionId,
-        targetCohortId,
       );
       if (enrollment) {
         alreadyEnrolled++;
@@ -2734,12 +2745,29 @@ class ProgressService extends BaseService {
         missingEmail++;
         continue;
       }
-      emailSet.add(user.email.toLowerCase().trim());
+      const normalizedEmail = user.email.toLowerCase().trim();
+
+      // Skip students who were already invited to the target course — a
+      // still-pending invite or one they already accepted. Cohort-agnostic for the
+      // same reason as the enrollment check above: a duplicate invite to the same
+      // course must never be created just because the configured cohort differs.
+      const existingInvite = await inviteRepo.findActiveInviteByEmailAndCourse(
+        normalizedEmail,
+        targetCourseId,
+        targetVersionId,
+      );
+      if (existingInvite) {
+        alreadyInvited++;
+        continue;
+      }
+
+      emailSet.add(normalizedEmail);
     }
 
     const summary = {
       completed: completedUserIds.length,
       alreadyEnrolled,
+      alreadyInvited,
       missingEmail,
       invited: emailSet.size,
     };

--- a/backend/src/shared/database/providers/mongo/repositories/InviteRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/InviteRepository.ts
@@ -200,6 +200,45 @@ export class InviteRepository {
     };
   }
 
+  // Returns an existing "blocking" invite for this email + course version: one
+  // that is still PENDING (awaiting action) or already ACCEPTED. Used by the
+  // follow-up backfill so a learner who was already invited — and especially one
+  // who already accepted — is never sent a duplicate. EXPIRED/REJECTED/CANCELLED
+  // are intentionally NOT blocking, so a genuine re-nudge is still possible.
+  //
+  // Deliberately COHORT-AGNOSTIC (unlike findPendingInviteByEmailAndCourse): a
+  // learner already invited to the target course must not be re-invited
+  // regardless of which cohort that invite was for. Scoping the check to a
+  // specific cohort is what let the backfill create duplicate invites when the
+  // configured follow-up cohort differed from the learner's existing one.
+  async findActiveInviteByEmailAndCourse(
+    email: string,
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<Invite | null> {
+    await this.init();
+
+    const invite = await this.inviteCollection.findOne(
+      {
+        email: email.toLowerCase(),
+        courseId: new ObjectId(courseId),
+        courseVersionId: new ObjectId(courseVersionId),
+        inviteStatus: {$in: ['PENDING', 'ACCEPTED']},
+      },
+      {session},
+    );
+
+    if (!invite) return null;
+
+    return {
+      ...invite,
+      _id: invite._id.toString(),
+      courseId: invite.courseId?.toString(),
+      courseVersionId: invite.courseVersionId?.toString(),
+    };
+  }
+
   async findInvitesByCourse(
     courseId: string,
     courseVersionId: string,

--- a/frontend/src/components/EditProctoringModal.tsx
+++ b/frontend/src/components/EditProctoringModal.tsx
@@ -232,10 +232,13 @@ export function ProctoringModal({
   const handleBackfill = async () => {
     try {
       const summary = await backfillFollowUpInvites(courseId, courseVersionId)
-      const skipped = summary.alreadyEnrolled + summary.missingEmail
+      const skipped =
+        summary.alreadyEnrolled + summary.alreadyInvited + summary.missingEmail
       toast.success(
         `Invited ${summary.invited} past completer${summary.invited === 1 ? "" : "s"}.` +
-          (skipped > 0 ? ` Skipped ${skipped} (already enrolled or no email).` : ""),
+          (skipped > 0
+            ? ` Skipped ${skipped} (already enrolled, already invited, or no email).`
+            : ""),
       )
     } catch (error: any) {
       toast.error(error?.message || "Failed to send invites to past completers.")

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -2265,6 +2265,7 @@ export function useBackfillFollowUpInvites() {
   ): Promise<{
     completed: number;
     alreadyEnrolled: number;
+    alreadyInvited: number;
     missingEmail: number;
     invited: number;
   }> => {


### PR DESCRIPTION
"Invite past completers" re-invited learners **already enrolled** in the target course. `backfillFollowUpInvites` scopes its "already enrolled?" check to the configured follow-up cohort (`findActiveEnrollment(userId, targetCourseId, targetVersionId, targetCohortId)`). When that cohort differs from a learner's actual (cohortless) enrollment — or has been **deleted** — the check misses them and creates duplicate invites/enrollments into a stale cohort. Still present on `main` after #1063.

## Fix (3 sequenced commits)
1. Add `InviteRepository.findActiveInviteByEmailAndCourse` — cohort-agnostic active-invite (PENDING/ACCEPTED) lookup.
2. Backfill enrollment + invite checks ignore the configured cohort (enrolled in the target course at all ⇒ skip); track/report `alreadyInvited`.
3. Surface `alreadyInvited` in the hook return type and the modal's "skipped" toast.

## Notes
- Backend `tsc --noEmit` passes.
- The production data already affected was remediated operationally (out of scope for this PR).