### PR TITLE
 In-Page Face Registration & Proctoring Stability Fixes

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,8 +25,6 @@ const globalRateLimiter = createRateLimiter();
 
 // app.use(globalRateLimiter);
 app.use(loggingHandler);
-app.use(express.json({ limit: '10mb' }));
-app.use(express.urlencoded({ limit: '10mb', extended: true }));
 
 app.set('trust proxy', 1);
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,6 +25,8 @@ const globalRateLimiter = createRateLimiter();
 
 // app.use(globalRateLimiter);
 app.use(loggingHandler);
+app.use(express.json({ limit: '10mb' }));
+app.use(express.urlencoded({ limit: '10mb', extended: true }));
 
 app.set('trust proxy', 1);
 

--- a/backend/src/modules/auth/controllers/AuthController.ts
+++ b/backend/src/modules/auth/controllers/AuthController.ts
@@ -61,7 +61,7 @@ export class AuthController {
     description: 'Auth Error',
     statusCode: 401,
   })
-  async signup(@Body() body: SignUpBody, @Req() req: any) {
+  async signup(@Body({ options: { limit: '10mb' } }) body: SignUpBody, @Req() req: any) {
     const { recaptchaToken, ...signUpData } = body;
 
     // Verify reCAPTCHA token
@@ -109,7 +109,7 @@ export class AuthController {
     description: 'Auth Error',
     statusCode: 401,
   })
-  async googleSignup(@Body() body: GoogleSignUpBody, @Req() req: any) {
+  async googleSignup(@Body({ options: { limit: '10mb' } }) body: GoogleSignUpBody, @Req() req: any) {
     const acknowledgedInvites = await this.authService.googleSignup(
       body,
       req.headers.authorization?.split(' ')[1],

--- a/backend/src/modules/users/controllers/UserController.ts
+++ b/backend/src/modules/users/controllers/UserController.ts
@@ -158,7 +158,7 @@ export class UserController {
   @OnUndefined(200)
   async updateCurrentUserFaceReference(
     @Req() req: any,
-    @Body() body: UpdateFaceReferenceBody,
+    @Body({ options: { limit: '10mb' } }) body: UpdateFaceReferenceBody,
   ): Promise<void> {
     const token = req.headers.authorization?.split(' ')[1];
     const user = await this.authService.getCurrentUserFromToken(token);

--- a/frontend/src/components/ai/FaceDetectors.tsx
+++ b/frontend/src/components/ai/FaceDetectors.tsx
@@ -46,7 +46,7 @@ const isLookingAway = (face: Face): boolean => {
   return false;
 };
 
-const FaceDetectors: React.FC<FaceDetectorsProps> = ({ setIsFocused, faces, videoRef, onRecognitionResult, onDebugInfoUpdate, onMismatchChange, settings }) => {
+const FaceDetectors: React.FC<FaceDetectorsProps> = ({ setIsFocused, faces, videoRef, onRecognitionResult, onDebugInfoUpdate, onMismatchChange, onMissingEmbedding, settings }) => {
 
   useEffect(() => {
     const isFocused = true;
@@ -73,6 +73,7 @@ const FaceDetectors: React.FC<FaceDetectorsProps> = ({ setIsFocused, faces, vide
           onRecognitionResult={onRecognitionResult}
           onDebugInfoUpdate={onDebugInfoUpdate}
           onMismatchChange={onMismatchChange}
+          onMissingEmbedding={onMissingEmbedding}
           enabled={settings.isFaceRecognitionEnabled}
         />
       )}

--- a/frontend/src/components/ai/FaceRecognitionComponent.tsx
+++ b/frontend/src/components/ai/FaceRecognitionComponent.tsx
@@ -51,6 +51,7 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
   onRecognitionResult,
   onDebugInfoUpdate,
   onMismatchChange,
+  onMissingEmbedding,
   enabled = true,
 }) => {
   const [isReady, setIsReady] = useState(false);
@@ -202,14 +203,18 @@ const FaceRecognitionComponent: React.FC<FaceRecognitionComponentProps> = ({
         const normalizedEmbedding = normalizeEmbedding(reference.faceEmbedding);
 
         if (!normalizedEmbedding || normalizedEmbedding.length !== EMBEDDING_LENGTH) {
-          if (!missingEmbeddingRedirectedRef.current) {
-            missingEmbeddingRedirectedRef.current = true;
-            const redirectTo = typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/';
-            toast.error('This course requires a face photo. Please add one to continue.');
-            navigate({
-              to: '/auth',
-              search: { completeFace: '1', redirect: redirectTo } as any,
-            });
+          if (onMissingEmbedding) {
+            onMissingEmbedding();
+          } else {
+            if (!missingEmbeddingRedirectedRef.current) {
+              missingEmbeddingRedirectedRef.current = true;
+              const redirectTo = typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/';
+              toast.error('This course requires a face photo. Please add one to continue.');
+              navigate({
+                to: '/auth',
+                search: { completeFace: '1', redirect: redirectTo } as any,
+              });
+            }
           }
           return;
         }

--- a/frontend/src/components/ai/FaceRegistrationModal.tsx
+++ b/frontend/src/components/ai/FaceRegistrationModal.tsx
@@ -82,6 +82,16 @@ export const FaceRegistrationModal: React.FC<FaceRegistrationModalProps> = ({
     }
   };
 
+  const handleRetake = () => {
+    setStudentPhotoPreview("");
+    setStudentPhotoFile(null);
+    setCameraError("");
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+    void openCamera();
+  };
+
   const openCamera = async () => {
     try {
       setCameraError("");
@@ -366,7 +376,7 @@ export const FaceRegistrationModal: React.FC<FaceRegistrationModalProps> = ({
                     type="button"
                     variant="outline"
                     className="flex-1"
-                    onClick={openCamera}
+                    onClick={handleRetake}
                   >
                     <RefreshCcw className="mr-2 h-4 w-4" />
                     Retake

--- a/frontend/src/components/ai/FaceRegistrationModal.tsx
+++ b/frontend/src/components/ai/FaceRegistrationModal.tsx
@@ -1,0 +1,416 @@
+import React, { useState, useEffect, useRef, type ChangeEvent } from "react";
+import * as faceapi from "@vladmandic/face-api";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Camera, Upload, RefreshCcw, X, AlertCircle } from "lucide-react";
+import { toast } from "sonner";
+
+interface FaceRegistrationModalProps {
+  isOpen: boolean;
+  onSuccess: () => void;
+  onClose: () => void;
+}
+
+const EMBEDDING_LENGTH = 128;
+
+export const FaceRegistrationModal: React.FC<FaceRegistrationModalProps> = ({
+  isOpen,
+  onSuccess,
+  onClose,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [studentPhotoPreview, setStudentPhotoPreview] = useState<string>("");
+  const [studentPhotoFile, setStudentPhotoFile] = useState<File | null>(null);
+  const [isCameraOpen, setIsCameraOpen] = useState(false);
+  const [cameraError, setCameraError] = useState("");
+
+  const videoCaptureRef = useRef<HTMLVideoElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const faceModelsLoadedRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      stopCameraStream();
+      if (studentPhotoPreview && studentPhotoPreview.startsWith("blob:")) {
+        URL.revokeObjectURL(studentPhotoPreview);
+      }
+    };
+  }, [studentPhotoPreview]);
+
+  useEffect(() => {
+    if (!isCameraOpen || !mediaStreamRef.current || !videoCaptureRef.current) {
+      return;
+    }
+
+    const videoElement = videoCaptureRef.current;
+    videoElement.srcObject = mediaStreamRef.current;
+
+    const handleLoadedMetadata = () => {
+      void videoElement.play().catch((error) => {
+        console.error("[FaceRegistrationModal] Unable to start camera preview", error);
+        setCameraError("Camera opened, but preview could not start. Please try again.");
+      });
+    };
+
+    videoElement.addEventListener("loadedmetadata", handleLoadedMetadata);
+
+    if (videoElement.readyState >= 1) {
+      handleLoadedMetadata();
+    }
+
+    return () => {
+      videoElement.removeEventListener("loadedmetadata", handleLoadedMetadata);
+    };
+  }, [isCameraOpen]);
+
+  const stopCameraStream = () => {
+    if (mediaStreamRef.current) {
+      mediaStreamRef.current.getTracks().forEach((track) => track.stop());
+      mediaStreamRef.current = null;
+    }
+  };
+
+  const resetStudentPhoto = () => {
+    setStudentPhotoPreview("");
+    setStudentPhotoFile(null);
+    setCameraError("");
+    setIsCameraOpen(false);
+    stopCameraStream();
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const openCamera = async () => {
+    try {
+      setCameraError("");
+      stopCameraStream();
+
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: {
+          facingMode: "user",
+          width: { ideal: 640 },
+          height: { ideal: 480 },
+        },
+      });
+
+      mediaStreamRef.current = stream;
+      setIsCameraOpen(true);
+    } catch (error) {
+      console.error("[FaceRegistrationModal] Unable to access camera", error);
+      setCameraError("Camera access was blocked or unavailable. You can upload a photo instead.");
+      setIsCameraOpen(false);
+      stopCameraStream();
+    }
+  };
+
+  const capturePhoto = () => {
+    const videoElement = videoCaptureRef.current;
+    if (!videoElement || videoElement.videoWidth === 0 || videoElement.videoHeight === 0) {
+      setCameraError("Camera is not ready yet. Please try again.");
+      return;
+    }
+
+    const canvas = document.createElement("canvas");
+    canvas.width = videoElement.videoWidth;
+    canvas.height = videoElement.videoHeight;
+
+    const context = canvas.getContext("2d");
+    if (!context) {
+      setCameraError("Could not capture the image. Please try again.");
+      return;
+    }
+
+    context.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
+    const previewDataUrl = canvas.toDataURL("image/jpeg", 0.92);
+    setStudentPhotoPreview(previewDataUrl);
+
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        setCameraError("Could not save the captured image. Please try again.");
+        return;
+      }
+
+      const capturedFile = new File([blob], `student-photo-${Date.now()}.jpg`, {
+        type: "image/jpeg",
+      });
+
+      setStudentPhotoFile(capturedFile);
+      setIsCameraOpen(false);
+      stopCameraStream();
+    }, "image/jpeg", 0.92);
+  };
+
+  const handleStudentPhotoUpload = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith("image/")) {
+      setCameraError("Please choose a valid image file.");
+      return;
+    }
+
+    setCameraError("");
+    setStudentPhotoFile(file);
+    setStudentPhotoPreview(URL.createObjectURL(file));
+    setIsCameraOpen(false);
+    stopCameraStream();
+  };
+
+  const convertFileToDataUrl = (file: File) =>
+    new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result || ""));
+      reader.onerror = () => reject(new Error("Failed to read the selected image."));
+      reader.readAsDataURL(file);
+    });
+
+  const ensureFaceModelsLoaded = async () => {
+    if (faceModelsLoadedRef.current) {
+      return;
+    }
+
+    const modelPaths = [
+      "/models",
+      "https://cdn.jsdelivr.net/npm/@vladmandic/face-api/model",
+    ];
+
+    let lastError: unknown = null;
+    for (const modelPath of modelPaths) {
+      try {
+        await Promise.all([
+          faceapi.nets.tinyFaceDetector.loadFromUri(modelPath),
+          faceapi.nets.faceLandmark68Net.loadFromUri(modelPath),
+          faceapi.nets.faceRecognitionNet.loadFromUri(modelPath),
+        ]);
+        faceModelsLoadedRef.current = true;
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw new Error(`Unable to load face models: ${String(lastError)}`);
+  };
+
+  const createImageElementFromFile = (file: File) =>
+    new Promise<HTMLImageElement>((resolve, reject) => {
+      const objectUrl = URL.createObjectURL(file);
+      const image = new Image();
+
+      image.onload = () => {
+        URL.revokeObjectURL(objectUrl);
+        resolve(image);
+      };
+      image.onerror = () => {
+        URL.revokeObjectURL(objectUrl);
+        reject(new Error("Could not read the selected face image."));
+      };
+      image.src = objectUrl;
+    });
+
+  const generateFaceEmbedding = async (file: File) => {
+    await ensureFaceModelsLoaded();
+    const image = await createImageElementFromFile(file);
+    const detection = await faceapi
+      .detectSingleFace(image, new faceapi.TinyFaceDetectorOptions())
+      .withFaceLandmarks()
+      .withFaceDescriptor();
+
+    if (!detection?.descriptor) {
+      throw new Error("Could not detect a clear face in the selected photo. Please try another image.");
+    }
+
+    return Array.from(detection.descriptor);
+  };
+
+  const saveFaceReference = async () => {
+    if (!studentPhotoFile) {
+      setCameraError("Please capture or upload a clear face photo to continue.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setCameraError("");
+
+      const profileImage = await convertFileToDataUrl(studentPhotoFile);
+      const faceEmbedding = await generateFaceEmbedding(studentPhotoFile);
+
+      if (!faceEmbedding || faceEmbedding.length !== EMBEDDING_LENGTH) {
+        throw new Error("Face embedding generation failed. Try another image.");
+      }
+
+      const authToken = localStorage.getItem("firebase-auth-token");
+      if (!authToken) {
+        throw new Error("No authentication token found. Please sign in again.");
+      }
+
+      const response = await fetch(
+        `${import.meta.env.VITE_BASE_URL}/users/me/face-reference`,
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ profileImage, faceEmbedding }),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to save face photo (status ${response.status})`);
+      }
+
+      toast.success("Face registration completed successfully.");
+      resetStudentPhoto();
+      onSuccess();
+    } catch (error: any) {
+      console.error("[FaceRegistrationModal] Failed to save face reference", error);
+      setCameraError(error?.message || "Unable to save your face photo. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[999999] flex items-center justify-center bg-black/75 p-4 backdrop-blur-sm">
+      <Card className="w-full max-w-lg border border-border/60 bg-background shadow-2xl">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-xl font-bold flex items-center gap-2">
+              <Camera className="h-5 w-5 text-primary" />
+              Face Photo Required
+            </CardTitle>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 rounded-full"
+              onClick={onClose}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <CardDescription>
+            This course has face recognition proctoring enabled. Please take a webcam photo or upload an image to confirm your identity.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-3 rounded-xl border border-border/60 bg-muted/20 p-4">
+            {!studentPhotoPreview ? (
+              <div className="space-y-3">
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Button type="button" className="flex-1" onClick={openCamera}>
+                    <Camera className="mr-2 h-4 w-4" />
+                    Use Webcam
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="flex-1"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <Upload className="mr-2 h-4 w-4" />
+                    Upload Photo
+                  </Button>
+                </div>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={handleStudentPhotoUpload}
+                />
+                {isCameraOpen && (
+                  <div className="space-y-3 rounded-lg border border-border p-3">
+                    <video
+                      ref={videoCaptureRef}
+                      autoPlay
+                      muted
+                      playsInline
+                      className="h-56 w-full rounded-lg bg-slate-950 object-cover"
+                      style={{ transform: "scaleX(-1)" }}
+                    />
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <Button type="button" className="flex-1" onClick={capturePhoto}>
+                        <Camera className="mr-2 h-4 w-4" />
+                        Capture Photo
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="flex-1"
+                        onClick={() => {
+                          setIsCameraOpen(false);
+                          stopCameraStream();
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <img
+                  src={studentPhotoPreview}
+                  alt="Student preview"
+                  className="h-56 w-full rounded-lg object-cover"
+                />
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="flex-1"
+                    onClick={openCamera}
+                  >
+                    <RefreshCcw className="mr-2 h-4 w-4" />
+                    Retake
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="flex-1 text-destructive hover:text-destructive hover:bg-destructive/10"
+                    onClick={resetStudentPhoto}
+                  >
+                    <X className="mr-2 h-4 w-4" />
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            )}
+            {cameraError && (
+              <div className="flex items-start gap-2 text-destructive text-xs mt-2 rounded bg-destructive/10 p-2 border border-destructive/20">
+                <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+                <p>{cameraError}</p>
+              </div>
+            )}
+          </div>
+        </CardContent>
+        <CardFooter className="flex gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            className="flex-1"
+            disabled={loading}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            className="flex-1"
+            onClick={saveFaceReference}
+            disabled={loading || !studentPhotoFile}
+          >
+            {loading ? "Saving..." : "Save and Continue"}
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+};

--- a/frontend/src/components/floating-video.tsx
+++ b/frontend/src/components/floating-video.tsx
@@ -16,6 +16,9 @@ import type { FloatingVideoProps } from '@/types/video.types';
 import { useReportAnomalyAudio, useReportAnomalyImage } from '@/hooks/hooks';
 import {registerStream, unRegisterStream} from "@/lib/MediaRegistry";
 import { runProctoringChecks } from "@/utils/proctoring/proctoringGuard";
+import { useNavigate } from '@tanstack/react-router';
+import { toast } from 'sonner';
+import { FaceRegistrationModal } from './ai/FaceRegistrationModal';
 
 // let flag = 0;
 function FloatingVideo({
@@ -70,6 +73,7 @@ function FloatingVideo({
   const [facesCount, setFacesCount] = useState(0);
   const [recognizedFaces, setRecognizedFaces] = useState<any[]>([]);
   const [hasFaceRecognitionMismatch, setHasFaceRecognitionMismatch] = useState(false);
+  const [showFaceRegisterModal, setShowFaceRegisterModal] = useState(false);
   const [penaltyPoints, setPenaltyPoints] = useState(0);
   const [penaltyType, setPenaltyType] = useState("");
   const [contiguousAnomalyPoints, setContiguousAnomalyPoints] = useState(0);
@@ -470,6 +474,21 @@ const lastCalledRef = useRef<number>(0);
       console.error('[FloatingVideo] Error restarting video:', error);
     }
   }, [videoRef, currentStream]);
+
+  const navigate = useNavigate();
+
+  const handleFaceRegistrationSuccess = useCallback(() => {
+    setShowFaceRegisterModal(false);
+    toast.success("Identity verified! Resuming course...");
+    void restartVideo();
+    setPauseVid(false);
+    setReadyToDetect(true);
+  }, [restartVideo, setPauseVid, setReadyToDetect]);
+
+  const handleFaceRegistrationClose = useCallback(() => {
+    setShowFaceRegisterModal(false);
+    navigate({ to: '/student' });
+  }, [navigate]);
 
   useEffect(() => {
   if (!currentStream || !readyToDetect || !isVideoActive) return;
@@ -1447,6 +1466,11 @@ const lastCalledRef = useRef<number>(0);
             videoRef={videoRef}
             onRecognitionResult={handleFaceRecognitionResult}
             onMismatchChange={handleFaceRecognitionMismatchChange}
+            onMissingEmbedding={() => {
+              setPauseVid(true);
+              setReadyToDetect(false);
+              setShowFaceRegisterModal(true);
+            }}
             settings={{
               isFaceCountDetectionEnabled,
               isFaceRecognitionEnabled, 
@@ -1484,12 +1508,31 @@ const lastCalledRef = useRef<number>(0);
     </div>
   );
 
+  const modalPortal = (showFaceRegisterModal && typeof window !== 'undefined') ? ReactDOM.createPortal(
+    <FaceRegistrationModal
+      isOpen={showFaceRegisterModal}
+      onSuccess={handleFaceRegistrationSuccess}
+      onClose={handleFaceRegistrationClose}
+    />,
+    document.body
+  ) : null;
+
   // Use portal to render floating video at the end of body if popped out
   if (isPoppedOut && typeof window !== 'undefined') {
-    return ReactDOM.createPortal(floatingVideoContent, document.body);
+    return (
+      <>
+        {ReactDOM.createPortal(floatingVideoContent, document.body)}
+        {modalPortal}
+      </>
+    );
   }
   // Otherwise render in place (sidebar)
-  return floatingVideoContent;
+  return (
+    <>
+      {floatingVideoContent}
+      {modalPortal}
+    </>
+  );
 };
 
 export default FloatingVideo;

--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -612,20 +612,21 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
     }
   }, [startItem.data?.watchItemId, setWatchItemId]);
 
- // ✅ Call upsert watch time API every 15 seconds while video is playing
+  // ✅ Call upsert watch time API every 15 seconds while video is playing
   useEffect(() => {
-    if (!startItem.data?.watchItemId || !playing) return;
+    const watchItemId = startItem.data?.watchItemId || currentCourse?.watchItemId;
+    if (!watchItemId || !playing) return;
     const interval = setInterval(() => {
       upsertWatchTime.mutate({
         body: {
-          watchItemId: watchItemIdRef.current!,
+          watchItemId,
           itemId: currentCourse?.itemId!,
           cohortId: currentCourse?.cohortId || undefined,
         }
       } as any);
     }, 15000); // every 15 seconds
     return () => clearInterval(interval); // cleanup on unmount
-  }, [startItem.data?.watchItemId, playing]);
+  }, [startItem.data?.watchItemId, playing, currentCourse?.watchItemId]);
 
 
   const forceHighestQuality = (player: YTPlayerInstance) => {

--- a/frontend/src/types/ai.types.ts
+++ b/frontend/src/types/ai.types.ts
@@ -12,6 +12,7 @@ export interface FaceDetectorsProps {
   onRecognitionResult?: (recognitions: FaceRecognition[]) => void;
   onDebugInfoUpdate?: (debugInfo: FaceRecognitionDebugInfo) => void;
   onMismatchChange?: (hasMismatch: boolean) => void;
+  onMissingEmbedding?: () => void;
   settings:{
     isFaceCountDetectionEnabled:boolean, 
     isFaceRecognitionEnabled:boolean, 
@@ -68,6 +69,7 @@ export interface FaceRecognitionComponentProps {
   onRecognitionResult?: (recognitions: FaceRecognition[]) => void;
   onDebugInfoUpdate?: (debugInfo: FaceRecognitionDebugInfo) => void;
   onMismatchChange?: (hasMismatch: boolean) => void;
+  onMissingEmbedding?: () => void;
   enabled?: boolean;
 }
 


### PR DESCRIPTION
## Overview
This PR introduces a seamless, in-page face registration flow for students attempting to access face-recognition-proctored courses without a registered face embedding, replacing the disruptive redirect to the login page (`/auth`). It also addresses downstream API payload limits and stream consumption bugs that caused errors during webcam photo saving and watchtime progress tracking.

---

## Key Changes

### 1. In-Page Face Registration Modal (Frontend)
* **New Component:** Added `FaceRegistrationModal.tsx` to replicate the face capture, model loading, embedding calculation, and uploading process within a portal overlay directly on the course page.
* **Component Refactor:** Extended `FaceRecognitionComponent.tsx` and `FaceDetectors.tsx` to accept and trigger an `onMissingEmbedding()` callback instead of redirecting the student.
* **Course Player Integration:** Integrated the modal in `floating-video.tsx`. It pauses the player video and proctoring during registration, and automatically remounts the detectors to immediately check the new embedding upon successful registration.
* **Webcam Retake Fix:** Resolved a bug in `FaceRegistrationModal.tsx` where clicking **Retake** opened the webcam stream in the background but failed to display it because the old static preview state was not cleared.

### 2. Progress Tracking Watchtime Upsert Fix (Frontend)
* **Interval Refactor:** Updated the watchtime tracking interval in `video.tsx` to read the stable, reactive `startItem.data?.watchItemId` (falling back to `currentCourse?.watchItemId`).
* **Why:** The previous implementation relied on the mutable ref `watchItemIdRef.current`, which is cleared (set to `null`) during player re-creations (such as toggling webcam streams/closing the face modal). This caused the interval to send `null` to the backend, triggering `400 Bad Request` validation errors.

### 3. Payload size limit & double body-parsing Fixes (Backend)
* **Removed Global Body Parsers:** Removed the global `express.json({ limit: '10mb' })` and `express.urlencoded` parsers from `index.ts`. Having global parsers pre-consumed the request stream, causing routing-controllers' per-route body-parsers to throw `InternalServerError: stream is not readable`.
* **Per-Route Limits:** Added a `10mb` size limit option directly to the `@Body()` decorator for the specific endpoints receiving large base64 webcam photo strings:
  * `PATCH /users/me/face-reference` in `UserController.ts`
  * `POST /auth/signup` in `AuthController.ts`
  * `POST /auth/signup/google` in `AuthController.ts`

---

## Files Changed

### Frontend
* `[MODIFY]` [ai.types.ts](file:///d:/programm3d/vibe/frontend/src/types/ai.types.ts) — Extended props with callback.
* `[MODIFY]` [FaceRecognitionComponent.tsx](file:///d:/programm3d/vibe/frontend/src/components/ai/FaceRecognitionComponent.tsx) — Trigger callback.
* `[MODIFY]` [FaceDetectors.tsx](file:///d:/programm3d/vibe/frontend/src/components/ai/FaceDetectors.tsx) — Propagate callback.
* `[NEW]` [FaceRegistrationModal.tsx](file:///d:/programm3d/vibe/frontend/src/components/ai/FaceRegistrationModal.tsx) — Webcam capture, model loading, and upload.
* `[MODIFY]` [floating-video.tsx](file:///d:/programm3d/vibe/frontend/src/components/floating-video.tsx) — Portal integration and player/proctor state sync.
* `[MODIFY]` [video.tsx](file:///d:/programm3d/vibe/frontend/src/components/video.tsx) — Fixed upsert interval watch ID reference.

### Backend
* `[MODIFY]` [index.ts](file:///d:/programm3d/vibe/backend/src/index.ts) — Cleaned up global body-parsers.
* `[MODIFY]` [UserController.ts](file:///d:/programm3d/vibe/backend/src/modules/users/controllers/UserController.ts) — Added route-specific 10mb body limit option.
* `[MODIFY]` [AuthController.ts](file:///d:/programm3d/vibe/backend/src/modules/auth/controllers/AuthController.ts) — Added route-specific 10mb body limit options to signup routes.

---

## Verification & Testing
* Checked frontend TypeScript compilation: `pnpm --filter frontend exec tsc --noEmit` — **Passed**
* Checked backend TypeScript compilation: `pnpm --filter vitest-vibe exec tsc --noEmit` — **Passed**
* Verified that webcam photo capture, webcam retake, face-reference saving (PATCH API), and watchtime upsert requests execute cleanly without errors.
* Tested the face registration popup triggers upon accessing a proctored course without a face reference, pauses the video player, successfully registers the face, closes the modal, and resumes video and proctoring smoothly. Run verification walkthrough details stored in [walkthrough.md](file:///C:/Users/PUSHAN%20SINHA/.gemini/antigravity/brain/5ecda48b-be7b-44da-9d19-59f5217ce184/walkthrough.md). Space-saved under branch `feature/in-page-face-registration`.

---