### PR TITLE
feat(timeslots): enforce booking access gate and surface blocks

### DIFF
--- a/backend/src/modules/courses/controllers/ItemController.ts
+++ b/backend/src/modules/courses/controllers/ItemController.ts
@@ -67,6 +67,20 @@ import {SETTING_TYPES} from '#root/modules/setting/types.js';
 import {TimeSlotService} from '#root/modules/setting/services/TimeSlotService.js';
 import {EnrollmentService} from '#root/modules/users/services/EnrollmentService.js';
 import {USERS_TYPES} from '#root/modules/users/types.js';
+
+/**
+ * Distinct 403 for the time-slot / commitment gate so the frontend can tell it apart
+ * from a generic ForbiddenError (e.g. linear-progression locks) and surface the right
+ * "book a time slot" message + CTA instead of the generic "lesson locked" notice.
+ */
+export class TimeSlotAccessError extends ForbiddenError {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'TimeSlotAccessDenied';
+    Object.setPrototypeOf(this, TimeSlotAccessError.prototype);
+  }
+}
+
 @OpenAPI({
   tags: ['Course Items'],
 })
@@ -209,6 +223,29 @@ export class ItemController {
         'You do not have permission to view items in this section',
       );
     }
+
+    // Time-slot ("commitment") gate: a student may only load section content
+    // during a booked window. Instructors/managers/TAs bypass. This mirrors the
+    // gate on getItem — without it, the player can fetch full item content here
+    // and skip the per-item check entirely.
+    const canManageGate = ability.can(
+      ItemActions.Modify,
+      subject('Item', {versionId}),
+    );
+    if (!canManageGate) {
+      const access =
+        await this.timeSlotService.canStudentAccessCourseByVersion(
+          user._id.toString(),
+          versionId,
+          cohortId,
+        );
+      if (!access.canAccess) {
+        throw new TimeSlotAccessError(
+          access.message || 'Time slot access denied',
+        );
+      }
+    }
+
     const items = await this.itemService.readAllItems(
       versionId,
       moduleId,
@@ -725,13 +762,17 @@ Access control logic:
           );
 
         if (!timeSlotAccess.canAccess) {
-          throw new ForbiddenError(
+          throw new TimeSlotAccessError(
             timeSlotAccess.message || 'Time slot access denied',
           );
         }
       } catch (error) {
-        // If it's already a ForbiddenError, re-throw it
-        if (error.name === 'ForbiddenError') {
+        // Re-throw our intended 403s (time-slot block or any ForbiddenError) untouched
+        // so the frontend can distinguish them by name.
+        if (
+          error.name === 'TimeSlotAccessDenied' ||
+          error.name === 'ForbiddenError'
+        ) {
           throw error;
         }
         throw new ForbiddenError('Time slot access check failed');

--- a/backend/src/modules/setting/services/TimeSlotService.ts
+++ b/backend/src/modules/setting/services/TimeSlotService.ts
@@ -39,7 +39,7 @@ export class TimeSlotService extends BaseService {
    */
   private isTimeslotFull(timeSlot: ITimeSlot): boolean {
     if (!timeSlot.maxStudents) return false; // No limit set
-    return timeSlot.studentIds.length > timeSlot.maxStudents;
+    return timeSlot.studentIds.length >= timeSlot.maxStudents;
   }
 
   /**
@@ -660,6 +660,28 @@ export class TimeSlotService extends BaseService {
   }
 
   /**
+   * Same gate as canStudentAccessCourse, but for callers that only have the
+   * course version id (e.g. the section-items endpoint, whose route has no
+   * courseId). Resolves the owning courseId from the version, then delegates.
+   */
+  async canStudentAccessCourseByVersion(
+    userId: string,
+    courseVersionId: string,
+    cohortId?: string,
+  ): Promise<{ canAccess: boolean; message?: string }> {
+    const version = await this.courseRepo.readVersion(courseVersionId);
+    if (!version) {
+      return { canAccess: false, message: 'Course version not found.' };
+    }
+    return this.canStudentAccessCourse(
+      userId,
+      version.courseId.toString(),
+      courseVersionId,
+      cohortId,
+    );
+  }
+
+  /**
    * Check if student can access course based on time slot
    */
   async canStudentAccessCourse(
@@ -693,7 +715,17 @@ export class TimeSlotService extends BaseService {
       }
 
       if (!enrollment.assignedTimeSlots || enrollment.assignedTimeSlots.length === 0) {
-        return { canAccess: true, message: 'No time slot assigned to this student.' };
+        // Feature is active (checked above). If no slots exist to book yet, don't lock
+        // everyone out — that would be a misconfiguration footgun the moment the toggle flips.
+        if (!timeslots.slots || timeslots.slots.length === 0) {
+          return { canAccess: true };
+        }
+        // Active course with bookable slots, but the student has no booking → restrict.
+        return {
+          canAccess: false,
+          message:
+            'You must book a time slot to access this course. Please choose a slot to continue.',
+        };
       }
 
       // Check if current time is within any of the assigned slots

--- a/backend/src/modules/setting/tests/TimeSlotService.test.ts
+++ b/backend/src/modules/setting/tests/TimeSlotService.test.ts
@@ -1,0 +1,243 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TimeSlotService } from '../services/TimeSlotService.js';
+
+/**
+ * Unit tests for TimeSlotService.canStudentAccessCourse — the access gate that
+ * decides whether a student may open a course item based on the course's
+ * time-slot ("commitment") booking config and the student's booked slot(s).
+ *
+ * The gate logic (all times IST):
+ *  - feature inactive / no config           -> ALLOW
+ *  - active, student not enrolled            -> DENY  ("not enrolled")
+ *  - active, slots defined, student unbooked -> DENY  ("must book a time slot")
+ *  - active, NO slots defined, unbooked      -> ALLOW (don't lock everyone out)
+ *  - active, booked, now inside any slot     -> ALLOW
+ *  - active, booked, now outside all slots   -> DENY  ("only allowed during ...")
+ *
+ * The DB is bypassed by stubbing BaseService._withTransaction, and the system
+ * clock is faked so the IST window checks are deterministic.
+ */
+
+const USER = 'student-1';
+const COURSE = 'course-1';
+const VERSION = 'version-1';
+
+function makeService(
+  opts: {
+    timeslots?: { isActive: boolean; slots: any[] } | null;
+    enrollment?: { assignedTimeSlots?: { from: string; to: string }[] } | null;
+    version?: { courseId: string } | null;
+  } = {},
+) {
+  const { timeslots = null, enrollment = undefined, version = { courseId: COURSE } } = opts;
+
+  const settingsRepo = {
+    readTimeslotsSettings: vi.fn().mockResolvedValue(timeslots),
+  };
+  const courseRepo = {
+    readVersion: vi.fn().mockResolvedValue(version),
+  };
+  const enrollmentService = {
+    findEnrollment: vi.fn().mockResolvedValue(enrollment),
+  };
+  const db = {} as any;
+
+  const svc = new TimeSlotService(
+    settingsRepo as any,
+    courseRepo as any,
+    enrollmentService as any,
+    db,
+  );
+
+  // Run transaction callbacks immediately with a dummy session — no real DB.
+  vi.spyOn(svc as any, '_withTransaction').mockImplementation((fn: any) => fn({}));
+
+  return { svc, settingsRepo, enrollmentService, courseRepo };
+}
+
+/**
+ * Freeze the clock so that the current IST wall-clock equals hh:mm.
+ * getCurrentISTTime() computes (UTC now + 5:30), so set UTC = (hh:mm - 5:30).
+ */
+function setNowToIST(hh: number, mm: number) {
+  const utcMinutes = (hh * 60 + mm - 330 + 1440) % 1440;
+  const uh = Math.floor(utcMinutes / 60);
+  const um = utcMinutes % 60;
+  vi.setSystemTime(new Date(Date.UTC(2026, 0, 15, uh, um, 0)));
+}
+
+const slot = (from: string, to: string) => ({ from, to, studentIds: [USER] });
+
+describe('TimeSlotService.canStudentAccessCourse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows access when the time-slot feature is inactive', async () => {
+    const { svc, enrollmentService } = makeService({
+      timeslots: { isActive: false, slots: [] },
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+
+    expect(res.canAccess).toBe(true);
+    // Should short-circuit before even looking up the enrollment.
+    expect(enrollmentService.findEnrollment).not.toHaveBeenCalled();
+  });
+
+  it('allows access when there is no time-slot config at all', async () => {
+    const { svc } = makeService({ timeslots: null });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+
+    expect(res.canAccess).toBe(true);
+  });
+
+  it('denies access when the student is not enrolled', async () => {
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: null,
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+
+    expect(res.canAccess).toBe(false);
+    expect(res.message).toMatch(/not enrolled/i);
+  });
+
+  it('denies access when active with slots but the student has not booked one', async () => {
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: { assignedTimeSlots: [] },
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+
+    expect(res.canAccess).toBe(false);
+    expect(res.message).toMatch(/book a time slot/i);
+  });
+
+  it('allows access when active but no slots are defined yet (avoids locking everyone out)', async () => {
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [] },
+      enrollment: { assignedTimeSlots: [] },
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+
+    expect(res.canAccess).toBe(true);
+  });
+
+  it('allows access when the current time is inside the booked slot', async () => {
+    setNowToIST(14, 0); // 14:00 IST, inside 13:00–15:00
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: { assignedTimeSlots: [{ from: '13:00', to: '15:00' }] },
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+
+    expect(res.canAccess).toBe(true);
+  });
+
+  it('denies access when the current time is OUTSIDE the booked slot', async () => {
+    setNowToIST(16, 30); // 16:30 IST, after 13:00–15:00
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: { assignedTimeSlots: [{ from: '13:00', to: '15:00' }] },
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+
+    expect(res.canAccess).toBe(false);
+    expect(res.message).toMatch(/only allowed during/i);
+    expect(res.message).toContain('13:00 to 15:00');
+  });
+
+  it('allows access when the current time falls in one of several booked slots', async () => {
+    setNowToIST(9, 30); // 09:30 IST, inside the first slot
+    const { svc } = makeService({
+      timeslots: {
+        isActive: true,
+        slots: [slot('09:00', '10:00'), slot('13:00', '15:00')],
+      },
+      enrollment: {
+        assignedTimeSlots: [
+          { from: '09:00', to: '10:00' },
+          { from: '13:00', to: '15:00' },
+        ],
+      },
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+
+    expect(res.canAccess).toBe(true);
+  });
+
+  it('treats the slot boundaries as inclusive (start and end minute allow access)', async () => {
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: { assignedTimeSlots: [{ from: '13:00', to: '15:00' }] },
+    });
+
+    setNowToIST(13, 0); // exactly at start
+    expect((await svc.canStudentAccessCourse(USER, COURSE, VERSION)).canAccess).toBe(true);
+
+    setNowToIST(15, 0); // exactly at end
+    expect((await svc.canStudentAccessCourse(USER, COURSE, VERSION)).canAccess).toBe(true);
+  });
+});
+
+describe('TimeSlotService.canStudentAccessCourseByVersion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves courseId from the version and denies outside the booked slot', async () => {
+    setNowToIST(16, 30); // outside 13:00–15:00
+    const { svc, courseRepo, settingsRepo } = makeService({
+      version: { courseId: COURSE },
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: { assignedTimeSlots: [{ from: '13:00', to: '15:00' }] },
+    });
+
+    const res = await svc.canStudentAccessCourseByVersion(USER, VERSION);
+
+    expect(courseRepo.readVersion).toHaveBeenCalledWith(VERSION);
+    expect(settingsRepo.readTimeslotsSettings).toHaveBeenCalled(); // delegated through
+    expect(res.canAccess).toBe(false);
+    expect(res.message).toMatch(/only allowed during/i);
+  });
+
+  it('allows access when inside the booked slot (via version lookup)', async () => {
+    setNowToIST(14, 0); // inside 13:00–15:00
+    const { svc } = makeService({
+      version: { courseId: COURSE },
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: { assignedTimeSlots: [{ from: '13:00', to: '15:00' }] },
+    });
+
+    const res = await svc.canStudentAccessCourseByVersion(USER, VERSION);
+
+    expect(res.canAccess).toBe(true);
+  });
+
+  it('denies and does not run the gate when the version cannot be found', async () => {
+    const { svc, settingsRepo } = makeService({ version: null });
+
+    const res = await svc.canStudentAccessCourseByVersion(USER, VERSION);
+
+    expect(res.canAccess).toBe(false);
+    expect(res.message).toMatch(/version not found/i);
+    expect(settingsRepo.readTimeslotsSettings).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/shared/middleware/errorHandler.ts
+++ b/backend/src/shared/middleware/errorHandler.ts
@@ -41,11 +41,13 @@ export class ErrorResponse<T> {
   message: string;
   errors?: T;
   sentryEventId?: string;
+  name?: string;
 
-  constructor(message: string, errors?: T, sentryEventId?: string) {
+  constructor(message: string, errors?: T, sentryEventId?: string, name?: string) {
     if (errors) this.errors = errors;
     this.message = message;
     if (sentryEventId) this.sentryEventId = sentryEventId;
+    if (name) this.name = name;
   }
 }
 
@@ -284,7 +286,7 @@ export class HttpErrorHandler implements ExpressErrorMiddlewareInterface {
       } else {
         response
           .status(error.httpCode)
-          .json(new ErrorResponse<null>(error.message, null, eventId));
+          .json(new ErrorResponse<null>(error.message, null, eventId, error.name));
       }
     } else if (error instanceof Error) {
       response.status(500).json(

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react"; ExternalLink
+import { useState, useEffect, useCallback, useRef, useMemo, lazy, Suspense } from "react"; ExternalLink
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -19,6 +19,7 @@ import { useAuthStore } from "@/store/auth-store";
 import { useCourseStore } from "@/store/course-store";
 import { Link, Navigate, useRouter } from "@tanstack/react-router";
 import StudentProjectItem from "./components/StudentProjectItem";
+const LazyStudentTimeslotModal = lazy(() => import("@/components/course/StudentTimeslotModal"));
 import type { Item, ItemContainerRef } from "@/types/item-container.types";
 import type { PendingStudentQuestionContext } from "@/types/student-question.types";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -226,6 +227,9 @@ export default function CoursePage() {
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({});
   const [doGesture, setDoGesture] = useState<boolean>(false);
   const [isItemForbidden, setIsItemForbidden] = useState<boolean>(false);
+  // Time-slot / commitment gate block (distinct from linear-progression ForbiddenError).
+  const [timeSlotBlock, setTimeSlotBlock] = useState<string | null>(null);
+  const [showTimeslotPicker, setShowTimeslotPicker] = useState<boolean>(false);
   const [isNavigatingToNext, setIsNavigatingToNext] = useState<boolean>(false);
   const [rewindVid, setRewindVid] = useState<boolean>(false);
   const [pauseVid, setPauseVid] = useState<boolean>(false);
@@ -298,7 +302,9 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
 
   const {
     data: currentSectionItems,
-    isLoading: itemsLoading
+    isLoading: itemsLoading,
+    error: sectionItemsError,
+    errorName: sectionItemsErrorName
   } = useItemsBySectionId(
     shouldFetchItems ? VERSION_ID : '',
     shouldFetchItems ? activeSectionInfo!.moduleId : '',
@@ -400,6 +406,14 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
   ]);
 
 
+  // The section-items endpoint is the other (ungated-until-now) content path.
+  // If it returns the time-slot block, surface the same persistent notice.
+  useEffect(() => {
+    if (sectionItemsErrorName === "TimeSlotAccessDenied" && sectionItemsError) {
+      setTimeSlotBlock(sectionItemsError);
+    }
+  }, [sectionItemsErrorName, sectionItemsError]);
+
   // Separate effect for handling item errors - prevents circular dependencies
   useEffect(() => {
     if (!itemError) return;
@@ -408,6 +422,34 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
     if (itemError.includes("auth/id-token-expired")) {
       logout();
       Navigate({ to: '/auth' });
+      return;
+    }
+
+    // Time-slot / commitment gate — distinct from a linear-progression ForbiddenError.
+    // Show a persistent, actionable notice instead of the generic "lesson locked" card.
+    if (itemError && selectedItemId && itemErrorName === "TimeSlotAccessDenied") {
+      setIsNavigatingToNext(false);
+      setIsItemForbidden(false);
+      setTimeSlotBlock(itemError);
+
+      // Revert to the last valid item so the player isn't stuck on a blocked item.
+      if (previousValidItem) {
+        setSelectedModuleId(previousValidItem.moduleId);
+        setSelectedSectionId(previousValidItem.sectionId);
+        setSelectedItemId(previousValidItem.itemId);
+        if (!sectionItems[previousValidItem.sectionId]) {
+          setActiveSectionInfo({
+            moduleId: previousValidItem.moduleId,
+            sectionId: previousValidItem.sectionId,
+          });
+        }
+        updateCourseNavigation(
+          previousValidItem.moduleId,
+          previousValidItem.sectionId,
+          previousValidItem.itemId,
+        );
+      }
+      // Persistent on purpose — the student must book a slot or wait for their window.
       return;
     }
 
@@ -2235,6 +2277,55 @@ return false;
                         </Button>
                       </CardContent>
                     </Card>
+                  )}
+
+                  {/* ⏰ Time-slot / commitment gate notice */}
+                  {timeSlotBlock && (
+                    <Card className="border border-amber-400/40 bg-amber-600/95 text-amber-50 shadow-lg backdrop-blur-md animate-in slide-in-from-right-3 duration-300">
+                      <CardContent className="flex items-start gap-3 px-4 py-3">
+                        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-amber-50/10 p-2">
+                          <AlertCircle className="h-7 w-7" />
+                        </div>
+                        <div className="flex-1 space-y-2">
+                          <Badge variant="outline" className="border-amber-50/30 bg-amber-50/10 text-amber-50 text-base font-bold">
+                            {/book a time slot|choose a slot/i.test(timeSlotBlock) ? 'Book a time slot' : 'Outside your study window'}
+                          </Badge>
+                          <p className="text-sm font-medium leading-relaxed">{timeSlotBlock}</p>
+                          <div className="flex gap-2 pt-1">
+                            {/book a time slot|choose a slot/i.test(timeSlotBlock) && (
+                              <Button
+                                size="sm"
+                                variant="secondary"
+                                onClick={() => setShowTimeslotPicker(true)}
+                              >
+                                Pick a slot
+                              </Button>
+                            )}
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="text-amber-50 hover:bg-amber-50/10"
+                              onClick={() => setTimeSlotBlock(null)}
+                            >
+                              Dismiss
+                            </Button>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  )}
+
+                  {showTimeslotPicker && (
+                    <Suspense fallback={null}>
+                      <LazyStudentTimeslotModal
+                        isOpen={showTimeslotPicker}
+                        onClose={() => { setShowTimeslotPicker(false); setTimeSlotBlock(null); }}
+                        courseId={COURSE_ID}
+                        courseVersionId={VERSION_ID}
+                        currentUserId={""}
+                        hasAssignedTimeslot={false}
+                      />
+                    </Suspense>
                   )}
 
                   {/* Gesture Notification */}

--- a/frontend/src/components/course/StudentTimeslotModal.tsx
+++ b/frontend/src/components/course/StudentTimeslotModal.tsx
@@ -268,7 +268,7 @@ export default function StudentTimeslotModal({
           <div className="text-xs text-muted-foreground">
             <p>• You can only choose one time slot per course.</p>
             <p>• Once selected, contact your instructor to make changes.</p>
-            <p>• Time slots are shown in your local timezone.</p>
+            <p>• Time slots are in IST (Indian Standard Time, UTC+5:30).</p>
           </div>
         </div>
       </DialogContent>

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -1348,6 +1348,7 @@ export function useItemsBySectionId(versionId: string, moduleId: string, section
   data: components['schemas']['ItemDataResponse'] | undefined,
   isLoading: boolean,
   error: string | null,
+  errorName: string | null,
   refetch: () => void
 } {
   const isEnabled: boolean | null =
@@ -1371,6 +1372,7 @@ export function useItemsBySectionId(versionId: string, moduleId: string, section
     data: result.data,
     isLoading: result.isLoading,
     error: result.error ? (result.error.message || 'Failed to fetch items') : null,
+    errorName: result.error ? ((result.error as any).name || null) : null,
     refetch: result.refetch
   };
 }


### PR DESCRIPTION
Phase 0 of the commitment-scheme (time-slot booking) work — make the access gate actually block, and tell the student why.

- Gate: deny course access when slot booking is active and the student has no booking covering "now" (previously allowed 24/7); keep a no-slots-defined exception to avoid locking everyone out. Fix the isTimeslotFull off-by-one (>= maxStudents).
- Close the content bypass: gate the readAll section-items endpoint (the player's main content path), not just getItem. Add canStudentAccessCourseByVersion to resolve courseId from versionId.
- Surface the block: throw a distinct TimeSlotAccessError (name=TimeSlotAccessDenied); include the error name in HttpErrorHandler responses (it was omitted, so the frontend could never detect forbidden reasons); show a persistent "book a slot" notice + Pick-a-slot CTA on the course page; expose errorName from useItemsBySectionId.
- Fix student modal copy: slots are IST, not "your local timezone".
- Add unit tests for the access gate (12 cases, incl. the by-version wrapper and slot-window boundaries).

Note: instructors/admins bypass the gate by design. Other content endpoints (video analytics, quiz attempts, progress) remain ungated — full enforcement coverage is a later hardening step.

