### PR TITLE
fix(invites): make follow-up invites cohort-agnostic + self-activate …

### DIFF
--- a/backend/src/config/app.ts
+++ b/backend/src/config/app.ts
@@ -23,7 +23,10 @@ export const appConfig = {
   adminPassword: env('ADMIN_PASSWORD') || 'admin123',
   ENABLE_DB_BACKUP: env('ENABLE_DB_BACKUP') === 'true',
   ENABLE_HP_JOB: env('ENABLE_HP_JOB') === 'true',
-  ENABLE_FOLLOWUP_INVITE_JOB: env('ENABLE_FOLLOWUP_INVITE_JOB') === 'true',
+  // Default ON: the follow-up invite reconciliation cron self-activates on deploy
+  // so it never silently sits idle waiting for an env var to be set. Set
+  // ENABLE_FOLLOWUP_INVITE_JOB='false' as a kill switch if it ever needs stopping.
+  ENABLE_FOLLOWUP_INVITE_JOB: env('ENABLE_FOLLOWUP_INVITE_JOB') !== 'false',
   GOOGLE_APPLICATION_CREDENTIALS: env('GOOGLE_APPLICATION_CREDENTIALS'),
   GCP_BACKUP_BUCKET: env('GCP_BACKUP_BUCKET'),
   GCP_BACKUP_ACTIVITY_BUCKET: env('GCP_BACKUP_ACTIVITY_BUCKET'),

--- a/backend/src/modules/notifications/services/InviteService.ts
+++ b/backend/src/modules/notifications/services/InviteService.ts
@@ -477,12 +477,17 @@ export class InviteService extends BaseService {
       for (const {email, role} of uniqueInviteData) {
         const normalizedEmail = email.toLowerCase().trim();
 
+        // Always check the already-invited list before sending a new invite.
+        // Cohort-agnostic and covers PENDING (awaiting action) + ACCEPTED, so a
+        // learner already invited to this course is never sent a duplicate —
+        // regardless of which cohort the existing invite targeted. (Scoping this
+        // to a specific cohort is what let duplicates slip through when the
+        // configured follow-up cohort differed from the learner's existing one.)
         const existingInvite =
-          await this.inviteRepo.findPendingInviteByEmailAndCourse(
+          await this.inviteRepo.findActiveInviteByEmailAndCourse(
             normalizedEmail,
             courseId,
             courseVersionId,
-            cohortId,
             session,
           );
         if (existingInvite) {

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -117,11 +117,18 @@ export class EnrollmentService extends BaseService {
         );
       }
 
+      // For invite acceptance, the duplicate check is COHORT-AGNOSTIC: a learner
+      // who is already actively enrolled in this course version must not be
+      // enrolled again, no matter which cohort the invite targeted. This is what
+      // enforces "however many invites a learner has, only one acceptance ever
+      // results in an enrollment" — duplicate invites with differing cohortIds
+      // would otherwise each create a separate enrollment. Direct (non-invite)
+      // enrollment keeps its cohort-scoped check.
       const existingEnrollment = await this.enrollmentRepo.findActiveEnrollment(
         userId,
         courseId,
         courseVersionId,
-        cohort,
+        throughInvite ? undefined : cohort,
         session,
       );
       // if (existingEnrollment && !throughInvite) {


### PR DESCRIPTION
…the backfill cron

Three durable fixes so follow-up "claim my spot" invites can't silently fail or duplicate:

- InviteService.inviteUserToCourse: check the already-invited list cohort-agnostically (findActiveInviteByEmailAndCourse, PENDING+ACCEPTED) for every send, instead of the cohort-scoped PENDING-only lookup. A learner already invited to a course is never re-invited regardless of cohort.
- EnrollmentService.enrollUser: the duplicate-enrollment guard is cohort-agnostic for invite acceptance (throughInvite ? undefined : cohort). Accepting a second duplicate invite — even one targeting a different cohort — can no longer create a second enrollment.
- config: ENABLE_FOLLOWUP_INVITE_JOB now defaults ON (disable with ='false'), so the daily reconciliation cron self-activates on deploy and never sits idle waiting for an env var. Acts as the catch-all that backfills any learner the real-time 98% trigger misses.
