### PR TITLE
Feat/crowd question bank promotion

### DIFF
--- a/backend/src/modules/quizzes/classes/transformers/Question.ts
+++ b/backend/src/modules/quizzes/classes/transformers/Question.ts
@@ -11,6 +11,8 @@ import {
   IDESSolution,
   Priority,
   BloomLevel,
+  QuestionSource,
+  QuestionReviewStatus,
 } from '#shared/interfaces/quiz.js';
 import {ObjectId} from 'mongodb';
 import {QuestionBody} from '../validators/QuestionValidator.js';
@@ -27,6 +29,9 @@ abstract class BaseQuestion implements IQuestion {
   timeLimitSeconds: number;
   points?: number;
   priority: Priority;
+  source?: QuestionSource;
+  reviewStatus?: QuestionReviewStatus;
+  studentQuestionId?: string | ObjectId;
   isDeleted?: boolean;
   deletedAt?: Date;
 
@@ -42,6 +47,11 @@ abstract class BaseQuestion implements IQuestion {
     this.timeLimitSeconds = question.timeLimitSeconds;
     this.points = question.points;
     this.priority = question.priority;
+    this.source = question.source;
+    this.reviewStatus = question.reviewStatus;
+    this.studentQuestionId = question.studentQuestionId
+      ? new ObjectId(question.studentQuestionId.toString())
+      : undefined;
     this.isDeleted = false;
     this.deletedAt = undefined;
   }

--- a/backend/src/modules/quizzes/services/QuestionService.ts
+++ b/backend/src/modules/quizzes/services/QuestionService.ts
@@ -218,6 +218,13 @@ class QuestionService extends BaseService {
     });
   }
 
+  public async setReviewStatus(
+    questionId: string,
+    status: 'PENDING_REVIEW' | 'APPROVED',
+  ): Promise<void> {
+    await this.questionRepository.update(questionId, {reviewStatus: status} as any);
+  }
+
   public async delete(questionId: string): Promise<void> {
     return this._withTransaction(async session => {
       const question = await this.questionRepository.getById(

--- a/backend/src/modules/studentQuestions/classes/transformers/StudentSegmentQuestion.ts
+++ b/backend/src/modules/studentQuestions/classes/transformers/StudentSegmentQuestion.ts
@@ -30,6 +30,7 @@ export interface IStudentSegmentQuestion {
   updatedAt: Date;
   isDeleted?: boolean;
   deletedAt?: Date;
+  promotedQuestionId?: ObjectId;
 }
 
 export class StudentSegmentQuestion implements IStudentSegmentQuestion {
@@ -52,6 +53,7 @@ export class StudentSegmentQuestion implements IStudentSegmentQuestion {
   updatedAt: Date;
   isDeleted?: boolean;
   deletedAt?: Date;
+  promotedQuestionId?: ObjectId;
 
   constructor(input: {
     courseId: string;

--- a/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
+++ b/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
@@ -212,6 +212,17 @@ export class StudentQuestionRepository {
     return result.matchedCount > 0;
   }
 
+  async setPromotedQuestionId(
+    studentQuestionId: string,
+    promotedId: string,
+  ): Promise<void> {
+    await this.init();
+    await this.collection.updateOne(
+      {_id: new ObjectId(studentQuestionId)},
+      {$set: {promotedQuestionId: new ObjectId(promotedId), updatedAt: new Date()}},
+    );
+  }
+
   async updateStatus(input: {
     courseId: string;
     courseVersionId: string;

--- a/backend/src/modules/studentQuestions/services/StudentQuestionService.ts
+++ b/backend/src/modules/studentQuestions/services/StudentQuestionService.ts
@@ -14,6 +14,14 @@ import {GLOBAL_TYPES} from '#root/types.js';
 import {ISettingRepository} from '#shared/database/index.js';
 import {NOTIFICATIONS_TYPES} from '../../notifications/types.js';
 import {NotificationService} from '../../notifications/services/NotificationService.js';
+import {QUIZZES_TYPES} from '../../quizzes/types.js';
+import {QuestionService} from '../../quizzes/services/QuestionService.js';
+import {QuestionBankService} from '../../quizzes/services/QuestionBankService.js';
+import {ItemRepository} from '#root/shared/database/providers/mongo/repositories/ItemRepository.js';
+import {COURSES_TYPES} from '../../courses/types.js';
+import {SOLQuestion} from '../../quizzes/classes/transformers/Question.js';
+import {IQuizDetails, ItemType} from '#root/shared/interfaces/models.js';
+import {ISOLSolution} from '#root/shared/interfaces/quiz.js';
 
 const REPEATED_CHAR_PATTERN = /(.)\1{7,}/;
 const REPEATED_WORD_PATTERN = /(\b\w+\b)(\s+\1){4,}/;
@@ -29,7 +37,62 @@ export class StudentQuestionService {
     private readonly settingRepo: ISettingRepository,
     @inject(NOTIFICATIONS_TYPES.NotificationService)
     private readonly notificationService: NotificationService,
+    @inject(QUIZZES_TYPES.QuestionService)
+    private readonly questionService: QuestionService,
+    @inject(QUIZZES_TYPES.QuestionBankService)
+    private readonly questionBankService: QuestionBankService,
+    @inject(COURSES_TYPES.ItemRepo)
+    private readonly itemRepo: ItemRepository,
   ) {}
+
+  private async _promoteToQuestionBank(
+    studentQuestionId: string,
+    input: {
+      segmentId: string;
+      questionText: string;
+      options: IStudentQuestionOption[];
+      correctOptionIndex: number;
+      createdBy: string;
+    },
+  ): Promise<void> {
+    try {
+      const item = await this.itemRepo.readItemById(input.segmentId).catch(() => null);
+      if (!item || (item as any).type !== ItemType.QUIZ) return;
+
+      const bankId = ((item as any).details as IQuizDetails | undefined)
+        ?.questionBankRefs?.[0]?.bankId?.toString();
+      if (!bankId) return;
+
+      const solution: ISOLSolution = {
+        correctLotItem: {
+          text: input.options[input.correctOptionIndex].text,
+          explaination: '',
+        },
+        incorrectLotItems: input.options
+          .filter((_, i) => i !== input.correctOptionIndex)
+          .map(opt => ({text: opt.text, explaination: ''})),
+      };
+
+      const solQuestion = new SOLQuestion(input.createdBy, {
+        text: input.questionText,
+        type: 'SELECT_ONE_IN_LOT',
+        isParameterized: false,
+        timeLimitSeconds: 60,
+        priority: 'LOW',
+        source: 'STUDENT_GENERATED',
+        reviewStatus: 'PENDING_REVIEW',
+        studentQuestionId,
+      }, solution);
+
+      const promotedId = await this.questionService.create(solQuestion);
+      await this.questionBankService.addQuestion(bankId, promotedId).catch(e =>
+        console.warn('crowd-q: failed to add to bank', e),
+      );
+      await this.repository.setPromotedQuestionId(studentQuestionId, promotedId).catch(() => {});
+    } catch (err) {
+      console.warn('crowd-q: promotion failed (non-fatal)', err);
+    }
+  }
 
   /**
    * Phase 4: emit an in-app notification to the question's author when a
@@ -219,7 +282,17 @@ export class StudentQuestionService {
       createdBy: input.createdBy,
     });
 
-    return await this.repository.create(question);
+    const createdId = await this.repository.create(question);
+
+    await this._promoteToQuestionBank(createdId, {
+      segmentId: input.segmentId,
+      questionText,
+      options,
+      correctOptionIndex: input.correctOptionIndex,
+      createdBy: input.createdBy,
+    });
+
+    return createdId;
   }
 
   async listSegmentQuestions(input: {
@@ -402,8 +475,7 @@ export class StudentQuestionService {
       throw new NotFoundError('Student question not found for the given segment.');
     }
 
-    // Notify the student author on APPROVED / REJECTED. Fetch fresh so we
-    // have createdBy / segmentId / courseId for the notification payload.
+    // Fetch fresh doc for notifications and promotion sync.
     if (input.status === 'APPROVED' || input.status === 'REJECTED') {
       const question = await this.repository.findById({
         courseId: input.courseId,
@@ -417,6 +489,19 @@ export class StudentQuestionService {
           input.status,
           input.reason?.trim(),
         );
+        // Sync the promoted quiz Question's reviewStatus.
+        if (question.promotedQuestionId) {
+          const promotedId = question.promotedQuestionId.toString();
+          if (input.status === 'APPROVED') {
+            await this.questionService.setReviewStatus(promotedId, 'APPROVED').catch(e =>
+              console.warn('crowd-q: failed to approve quiz question', e),
+            );
+          } else {
+            await this.questionService.delete(promotedId).catch(e =>
+              console.warn('crowd-q: failed to delete quiz question', e),
+            );
+          }
+        }
       }
     }
   }

--- a/backend/src/shared/interfaces/quiz.ts
+++ b/backend/src/shared/interfaces/quiz.ts
@@ -1,5 +1,8 @@
 import {ObjectId} from 'mongodb';
 
+export type QuestionSource = 'INSTRUCTOR' | 'AI_GENERATED' | 'STUDENT_GENERATED';
+export type QuestionReviewStatus = 'PENDING_REVIEW' | 'APPROVED';
+
 type QuestionType =
   | 'SELECT_ONE_IN_LOT'
   | 'SELECT_MANY_IN_LOT'
@@ -34,6 +37,9 @@ interface IQuestion {
   timeLimitSeconds: number;
   points?: number;
   priority: Priority;
+  source?: QuestionSource;
+  reviewStatus?: QuestionReviewStatus;
+  studentQuestionId?: string | ObjectId;
 }
 
 interface INATSolution {

--- a/frontend/src/app/pages/teacher/components/expandable-question-card.tsx
+++ b/frontend/src/app/pages/teacher/components/expandable-question-card.tsx
@@ -1079,6 +1079,12 @@ const ExpandableQuestionCard: React.FC<ExpandableQuestionCardProps> = ({
                       <Badge variant="outline" className="font-medium text-xs sm:text-sm flex-shrink-0">
                         {question?.type?.replace(/_/g, ' ') || 'Unknown'}
                       </Badge>
+                      {(question as any)?.source === 'STUDENT_GENERATED' &&
+                        (question as any)?.reviewStatus === 'PENDING_REVIEW' && (
+                          <Badge className="bg-amber-100 text-amber-800 border-amber-300 text-xs flex-shrink-0">
+                            Pending Review
+                          </Badge>
+                        )}
                     </div>
                     <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded self-start flex-shrink-0">
                       ID: {questionId.slice(-6)}


### PR DESCRIPTION
## Summary

- Student-submitted MCQ questions are now automatically promoted into the
  quiz item's question bank on submission, so teachers can review them
  directly in the question bank editor without needing a separate inbox.
- Two new fields (`source`, `reviewStatus`) on the quiz `Question` model
  allow crowd-sourced questions to be distinguished from instructor/AI
  questions and tracked through a lightweight review lifecycle.
- The teacher sees an amber **"Pending Review"** badge on promoted questions
  in the question bank UI. Approving a student question (`APPROVED`) clears
  the badge; rejecting it soft-deletes the quiz `Question`.
- Promotion is **non-fatal**: if the segment has no associated quiz item or
  the question bank lookup fails, the student submission still succeeds.

## What changed

### Backend

| File | Change |
|---|---|
| `shared/interfaces/quiz.ts` | Added `QuestionSource` and `QuestionReviewStatus` types; extended `IQuestion` with `source?`, `reviewStatus?`, `studentQuestionId?` |
| `quizzes/classes/transformers/Question.ts` | `BaseQuestion` picks up the three new optional fields in its constructor |
| `quizzes/services/QuestionService.ts` | Added `setReviewStatus(questionId, status)` — lightweight update without a full question replace |
| `studentQuestions/classes/transformers/StudentSegmentQuestion.ts` | Added `promotedQuestionId?: ObjectId` to track the linked quiz `Question` |
| `studentQuestions/repositories/…/StudentQuestionRepository.ts` | Added `setPromotedQuestionId(studentQuestionId, promotedId)` |
| `studentQuestions/services/StudentQuestionService.ts` | Injected `QuestionService`, `QuestionBankService`, `ItemRepository`; added `_promoteToQuestionBank()` (called on create) and status-sync on `updateQuestionStatus()` |

### Frontend

| File | Change |
|---|---|
| `expandable-question-card.tsx` | Renders an amber **"Pending Review"** badge when `source === 'STUDENT_GENERATED' && reviewStatus === 'PENDING_REVIEW'` |

## How it works

Student submits question
│
▼
StudentSegmentQuestion created (status=PENDING)
│
▼  _promoteToQuestionBank() — non-fatal
readItemById(segmentId) → must be a QUIZ item with questionBankRefs
│
▼
SOLQuestion created (source=STUDENT_GENERATED, reviewStatus=PENDING_REVIEW)
│
▼
QuestionBankService.addQuestion(bankId, questionId)
│
▼
StudentSegmentQuestion.promotedQuestionId = questionId

── Teacher reviews ──────────────────────────────────────────────
APPROVED  →  QuestionService.setReviewStatus(promotedId, 'APPROVED')
REJECTED  →  QuestionService.delete(promotedId)   [soft delete]



## Edge cases

- `segmentId` resolves to a video/blog item (no `questionBankRefs`) → promotion skipped, submission still returns 201
- Quiz item has no question banks configured → same skip
- `QuestionService.create` or `addQuestion` throws → logged as warning, submission unaffected
- `updateQuestionStatus` called on a question with no `promotedQuestionId` → no-op on quiz side

## Test plan

- [ ] POST a student question for a quiz-item segment → verify `questions` collection has a new SOL doc with `source: 'STUDENT_GENERATED'`, `reviewStatus: 'PENDING_REVIEW'`; verify `questionBanks` doc has the question ID; verify `studentSegmentQuestions` doc has `promotedQuestionId` set
- [ ] Open question bank editor as teacher → amber "Pending Review" badge visible
- [ ] PATCH student question to `APPROVED` → `questions` doc has `reviewStatus: 'APPROVED'`, badge gone
- [ ] PATCH student question to `REJECTED` → quiz `Question` is soft-deleted (`isDeleted: true`)
- [ ] POST a student question for a video-segment ID → 201 returned, no quiz `Question` created