### PR TITLE
Feat/timeslot commitment phase1 booking

### DIFF
--- a/backend/src/container.ts
+++ b/backend/src/container.ts
@@ -9,6 +9,7 @@ import { AuditTrailsHandler } from './shared/middleware/auditTrails.js';
 import {GLOBAL_TYPES} from './types.js';
 import {dbConfig} from './config/db.js';
 import {CourseRepository} from '#shared/database/providers/mongo/repositories/CourseRepository.js';
+import {SlotBookingRepository} from '#shared/database/providers/mongo/repositories/SlotBookingRepository.js';
 import { FirebaseAuthService } from './modules/auth/services/FirebaseAuthService.js';
 import { ProgressService } from './modules/users/services/ProgressService.js';
 import { EnrollmentService } from './modules/users/services/EnrollmentService.js';
@@ -35,6 +36,10 @@ export const sharedContainerModule = new ContainerModule(options => {
   options
     .bind(GLOBAL_TYPES.SettingRepo)
     .to(SettingRepository)
+    .inSingletonScope();
+  options
+    .bind(GLOBAL_TYPES.SlotBookingRepo)
+    .to(SlotBookingRepository)
     .inSingletonScope();
 
   // Other

--- a/backend/src/modules/setting/container.ts
+++ b/backend/src/modules/setting/container.ts
@@ -5,6 +5,7 @@ import { UserSettingController } from './controllers/UserSettingController.js';
 import { UserSettingService } from './services/UserSettingService.js';
 import { TimeSlotController } from './controllers/TimeSlotController.js';
 import { TimeSlotService } from './services/TimeSlotService.js';
+import { SlotBookingService } from './services/SlotBookingService.js';
 import { SettingRepository } from '#root/shared/index.js';
 
 export const settingContainerModule = new ContainerModule(options => {
@@ -14,6 +15,7 @@ export const settingContainerModule = new ContainerModule(options => {
   
   options.bind(SETTING_TYPES.UserSettingService).to(UserSettingService);
   options.bind(SETTING_TYPES.TimeSlotService).to(TimeSlotService);
+  options.bind(SETTING_TYPES.SlotBookingService).to(SlotBookingService);
 
   // Controllers
   options.bind(CourseSettingController).toSelf().inSingletonScope();

--- a/backend/src/modules/setting/container.ts
+++ b/backend/src/modules/setting/container.ts
@@ -4,6 +4,7 @@ import { CourseSettingService } from './services/CourseSettingService.js';
 import { UserSettingController } from './controllers/UserSettingController.js';
 import { UserSettingService } from './services/UserSettingService.js';
 import { TimeSlotController } from './controllers/TimeSlotController.js';
+import { SlotBookingController } from './controllers/SlotBookingController.js';
 import { TimeSlotService } from './services/TimeSlotService.js';
 import { SlotBookingService } from './services/SlotBookingService.js';
 import { SettingRepository } from '#root/shared/index.js';
@@ -21,4 +22,5 @@ export const settingContainerModule = new ContainerModule(options => {
   options.bind(CourseSettingController).toSelf().inSingletonScope();
   options.bind(UserSettingController).toSelf().inSingletonScope();
   options.bind(TimeSlotController).toSelf().inSingletonScope();
+  options.bind(SlotBookingController).toSelf().inSingletonScope();
 });

--- a/backend/src/modules/setting/controllers/SlotBookingController.ts
+++ b/backend/src/modules/setting/controllers/SlotBookingController.ts
@@ -1,0 +1,183 @@
+import {SlotBookingService} from '../services/SlotBookingService.js';
+import {SETTING_TYPES} from '../types.js';
+import {injectable, inject} from 'inversify';
+import {
+  JsonController,
+  Post,
+  Get,
+  Body,
+  Param,
+  QueryParam,
+  Authorized,
+  HttpCode,
+  CurrentUser,
+  BadRequestError,
+  NotFoundError,
+  ForbiddenError,
+  InternalServerError,
+} from 'routing-controllers';
+import {OpenAPI} from 'routing-controllers-openapi';
+import {IUser} from '#root/shared/index.js';
+import {Ability} from '#root/shared/functions/AbilityDecorator.js';
+import {
+  getItemAbility,
+  ItemActions,
+} from '#root/modules/courses/abilities/itemAbilities.js';
+import {subject} from '@casl/ability';
+
+class BookSlotRequestBody {
+  courseId: string;
+  courseVersionId: string;
+  timeSlot: {from: string; to: string};
+  cohortId?: string;
+}
+
+class CancelBookingRequestBody {
+  bookingId: string;
+}
+
+class BookingResponse {
+  success: boolean;
+  message?: string;
+  data?: any;
+}
+
+@OpenAPI({tags: ['Slot Bookings']})
+@JsonController('/slot-bookings', {transformResponse: true})
+@injectable()
+class SlotBookingController {
+  constructor(
+    @inject(SETTING_TYPES.SlotBookingService)
+    private readonly slotBookingService: SlotBookingService,
+  ) {}
+
+  @OpenAPI({
+    summary: 'Book a time slot',
+    description:
+      'A student books a time slot for the current IST day, subject to the slot capacity cap and their daily allowance.',
+  })
+  @Authorized()
+  @Post('/book')
+  @HttpCode(200)
+  async bookSlot(
+    @Body() body: BookSlotRequestBody,
+    @CurrentUser() user: IUser,
+  ): Promise<BookingResponse> {
+    try {
+      const booking = await this.slotBookingService.bookSlot(
+        user._id.toString(),
+        body.courseId,
+        body.courseVersionId,
+        body.timeSlot,
+        body.cohortId,
+      );
+      return {
+        success: true,
+        message: 'Time slot booked successfully',
+        data: booking,
+      };
+    } catch (error) {
+      if (
+        error instanceof BadRequestError ||
+        error instanceof NotFoundError ||
+        error instanceof ForbiddenError
+      ) {
+        return {success: false, message: error.message};
+      }
+      throw new InternalServerError(`Failed to book time slot: ${error}`);
+    }
+  }
+
+  @OpenAPI({
+    summary: 'Cancel a booking',
+    description: 'A student cancels one of their own bookings (used to re-book).',
+  })
+  @Authorized()
+  @Post('/cancel')
+  @HttpCode(200)
+  async cancelBooking(
+    @Body() body: CancelBookingRequestBody,
+    @CurrentUser() user: IUser,
+  ): Promise<BookingResponse> {
+    try {
+      const ok = await this.slotBookingService.cancelBooking(
+        user._id.toString(),
+        body.bookingId,
+      );
+      return {
+        success: ok,
+        message: ok ? 'Booking cancelled' : 'Failed to cancel booking',
+      };
+    } catch (error) {
+      if (
+        error instanceof BadRequestError ||
+        error instanceof NotFoundError ||
+        error instanceof ForbiddenError
+      ) {
+        return {success: false, message: error.message};
+      }
+      throw new InternalServerError(`Failed to cancel booking: ${error}`);
+    }
+  }
+
+  @OpenAPI({
+    summary: "List the student's bookings",
+    description:
+      "Returns the calling student's active bookings for a course, optionally filtered to one IST date (YYYY-MM-DD).",
+  })
+  @Authorized()
+  @Get('/my/course/:courseId/version/:courseVersionId')
+  @HttpCode(200)
+  async myBookings(
+    @Param('courseId') courseId: string,
+    @Param('courseVersionId') courseVersionId: string,
+    @CurrentUser() user: IUser,
+    @QueryParam('date') date?: string,
+  ): Promise<BookingResponse> {
+    try {
+      const data = await this.slotBookingService.getStudentBookings(
+        user._id.toString(),
+        courseId,
+        courseVersionId,
+        date,
+      );
+      return {success: true, data};
+    } catch (error) {
+      throw new InternalServerError(`Failed to get bookings: ${error}`);
+    }
+  }
+
+  @OpenAPI({
+    summary: 'Slot demand schedule',
+    description:
+      'Booked load per window for an IST day (default today) — the demand schedule for capacity planning. Instructors/managers only.',
+  })
+  @Authorized()
+  @Get('/demand/course/:courseId/version/:courseVersionId')
+  @HttpCode(200)
+  async getDemand(
+    @Param('courseId') courseId: string,
+    @Param('courseVersionId') courseVersionId: string,
+    @Ability(getItemAbility) {ability},
+    @QueryParam('date') date?: string,
+  ): Promise<BookingResponse> {
+    const itemResource = subject('Item', {versionId: courseVersionId});
+    if (!ability.can(ItemActions.ViewAll, itemResource)) {
+      throw new ForbiddenError(
+        'You do not have permission to view this course.',
+      );
+    }
+    try {
+      const data = await this.slotBookingService.getSlotDemand(
+        courseId,
+        courseVersionId,
+        date,
+      );
+      return {success: true, data};
+    } catch (error) {
+      throw new InternalServerError(`Failed to get slot demand: ${error}`);
+    }
+  }
+}
+
+export {SlotBookingController};

--- a/backend/src/modules/setting/controllers/index.ts
+++ b/backend/src/modules/setting/controllers/index.ts
@@ -1,3 +1,4 @@
 export * from './CourseSettingController.js';
 export * from './UserSettingController.js';
 export * from './TimeSlotController.js';
+export * from './SlotBookingController.js';

--- a/backend/src/modules/setting/index.ts
+++ b/backend/src/modules/setting/index.ts
@@ -6,6 +6,7 @@ import { settingContainerModule } from './container.js';
 import { authContainerModule } from '../auth/container.js';
 import { UserSettingController } from './controllers/UserSettingController.js';
 import { TimeSlotController } from './controllers/TimeSlotController.js';
+import { SlotBookingController } from './controllers/SlotBookingController.js';
 
 export const settingContainerModules: ContainerModule[] = [
   settingContainerModule,
@@ -16,7 +17,8 @@ export const settingContainerModules: ContainerModule[] = [
 export const settingModuleControllers: Function[] = [
   CourseSettingController,
   UserSettingController,
-  TimeSlotController
+  TimeSlotController,
+  SlotBookingController
 ];
 
 export async function setupSettingContainer(): Promise<void> {

--- a/backend/src/modules/setting/services/SlotBookingService.ts
+++ b/backend/src/modules/setting/services/SlotBookingService.ts
@@ -1,0 +1,211 @@
+import {injectable, inject} from 'inversify';
+import {
+  BadRequestError,
+  NotFoundError,
+  ForbiddenError,
+  InternalServerError,
+} from 'routing-controllers';
+import {
+  BaseService,
+  MongoDatabase,
+  ISettingRepository,
+  ISlotBookingRepository,
+} from '#shared/index.js';
+import {
+  ISlotBooking,
+  SlotBookingKind,
+  SlotBookingStatus,
+} from '#shared/interfaces/models.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {EnrollmentService} from '#users/services/EnrollmentService.js';
+import {USERS_TYPES} from '#users/types.js';
+
+/**
+ * Books and manages per-day slot bookings (the commitment-scheme records).
+ *
+ * The resource-optimization goal is load scheduling: the per-slot capacity cap
+ * is the ceiling on concurrent learners in a window, and the bookings form a
+ * demand schedule. This service enforces that ceiling plus each student's daily
+ * allowance, in IST.
+ */
+@injectable()
+export class SlotBookingService extends BaseService {
+  constructor(
+    @inject(GLOBAL_TYPES.SlotBookingRepo)
+    private readonly slotBookingRepo: ISlotBookingRepository,
+
+    @inject(GLOBAL_TYPES.SettingRepo)
+    private readonly settingsRepo: ISettingRepository,
+
+    @inject(USERS_TYPES.EnrollmentService)
+    private readonly enrollmentService: EnrollmentService,
+
+    @inject(GLOBAL_TYPES.Database)
+    private readonly mongoDatabase: MongoDatabase,
+  ) {
+    super(mongoDatabase);
+  }
+
+  /** Current calendar date in IST as YYYY-MM-DD. */
+  private getCurrentISTDate(): string {
+    const istNow = new Date(Date.now() + 5.5 * 60 * 60 * 1000);
+    const y = istNow.getUTCFullYear();
+    const m = String(istNow.getUTCMonth() + 1).padStart(2, '0');
+    const d = String(istNow.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  private toMinutes(time: string): number {
+    const [h, m] = time.split(':').map(Number);
+    return h * 60 + m;
+  }
+
+  /** A window crosses midnight when its start is at/after its end. */
+  private isOvernight(from: string, to: string): boolean {
+    return this.toMinutes(from) >= this.toMinutes(to);
+  }
+
+  /** Window length in hours, handling cross-midnight wrap. */
+  private slotHours(from: string, to: string): number {
+    let minutes = this.toMinutes(to) - this.toMinutes(from);
+    if (minutes <= 0) minutes += 24 * 60;
+    return Math.round((minutes / 60) * 100) / 100;
+  }
+
+  /**
+   * Book a time slot for the current IST day. Enforces: feature active, the slot
+   * is offered, no duplicate, the student's daily allowance, and the slot's hard
+   * capacity cap.
+   */
+  async bookSlot(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    slot: {from: string; to: string},
+    cohortId?: string,
+  ): Promise<ISlotBooking> {
+    return this._withTransaction(async (session) => {
+      const timeslots = await this.settingsRepo.readTimeslotsSettings(
+        courseId,
+        courseVersionId,
+        session,
+      );
+      if (!timeslots || !timeslots.isActive) {
+        throw new BadRequestError(
+          'Time slot booking is not enabled for this course.',
+        );
+      }
+
+      const configured = timeslots.slots.find(
+        s => s.from === slot.from && s.to === slot.to,
+      );
+      if (!configured) {
+        throw new NotFoundError(
+          'That time slot is not offered for this course.',
+        );
+      }
+
+      const enrollment = await this.enrollmentService.findEnrollment(
+        userId,
+        courseId,
+        courseVersionId,
+        cohortId,
+      );
+      if (!enrollment) {
+        throw new NotFoundError('You are not enrolled in this course.');
+      }
+
+      const date = this.getCurrentISTDate();
+      const myBookings = await this.slotBookingRepo.findActiveForStudent(
+        userId,
+        courseId,
+        courseVersionId,
+        date,
+        session,
+      );
+
+      if (myBookings.some(b => b.from === slot.from && b.to === slot.to)) {
+        throw new BadRequestError('You have already booked this slot today.');
+      }
+
+      const allowance = timeslots.dailyBaseAllowance ?? 1;
+      if (myBookings.length >= allowance) {
+        throw new BadRequestError(
+          `You have used your ${allowance} booking(s) for today.`,
+        );
+      }
+
+      // Hard capacity cap — the per-window concurrency ceiling.
+      if (configured.maxStudents) {
+        const taken = await this.slotBookingRepo.countActiveInSlot(
+          courseId,
+          courseVersionId,
+          date,
+          slot,
+          session,
+        );
+        if (taken >= configured.maxStudents) {
+          throw new BadRequestError(
+            'This time slot is full. Please choose another.',
+          );
+        }
+      }
+
+      const now = new Date();
+      const booking: ISlotBooking = {
+        userId,
+        enrollmentId: enrollment._id,
+        courseId,
+        courseVersionId,
+        cohortId: cohortId ?? undefined,
+        date,
+        from: slot.from,
+        to: slot.to,
+        overnight: this.isOvernight(slot.from, slot.to),
+        kind: SlotBookingKind.BASE,
+        status: SlotBookingStatus.BOOKED,
+        hoursReserved: this.slotHours(slot.from, slot.to),
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      const created = await this.slotBookingRepo.createBooking(
+        booking,
+        session,
+      );
+      if (!created) {
+        throw new InternalServerError('Failed to create the booking.');
+      }
+      return created;
+    });
+  }
+
+  /** Cancel one of the student's own bookings (used for re-booking / changes). */
+  async cancelBooking(userId: string, bookingId: string): Promise<boolean> {
+    return this._withTransaction(async (session) => {
+      const booking = await this.slotBookingRepo.findById(bookingId, session);
+      if (!booking) {
+        throw new NotFoundError('Booking not found.');
+      }
+      if (String(booking.userId) !== String(userId)) {
+        throw new ForbiddenError('You can only cancel your own bookings.');
+      }
+      return this.slotBookingRepo.cancelBooking(bookingId, session);
+    });
+  }
+
+  /** A student's active bookings, optionally for a single IST date. */
+  async getStudentBookings(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    date?: string,
+  ): Promise<ISlotBooking[]> {
+    return this.slotBookingRepo.findActiveForStudent(
+      userId,
+      courseId,
+      courseVersionId,
+      date,
+    );
+  }
+}

--- a/backend/src/modules/setting/services/SlotBookingService.ts
+++ b/backend/src/modules/setting/services/SlotBookingService.ts
@@ -208,4 +208,54 @@ export class SlotBookingService extends BaseService {
       date,
     );
   }
+
+  /**
+   * Booked load per window for an IST day — the "demand schedule" that lets ops
+   * size capacity per window and scale down off-peak. Defaults to today.
+   */
+  async getSlotDemand(
+    courseId: string,
+    courseVersionId: string,
+    date?: string,
+  ): Promise<{
+    date: string;
+    isActive: boolean;
+    slots: Array<{
+      from: string;
+      to: string;
+      maxStudents: number | null;
+      booked: number;
+      remaining: number | null;
+    }>;
+  }> {
+    const day = date ?? this.getCurrentISTDate();
+    const timeslots = await this.settingsRepo.readTimeslotsSettings(
+      courseId,
+      courseVersionId,
+    );
+    if (!timeslots) {
+      return {date: day, isActive: false, slots: []};
+    }
+
+    const slots = await Promise.all(
+      timeslots.slots.map(async s => {
+        const booked = await this.slotBookingRepo.countActiveInSlot(
+          courseId,
+          courseVersionId,
+          day,
+          {from: s.from, to: s.to},
+        );
+        return {
+          from: s.from,
+          to: s.to,
+          maxStudents: s.maxStudents ?? null,
+          booked,
+          remaining:
+            s.maxStudents != null ? Math.max(0, s.maxStudents - booked) : null,
+        };
+      }),
+    );
+
+    return {date: day, isActive: timeslots.isActive, slots};
+  }
 }

--- a/backend/src/modules/setting/services/TimeSlotService.ts
+++ b/backend/src/modules/setting/services/TimeSlotService.ts
@@ -10,6 +10,7 @@ import {
   MongoDatabase,
   ISettingRepository,
   ICourseRepository,
+  ISlotBookingRepository,
   ITimeSlot,
 } from '#shared/index.js';
 import { EnrollmentService } from '#users/services/EnrollmentService.js';
@@ -30,8 +31,52 @@ export class TimeSlotService extends BaseService {
 
     @inject(GLOBAL_TYPES.Database)
     private readonly mongoDatabase: MongoDatabase,
+
+    @inject(GLOBAL_TYPES.SlotBookingRepo)
+    private readonly slotBookingRepo: ISlotBookingRepository,
   ) {
     super(mongoDatabase);
+  }
+
+  /** Current IST date (YYYY-MM-DD), the previous IST date, and minutes-since-midnight. */
+  private getISTDateParts(): {date: string; prevDate: string; minutes: number} {
+    const istNow = new Date(Date.now() + 5.5 * 60 * 60 * 1000);
+    const fmt = (d: Date) =>
+      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+    const prev = new Date(istNow.getTime() - 24 * 60 * 60 * 1000);
+    return {
+      date: fmt(istNow),
+      prevDate: fmt(prev),
+      minutes: istNow.getUTCHours() * 60 + istNow.getUTCMinutes(),
+    };
+  }
+
+  /**
+   * Whether a booking covers the current IST minute, accounting for overnight
+   * windows that span two calendar days (a same-day booking only matches on its
+   * own date; an overnight booking matches its evening tail on its date and its
+   * morning tail on the next date).
+   */
+  private bookingCoversNow(
+    booking: {from: string; to: string; date: string},
+    todayDate: string,
+    nowMinutes: number,
+  ): boolean {
+    const fromMin = this.toMinutes(booking.from);
+    const toMin = this.toMinutes(booking.to);
+    const overnight = fromMin >= toMin;
+    if (booking.date === todayDate) {
+      return overnight
+        ? nowMinutes >= fromMin
+        : nowMinutes >= fromMin && nowMinutes <= toMin;
+    }
+    // booking.date is the previous day — only an overnight morning tail applies
+    return overnight ? nowMinutes <= toMin : false;
+  }
+
+  private toMinutes(time: string): number {
+    const [h, m] = time.split(':').map(Number);
+    return h * 60 + m;
   }
 
   /**
@@ -714,13 +759,51 @@ export class TimeSlotService extends BaseService {
         return { canAccess: false, message: 'Student not enrolled in this course.' };
       }
 
-      if (!enrollment.assignedTimeSlots || enrollment.assignedTimeSlots.length === 0) {
-        // Feature is active (checked above). If no slots exist to book yet, don't lock
-        // everyone out — that would be a misconfiguration footgun the moment the toggle flips.
-        if (!timeslots.slots || timeslots.slots.length === 0) {
-          return { canAccess: true };
-        }
-        // Active course with bookable slots, but the student has no booking → restrict.
+      // Feature active but no slots configured yet → don't lock everyone out
+      // the moment the toggle flips.
+      if (!timeslots.slots || timeslots.slots.length === 0) {
+        return { canAccess: true };
+      }
+
+      const { date, prevDate, minutes } = this.getISTDateParts();
+
+      // NEW source of truth: per-day slot bookings (today + yesterday, so an
+      // overnight window that spills past midnight still grants access).
+      const [todayBookings, prevBookings] = await Promise.all([
+        this.slotBookingRepo.findActiveForStudent(
+          userId,
+          courseId,
+          courseVersionId,
+          date,
+          session,
+        ),
+        this.slotBookingRepo.findActiveForStudent(
+          userId,
+          courseId,
+          courseVersionId,
+          prevDate,
+          session,
+        ),
+      ]);
+      const bookingCovers = [...todayBookings, ...prevBookings].some(b =>
+        this.bookingCoversNow(b, date, minutes),
+      );
+
+      // LEGACY source during the transition: enrollment.assignedTimeSlots.
+      const legacySlots = enrollment.assignedTimeSlots ?? [];
+      const legacyCovers = legacySlots.some(slot =>
+        this.isCurrentTimeInSlot(slot),
+      );
+
+      if (bookingCovers || legacyCovers) {
+        return { canAccess: true };
+      }
+
+      // Nothing covers the current time. No commitment at all → they haven't
+      // booked; otherwise they're simply outside their window.
+      const hasAnyCommitment =
+        todayBookings.length > 0 || legacySlots.length > 0;
+      if (!hasAnyCommitment) {
         return {
           canAccess: false,
           message:
@@ -728,23 +811,14 @@ export class TimeSlotService extends BaseService {
         };
       }
 
-      // Check if current time is within any of the assigned slots
-      const currentTime = this.getCurrentISTTime();
-      const hasAccess = enrollment.assignedTimeSlots.some(timeSlot => 
-        this.isCurrentTimeInSlot(timeSlot)
-      );
-      
-      if (!hasAccess) {
-        const timeSlotsStr = enrollment.assignedTimeSlots
-          .map(slot => `${slot.from} to ${slot.to}`)
-          .join(', ');
-        return {
-          canAccess: false,
-          message: `Course access is only allowed during these time slots: ${timeSlotsStr} IST. Current time: ${currentTime}`,
-        };
-      }
-
-      return { canAccess: true };
+      const windows = [
+        ...todayBookings.map(b => `${b.from} to ${b.to}`),
+        ...legacySlots.map(s => `${s.from} to ${s.to}`),
+      ].join(', ');
+      return {
+        canAccess: false,
+        message: `Course access is only allowed during your booked time slots: ${windows} IST. Current time: ${this.getCurrentISTTime()}`,
+      };
     });
   }
 }

--- a/backend/src/modules/setting/services/TimeSlotService.ts
+++ b/backend/src/modules/setting/services/TimeSlotService.ts
@@ -358,57 +358,13 @@ export class TimeSlotService extends BaseService {
         session,
       );
 
-      // Initialize timeslots if not exists
-      if (!existingTimeslots) {
-        const newTimeslots = {
-          isActive,
-          slots: [],
-        };
-        
-        const result = await this.settingsRepo.updateTimeslotsSettings(
-          courseId,
-          courseVersionId,
-          newTimeslots,
-          session,
-        );
-        
-        return !!result;
-      }
-
-      // If toggling off, delete all slots and remove assigned slots from enrollments
-      if (!isActive && existingTimeslots.slots && existingTimeslots.slots.length > 0) {
-        // Remove time slot from all student enrollments
-        for (const slot of existingTimeslots.slots) {
-          // Find students assigned to this time slot
-          const enrollments = await this.enrollmentService.findEnrollmentsByTimeSlot(
-            courseId,
-            courseVersionId,
-            { from: slot.from, to: slot.to },
-            session,
-          );
-
-          // Remove time slot from each student's enrollment
-          for (const enrollment of enrollments) {
-            const studentUserId = typeof enrollment.userId === 'string' 
-              ? enrollment.userId 
-              : enrollment.userId.toString();
-            
-            await this.enrollmentService.removeSpecificTimeSlotFromStudent(
-              studentUserId,
-              courseId,
-              courseVersionId,
-              { from: slot.from, to: slot.to },
-              session,
-            );
-          }
-      }
-    }
-
-    // Update existing timeslots with new isActive value and empty slots if toggling off
-    const updatedTimeslots = {
-        isActive,
-        slots: isActive ? (existingTimeslots.slots || []) : []
-      };
+      // Preserve the configured slots, allowance, and existing bookings —
+      // toggling off only flips the flag so the whole setup can be restored
+      // intact by re-enabling. (Bookings live in their own collection and are
+      // untouched here.)
+      const updatedTimeslots = existingTimeslots
+        ? { ...existingTimeslots, isActive }
+        : { isActive, slots: [] };
 
       const result = await this.settingsRepo.updateTimeslotsSettings(
         courseId,

--- a/backend/src/modules/setting/services/TimeSlotService.ts
+++ b/backend/src/modules/setting/services/TimeSlotService.ts
@@ -13,6 +13,10 @@ import {
   ISlotBookingRepository,
   ITimeSlot,
 } from '#shared/index.js';
+import {
+  SlotBookingKind,
+  SlotBookingStatus,
+} from '#shared/interfaces/models.js';
 import { EnrollmentService } from '#users/services/EnrollmentService.js';
 import { USERS_TYPES } from '#users/types.js';
 
@@ -603,11 +607,39 @@ export class TimeSlotService extends BaseService {
         throw new InternalServerError('Failed to update enrollment.');
       }
 
+      // Dual-write (migration): also record the choice as a slot booking so the
+      // bookings collection and the demand view stay accurate while the legacy
+      // assignedTimeSlots path is retired.
+      const { date } = this.getISTDateParts();
+      const fromMin = this.toMinutes(timeSlot.from);
+      const toMin = this.toMinutes(timeSlot.to);
+      let durationMin = toMin - fromMin;
+      if (durationMin <= 0) durationMin += 24 * 60; // overnight wrap
+      const now = new Date();
+      await this.slotBookingRepo.createBooking(
+        {
+          userId: studentUserId,
+          enrollmentId: enrollment._id,
+          courseId,
+          courseVersionId,
+          date,
+          from: timeSlot.from,
+          to: timeSlot.to,
+          overnight: fromMin >= toMin,
+          kind: SlotBookingKind.BASE,
+          status: SlotBookingStatus.BOOKED,
+          hoursReserved: Math.round((durationMin / 60) * 100) / 100,
+          createdAt: now,
+          updatedAt: now,
+        },
+        session,
+      );
+
       return true;
     });
   }
 
-  
+
   /**
    * Teacher removes a student from a specific time slot
    */

--- a/backend/src/modules/setting/tests/SlotBookingService.test.ts
+++ b/backend/src/modules/setting/tests/SlotBookingService.test.ts
@@ -1,0 +1,201 @@
+import 'reflect-metadata';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {SlotBookingService} from '../services/SlotBookingService.js';
+import {
+  SlotBookingKind,
+  SlotBookingStatus,
+} from '#shared/interfaces/models.js';
+
+/**
+ * Unit tests for SlotBookingService.bookSlot / cancelBooking — the
+ * commitment-scheme booking logic. The hard capacity cap (per-window
+ * concurrency ceiling) and the per-student daily allowance are the load-control
+ * knobs and get the most coverage.
+ *
+ * The DB is bypassed by stubbing BaseService._withTransaction.
+ */
+
+const USER = 'student-1';
+const COURSE = 'course-1';
+const VERSION = 'version-1';
+
+const SLOT = {from: '13:00', to: '15:00'}; // 2h, same-day
+
+function makeService(
+  opts: {
+    timeslots?: any;
+    enrollment?: any;
+    myBookings?: any[];
+    slotCount?: number;
+    bookingById?: any;
+  } = {},
+) {
+  const {
+    timeslots = {
+      isActive: true,
+      slots: [{from: '13:00', to: '15:00', studentIds: [], maxStudents: 2}],
+      dailyBaseAllowance: 1,
+    },
+    enrollment = {_id: 'enroll-1'},
+    myBookings = [],
+    slotCount = 0,
+    bookingById = null,
+  } = opts;
+
+  const slotBookingRepo = {
+    findActiveForStudent: vi.fn().mockResolvedValue(myBookings),
+    countActiveInSlot: vi.fn().mockResolvedValue(slotCount),
+    createBooking: vi
+      .fn()
+      .mockImplementation((b: any) => Promise.resolve({...b, _id: 'booking-new'})),
+    findById: vi.fn().mockResolvedValue(bookingById),
+    cancelBooking: vi.fn().mockResolvedValue(true),
+  };
+  const settingsRepo = {
+    readTimeslotsSettings: vi.fn().mockResolvedValue(timeslots),
+  };
+  const enrollmentService = {
+    findEnrollment: vi.fn().mockResolvedValue(enrollment),
+  };
+  const db = {} as any;
+
+  const svc = new SlotBookingService(
+    slotBookingRepo as any,
+    settingsRepo as any,
+    enrollmentService as any,
+    db,
+  );
+  vi.spyOn(svc as any, '_withTransaction').mockImplementation((fn: any) =>
+    fn({}),
+  );
+
+  return {svc, slotBookingRepo, settingsRepo, enrollmentService};
+}
+
+describe('SlotBookingService.bookSlot', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects when the time-slot feature is inactive', async () => {
+    const {svc} = makeService({timeslots: {isActive: false, slots: []}});
+    await expect(
+      svc.bookSlot(USER, COURSE, VERSION, SLOT),
+    ).rejects.toThrowError(/not enabled/i);
+  });
+
+  it('rejects a slot that the course does not offer', async () => {
+    const {svc} = makeService();
+    await expect(
+      svc.bookSlot(USER, COURSE, VERSION, {from: '08:00', to: '09:00'}),
+    ).rejects.toThrowError(/not offered/i);
+  });
+
+  it('rejects when the student is not enrolled', async () => {
+    const {svc} = makeService({enrollment: null});
+    await expect(
+      svc.bookSlot(USER, COURSE, VERSION, SLOT),
+    ).rejects.toThrowError(/not enrolled/i);
+  });
+
+  it('rejects double-booking the same slot', async () => {
+    const {svc} = makeService({myBookings: [{from: '13:00', to: '15:00'}]});
+    await expect(
+      svc.bookSlot(USER, COURSE, VERSION, SLOT),
+    ).rejects.toThrowError(/already booked/i);
+  });
+
+  it('rejects when the daily allowance is used up', async () => {
+    // One booking already today (a different slot), allowance = 1.
+    const {svc} = makeService({myBookings: [{from: '09:00', to: '10:00'}]});
+    await expect(
+      svc.bookSlot(USER, COURSE, VERSION, SLOT),
+    ).rejects.toThrowError(/booking\(s\) for today/i);
+  });
+
+  it('enforces the hard capacity cap (slot full)', async () => {
+    const {svc} = makeService({slotCount: 2}); // maxStudents = 2
+    await expect(
+      svc.bookSlot(USER, COURSE, VERSION, SLOT),
+    ).rejects.toThrowError(/full/i);
+  });
+
+  it('books a same-day slot and records BASE/BOOKED with correct hours', async () => {
+    const {svc, slotBookingRepo} = makeService();
+    const result = await svc.bookSlot(USER, COURSE, VERSION, SLOT);
+
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+    const saved = slotBookingRepo.createBooking.mock.calls[0][0];
+    expect(saved).toMatchObject({
+      userId: USER,
+      enrollmentId: 'enroll-1',
+      courseId: COURSE,
+      courseVersionId: VERSION,
+      from: '13:00',
+      to: '15:00',
+      overnight: false,
+      kind: SlotBookingKind.BASE,
+      status: SlotBookingStatus.BOOKED,
+      hoursReserved: 2,
+    });
+    expect(result._id).toBe('booking-new');
+  });
+
+  it('supports overnight windows (from > to) with wrapped duration', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      timeslots: {
+        isActive: true,
+        slots: [{from: '22:00', to: '01:00', studentIds: []}],
+        dailyBaseAllowance: 1,
+      },
+    });
+
+    await svc.bookSlot(USER, COURSE, VERSION, {from: '22:00', to: '01:00'});
+
+    const saved = slotBookingRepo.createBooking.mock.calls[0][0];
+    expect(saved.overnight).toBe(true);
+    expect(saved.hoursReserved).toBe(3); // 22:00 -> 01:00 = 3h
+  });
+
+  it('respects a higher daily allowance (books a second, different slot)', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      timeslots: {
+        isActive: true,
+        slots: [
+          {from: '09:00', to: '10:00', studentIds: []},
+          {from: '13:00', to: '15:00', studentIds: []},
+        ],
+        dailyBaseAllowance: 2,
+      },
+      myBookings: [{from: '09:00', to: '10:00'}], // already has 1 of 2
+    });
+
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT);
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+  });
+});
+
+describe('SlotBookingService.cancelBooking', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects cancelling a non-existent booking', async () => {
+    const {svc} = makeService({bookingById: null});
+    await expect(svc.cancelBooking(USER, 'b1')).rejects.toThrowError(
+      /not found/i,
+    );
+  });
+
+  it("rejects cancelling someone else's booking", async () => {
+    const {svc} = makeService({bookingById: {userId: 'other-user'}});
+    await expect(svc.cancelBooking(USER, 'b1')).rejects.toThrowError(
+      /your own/i,
+    );
+  });
+
+  it('cancels the student own booking', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      bookingById: {userId: USER},
+    });
+    const ok = await svc.cancelBooking(USER, 'b1');
+    expect(ok).toBe(true);
+    expect(slotBookingRepo.cancelBooking).toHaveBeenCalledWith('b1', {});
+  });
+});

--- a/backend/src/modules/setting/tests/SlotBookingService.test.ts
+++ b/backend/src/modules/setting/tests/SlotBookingService.test.ts
@@ -199,3 +199,38 @@ describe('SlotBookingService.cancelBooking', () => {
     expect(slotBookingRepo.cancelBooking).toHaveBeenCalledWith('b1', {});
   });
 });
+
+describe('SlotBookingService.getSlotDemand', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reports booked load and remaining capacity per window', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      timeslots: {
+        isActive: true,
+        slots: [
+          {from: '09:00', to: '10:00', studentIds: [], maxStudents: 30},
+          {from: '13:00', to: '15:00', studentIds: []}, // uncapped
+        ],
+        dailyBaseAllowance: 1,
+      },
+    });
+    slotBookingRepo.countActiveInSlot
+      .mockResolvedValueOnce(5)
+      .mockResolvedValueOnce(12);
+
+    const demand = await svc.getSlotDemand(COURSE, VERSION, '2026-01-15');
+
+    expect(demand.date).toBe('2026-01-15');
+    expect(demand.isActive).toBe(true);
+    expect(demand.slots).toEqual([
+      {from: '09:00', to: '10:00', maxStudents: 30, booked: 5, remaining: 25},
+      {from: '13:00', to: '15:00', maxStudents: null, booked: 12, remaining: null},
+    ]);
+  });
+
+  it('returns an empty schedule when no config exists', async () => {
+    const {svc} = makeService({timeslots: null});
+    const demand = await svc.getSlotDemand(COURSE, VERSION, '2026-01-15');
+    expect(demand).toEqual({date: '2026-01-15', isActive: false, slots: []});
+  });
+});

--- a/backend/src/modules/setting/tests/TimeSlotService.test.ts
+++ b/backend/src/modules/setting/tests/TimeSlotService.test.ts
@@ -29,7 +29,7 @@ const VERSION = 'version-1';
 
 function makeService(
   opts: {
-    timeslots?: { isActive: boolean; slots: any[] } | null;
+    timeslots?: { isActive: boolean; slots: any[]; dailyBaseAllowance?: number } | null;
     enrollment?: {
       _id?: string;
       assignedTimeSlots?: { from: string; to: string }[];
@@ -371,5 +371,39 @@ describe('TimeSlotService.chooseTimeSlot (dual-write)', () => {
       svc.chooseTimeSlot(COURSE, VERSION, { from: '13:00', to: '15:00' }, USER),
     ).rejects.toThrowError(/already have a time slot/i);
     expect(slotBookingRepo.createBooking).not.toHaveBeenCalled();
+  });
+});
+
+describe('TimeSlotService.toggleTimeSlots (preserve)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('preserves slots and allowance when toggling off', async () => {
+    const { svc, settingsRepo } = makeService({
+      timeslots: {
+        isActive: true,
+        slots: [slot('13:00', '15:00')],
+        dailyBaseAllowance: 2,
+      },
+    });
+
+    const ok = await svc.toggleTimeSlots(COURSE, VERSION, false, 'teacher-1');
+
+    expect(ok).toBe(true);
+    const saved = settingsRepo.updateTimeslotsSettings.mock.calls[0][2];
+    expect(saved.isActive).toBe(false);
+    expect(saved.slots).toHaveLength(1); // preserved, not cleared
+    expect(saved.dailyBaseAllowance).toBe(2); // preserved
+  });
+
+  it('initializes an empty config when none exists', async () => {
+    const { svc, settingsRepo } = makeService({ timeslots: null });
+
+    const ok = await svc.toggleTimeSlots(COURSE, VERSION, true, 'teacher-1');
+
+    expect(ok).toBe(true);
+    expect(settingsRepo.updateTimeslotsSettings.mock.calls[0][2]).toMatchObject({
+      isActive: true,
+      slots: [],
+    });
   });
 });

--- a/backend/src/modules/setting/tests/TimeSlotService.test.ts
+++ b/backend/src/modules/setting/tests/TimeSlotService.test.ts
@@ -28,9 +28,15 @@ function makeService(
     timeslots?: { isActive: boolean; slots: any[] } | null;
     enrollment?: { assignedTimeSlots?: { from: string; to: string }[] } | null;
     version?: { courseId: string } | null;
+    bookings?: { date: string; from: string; to: string }[];
   } = {},
 ) {
-  const { timeslots = null, enrollment = undefined, version = { courseId: COURSE } } = opts;
+  const {
+    timeslots = null,
+    enrollment = undefined,
+    version = { courseId: COURSE },
+    bookings = [],
+  } = opts;
 
   const settingsRepo = {
     readTimeslotsSettings: vi.fn().mockResolvedValue(timeslots),
@@ -41,6 +47,14 @@ function makeService(
   const enrollmentService = {
     findEnrollment: vi.fn().mockResolvedValue(enrollment),
   };
+  const slotBookingRepo = {
+    // Date-aware: return only the bookings whose date matches the queried day.
+    findActiveForStudent: vi
+      .fn()
+      .mockImplementation((_u: string, _c: string, _v: string, date?: string) =>
+        Promise.resolve(bookings.filter(b => !date || b.date === date)),
+      ),
+  };
   const db = {} as any;
 
   const svc = new TimeSlotService(
@@ -48,12 +62,13 @@ function makeService(
     courseRepo as any,
     enrollmentService as any,
     db,
+    slotBookingRepo as any,
   );
 
   // Run transaction callbacks immediately with a dummy session — no real DB.
   vi.spyOn(svc as any, '_withTransaction').mockImplementation((fn: any) => fn({}));
 
-  return { svc, settingsRepo, enrollmentService, courseRepo };
+  return { svc, settingsRepo, enrollmentService, courseRepo, slotBookingRepo };
 }
 
 /**
@@ -190,6 +205,60 @@ describe('TimeSlotService.canStudentAccessCourse', () => {
 
     setNowToIST(15, 0); // exactly at end
     expect((await svc.canStudentAccessCourse(USER, COURSE, VERSION)).canAccess).toBe(true);
+  });
+
+  // --- dual-read: NEW slotBookings path (alongside the legacy assignedTimeSlots) ---
+
+  it('allows access via a slot booking covering now (no legacy slot)', async () => {
+    setNowToIST(14, 0); // inside 13:00–15:00 on 2026-01-15
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: {}, // no assignedTimeSlots — only the new booking
+      bookings: [{ date: '2026-01-15', from: '13:00', to: '15:00' }],
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+    expect(res.canAccess).toBe(true);
+  });
+
+  it('denies when a booking exists but the current time is outside it', async () => {
+    setNowToIST(16, 30); // after 13:00–15:00
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: {},
+      bookings: [{ date: '2026-01-15', from: '13:00', to: '15:00' }],
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+    expect(res.canAccess).toBe(false);
+    expect(res.message).toMatch(/only allowed during/i);
+  });
+
+  it('honors an overnight booking after midnight (booked the previous day)', async () => {
+    // setNowToIST pins UTC to Jan 15, so IST 00:30 lands on Jan 16; the evening
+    // window was therefore booked on the previous IST day, Jan 15.
+    setNowToIST(0, 30);
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [slot('22:00', '01:00')] },
+      enrollment: {},
+      bookings: [{ date: '2026-01-15', from: '22:00', to: '01:00' }],
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+    expect(res.canAccess).toBe(true);
+  });
+
+  it('denies (must book) when neither a booking nor a legacy slot exists', async () => {
+    setNowToIST(14, 0);
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: {}, // no legacy slot, no bookings
+      bookings: [],
+    });
+
+    const res = await svc.canStudentAccessCourse(USER, COURSE, VERSION);
+    expect(res.canAccess).toBe(false);
+    expect(res.message).toMatch(/book a time slot/i);
   });
 });
 

--- a/backend/src/modules/setting/tests/TimeSlotService.test.ts
+++ b/backend/src/modules/setting/tests/TimeSlotService.test.ts
@@ -1,6 +1,10 @@
 import 'reflect-metadata';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TimeSlotService } from '../services/TimeSlotService.js';
+import {
+  SlotBookingKind,
+  SlotBookingStatus,
+} from '#shared/interfaces/models.js';
 
 /**
  * Unit tests for TimeSlotService.canStudentAccessCourse — the access gate that
@@ -26,7 +30,10 @@ const VERSION = 'version-1';
 function makeService(
   opts: {
     timeslots?: { isActive: boolean; slots: any[] } | null;
-    enrollment?: { assignedTimeSlots?: { from: string; to: string }[] } | null;
+    enrollment?: {
+      _id?: string;
+      assignedTimeSlots?: { from: string; to: string }[];
+    } | null;
     version?: { courseId: string } | null;
     bookings?: { date: string; from: string; to: string }[];
   } = {},
@@ -40,12 +47,14 @@ function makeService(
 
   const settingsRepo = {
     readTimeslotsSettings: vi.fn().mockResolvedValue(timeslots),
+    updateTimeslotsSettings: vi.fn().mockResolvedValue({acknowledged: true}),
   };
   const courseRepo = {
     readVersion: vi.fn().mockResolvedValue(version),
   };
   const enrollmentService = {
     findEnrollment: vi.fn().mockResolvedValue(enrollment),
+    addMultipleTimeSlotsToStudent: vi.fn().mockResolvedValue(true),
   };
   const slotBookingRepo = {
     // Date-aware: return only the bookings whose date matches the queried day.
@@ -54,6 +63,7 @@ function makeService(
       .mockImplementation((_u: string, _c: string, _v: string, date?: string) =>
         Promise.resolve(bookings.filter(b => !date || b.date === date)),
       ),
+    createBooking: vi.fn().mockResolvedValue({_id: 'booking-new'}),
   };
   const db = {} as any;
 
@@ -308,5 +318,58 @@ describe('TimeSlotService.canStudentAccessCourseByVersion', () => {
     expect(res.canAccess).toBe(false);
     expect(res.message).toMatch(/version not found/i);
     expect(settingsRepo.readTimeslotsSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe('TimeSlotService.chooseTimeSlot (dual-write)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('records a slot booking when a student chooses a slot', async () => {
+    setNowToIST(14, 0);
+    const { svc, slotBookingRepo } = makeService({
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: { _id: 'enroll-1' }, // no assignedTimeSlots yet
+    });
+
+    const ok = await svc.chooseTimeSlot(
+      COURSE,
+      VERSION,
+      { from: '13:00', to: '15:00' },
+      USER,
+    );
+
+    expect(ok).toBe(true);
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+    expect(slotBookingRepo.createBooking.mock.calls[0][0]).toMatchObject({
+      userId: USER,
+      enrollmentId: 'enroll-1',
+      from: '13:00',
+      to: '15:00',
+      kind: SlotBookingKind.BASE,
+      status: SlotBookingStatus.BOOKED,
+      hoursReserved: 2,
+      overnight: false,
+    });
+  });
+
+  it('does not write a booking when the student already has a slot', async () => {
+    const { svc, slotBookingRepo } = makeService({
+      timeslots: { isActive: true, slots: [slot('13:00', '15:00')] },
+      enrollment: {
+        _id: 'enroll-1',
+        assignedTimeSlots: [{ from: '13:00', to: '15:00' }],
+      },
+    });
+
+    await expect(
+      svc.chooseTimeSlot(COURSE, VERSION, { from: '13:00', to: '15:00' }, USER),
+    ).rejects.toThrowError(/already have a time slot/i);
+    expect(slotBookingRepo.createBooking).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/setting/types.ts
+++ b/backend/src/modules/setting/types.ts
@@ -3,6 +3,7 @@ const TYPES = {
   CourseSettingService: Symbol.for('CourseSettingService'),
   UserSettingService: Symbol.for('UserSettingService'),
   TimeSlotService: Symbol.for('TimeSlotService'),
+  SlotBookingService: Symbol.for('SlotBookingService'),
 
   // Repositories
   SettingRepo: Symbol.for('SettingRepo'),

--- a/backend/src/shared/database/interfaces/ISettingRepository.ts
+++ b/backend/src/shared/database/interfaces/ISettingRepository.ts
@@ -250,7 +250,7 @@ export interface ISettingRepository {
   updateTimeslotsSettings(
     courseId: string,
     courseVersionId: string,
-    timeslots: {isActive: boolean; slots: ITimeSlot[]},
+    timeslots: {isActive: boolean; slots: ITimeSlot[]; dailyBaseAllowance?: number},
     session?: ClientSession,
   ): Promise<UpdateResult | null>;
 
@@ -265,7 +265,7 @@ export interface ISettingRepository {
     courseId: string,
     courseVersionId: string,
     session?: ClientSession,
-  ): Promise<{isActive: boolean; slots: ITimeSlot[]} | null>;
+  ): Promise<{isActive: boolean; slots: ITimeSlot[]; dailyBaseAllowance?: number} | null>;
 
   getSettingsByVersionIds(
     courseVersionIds: ObjectId[],

--- a/backend/src/shared/database/interfaces/ISlotBookingRepository.ts
+++ b/backend/src/shared/database/interfaces/ISlotBookingRepository.ts
@@ -1,0 +1,47 @@
+import {ClientSession} from 'mongodb';
+import {ISlotBooking} from '../../interfaces/models.js';
+
+/**
+ * Repository for per-day slot bookings (the commitment-scheme booking records).
+ * Each booking is one student reserving one recurring time window for one date.
+ */
+export interface ISlotBookingRepository {
+  /** Persist a new booking. */
+  createBooking(
+    booking: ISlotBooking,
+    session?: ClientSession,
+  ): Promise<ISlotBooking | null>;
+
+  /** Fetch a single non-cancelled booking by id. */
+  findById(
+    bookingId: string,
+    session?: ClientSession,
+  ): Promise<ISlotBooking | null>;
+
+  /**
+   * Active (non-cancelled, non-deleted) bookings for a student on a course
+   * version. Pass `date` (YYYY-MM-DD IST) to restrict to a single day.
+   */
+  findActiveForStudent(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    date?: string,
+    session?: ClientSession,
+  ): Promise<ISlotBooking[]>;
+
+  /** Count active bookings in a given slot on a given date (capacity check). */
+  countActiveInSlot(
+    courseId: string,
+    courseVersionId: string,
+    date: string,
+    slot: {from: string; to: string},
+    session?: ClientSession,
+  ): Promise<number>;
+
+  /** Mark a booking cancelled (student re-book or instructor removal). */
+  cancelBooking(
+    bookingId: string,
+    session?: ClientSession,
+  ): Promise<boolean>;
+}

--- a/backend/src/shared/database/interfaces/index.ts
+++ b/backend/src/shared/database/interfaces/index.ts
@@ -4,3 +4,4 @@ export * from './ICourseRepository.js';
 export * from './IItemRepository.js';
 export * from './IInviteRepository.js';
 export * from './ISettingRepository.js';
+export * from './ISlotBookingRepository.js';

--- a/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
@@ -820,7 +820,7 @@ export class SettingRepository implements ISettingRepository {
   async updateTimeslotsSettings(
     courseId: string,
     courseVersionId: string,
-    timeslots: {isActive: boolean; slots: ITimeSlot[]},
+    timeslots: {isActive: boolean; slots: ITimeSlot[]; dailyBaseAllowance?: number},
     session?: ClientSession,
   ): Promise<UpdateResult | null> {
     await this.init();
@@ -845,7 +845,7 @@ export class SettingRepository implements ISettingRepository {
     courseId: string,
     courseVersionId: string,
     session?: ClientSession,
-  ): Promise<{isActive: boolean; slots: ITimeSlot[]} | null> {
+  ): Promise<{isActive: boolean; slots: ITimeSlot[]; dailyBaseAllowance?: number} | null> {
     await this.init();
 
     const courseSettings = await this.courseSettingsCollection.findOne(

--- a/backend/src/shared/database/providers/mongo/repositories/SlotBookingRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SlotBookingRepository.ts
@@ -1,0 +1,145 @@
+import 'reflect-metadata';
+import {Collection, ObjectId, ClientSession} from 'mongodb';
+import {injectable, inject} from 'inversify';
+import {MongoDatabase} from '../MongoDatabase.js';
+import {
+  ISlotBooking,
+  SlotBookingStatus,
+} from '#shared/interfaces/models.js';
+import {ISlotBookingRepository} from '#shared/database/index.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+
+/** Accepts a string or ObjectId and returns an ObjectId. */
+const oid = (value: string | ObjectId | null | undefined): ObjectId =>
+  value instanceof ObjectId ? value : new ObjectId(String(value));
+
+/**
+ * MongoDB implementation of the slot-bookings repository — the per-day
+ * commitment records for the time-slot booking feature.
+ */
+@injectable()
+export class SlotBookingRepository implements ISlotBookingRepository {
+  private slotBookingsCollection: Collection<ISlotBooking>;
+  private initialized = false;
+
+  constructor(@inject(GLOBAL_TYPES.Database) private db: MongoDatabase) {}
+
+  private async init() {
+    if (!this.initialized) {
+      this.slotBookingsCollection =
+        await this.db.getCollection<ISlotBooking>('slotBookings');
+      this.initialized = true;
+
+      // Look up a student's bookings for a course/day fast.
+      this.slotBookingsCollection.createIndex({
+        userId: 1,
+        courseId: 1,
+        courseVersionId: 1,
+        date: 1,
+        status: 1,
+      });
+      // Capacity counts per slot per day.
+      this.slotBookingsCollection.createIndex({
+        courseId: 1,
+        courseVersionId: 1,
+        date: 1,
+        from: 1,
+        to: 1,
+        status: 1,
+      });
+    }
+  }
+
+  async createBooking(
+    booking: ISlotBooking,
+    session?: ClientSession,
+  ): Promise<ISlotBooking | null> {
+    await this.init();
+    const now = new Date();
+    const doc: ISlotBooking = {
+      ...booking,
+      userId: oid(booking.userId),
+      enrollmentId: oid(booking.enrollmentId),
+      courseId: oid(booking.courseId),
+      courseVersionId: oid(booking.courseVersionId),
+      cohortId: booking.cohortId ? oid(booking.cohortId) : undefined,
+      createdAt: booking.createdAt ?? now,
+      updatedAt: now,
+      isDeleted: false,
+    };
+
+    const result = await this.slotBookingsCollection.insertOne(doc as any, {
+      session,
+    });
+    return {...doc, _id: result.insertedId};
+  }
+
+  async findById(
+    bookingId: string,
+    session?: ClientSession,
+  ): Promise<ISlotBooking | null> {
+    await this.init();
+    return this.slotBookingsCollection.findOne(
+      {
+        _id: new ObjectId(bookingId),
+        status: {$ne: SlotBookingStatus.CANCELLED},
+        isDeleted: {$ne: true},
+      } as any,
+      {session},
+    );
+  }
+
+  async findActiveForStudent(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    date?: string,
+    session?: ClientSession,
+  ): Promise<ISlotBooking[]> {
+    await this.init();
+    const query: Record<string, unknown> = {
+      userId: new ObjectId(userId),
+      courseId: new ObjectId(courseId),
+      courseVersionId: new ObjectId(courseVersionId),
+      status: {$ne: SlotBookingStatus.CANCELLED},
+      isDeleted: {$ne: true},
+    };
+    if (date) query.date = date;
+    return this.slotBookingsCollection.find(query as any, {session}).toArray();
+  }
+
+  async countActiveInSlot(
+    courseId: string,
+    courseVersionId: string,
+    date: string,
+    slot: {from: string; to: string},
+    session?: ClientSession,
+  ): Promise<number> {
+    await this.init();
+    return this.slotBookingsCollection.countDocuments(
+      {
+        courseId: new ObjectId(courseId),
+        courseVersionId: new ObjectId(courseVersionId),
+        date,
+        from: slot.from,
+        to: slot.to,
+        status: {$ne: SlotBookingStatus.CANCELLED},
+        isDeleted: {$ne: true},
+      } as any,
+      {session},
+    );
+  }
+
+  async cancelBooking(
+    bookingId: string,
+    session?: ClientSession,
+  ): Promise<boolean> {
+    await this.init();
+    const result = await this.slotBookingsCollection.updateOne(
+      {_id: new ObjectId(bookingId)} as any,
+      {$set: {status: SlotBookingStatus.CANCELLED, updatedAt: new Date()}},
+      {session},
+    );
+    return result.modifiedCount > 0;
+  }
+}

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -586,6 +586,47 @@ export interface ITimeSlot {
   maxStudents?: number; // Maximum number of students allowed in this timeslot
 }
 
+// How a slot booking was obtained.
+export enum SlotBookingKind {
+  BASE = 'BASE', // part of the student's daily base allowance
+  BONUS = 'BONUS', // earned by fully using a prior booking (Phase 3)
+}
+
+// Lifecycle of a single booking, evaluated at the window's end.
+export enum SlotBookingStatus {
+  BOOKED = 'BOOKED', // reserved, window not yet evaluated
+  FULFILLED = 'FULFILLED', // student was active for >= the required share of the window (Phase 3)
+  UNFULFILLED = 'UNFULFILLED', // window passed without being fully used (Phase 3)
+  CANCELLED = 'CANCELLED', // released by the student (re-book) or removed by the instructor
+}
+
+/**
+ * A single per-day commitment: a student booking one recurring time window of a
+ * course for a specific date (IST). Replaces the flat enrollment.assignedTimeSlots
+ * array — each booking is its own document with a lifecycle, so we can track
+ * fulfillment, bonuses, and an hours budget in later phases.
+ */
+export interface ISlotBooking {
+  _id?: ID;
+  userId: ID;
+  enrollmentId: ID;
+  courseId: ID;
+  courseVersionId: ID;
+  cohortId?: ID;
+  date: string; // YYYY-MM-DD in IST — the day this booking applies to
+  from: string; // HH:MM IST
+  to: string; // HH:MM IST
+  overnight: boolean; // window crosses midnight (from > to)
+  kind: SlotBookingKind;
+  status: SlotBookingStatus;
+  hoursReserved: number; // window length in hours, charged to the course budget (Phase 2)
+  activePct?: number; // share of the window the student was active (set at fulfillment, Phase 3)
+  fulfilledAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  isDeleted?: boolean;
+}
+
 export interface ISettings {
   proctors: IProctoringSettings;
   linearProgressionEnabled: boolean;
@@ -607,6 +648,9 @@ export interface ISettings {
   timeslots?: {
     isActive: boolean;
     slots: ITimeSlot[];
+    // How many base bookings a student gets per day (default 1). Bonuses add on
+    // top via fulfillment in later phases.
+    dailyBaseAllowance?: number;
   };
   // When a student completes this course version, automatically create an
   // exclusive invite to the configured follow-up course.

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -15,6 +15,7 @@ const TYPES = {
   CourseVersionService: Symbol.for('CourseVersionService'),
   
   SettingRepo: Symbol.for('SettingRepo'),
+  SlotBookingRepo: Symbol.for('SlotBookingRepo'),
 
   //Constants
   uri: Symbol.for('dbURI'),


### PR DESCRIPTION
Summary
Phase 1 of the Commitment Scheme (time-slot booking), a resource-optimization lever: per-slot capacity caps bound peak concurrent learners (the main DB/app-load driver), and bookings form a demand schedule ops can use to size capacity per window. Introduces a first-class slotBookings collection that supersedes the flat enrollment.assignedTimeSlots array. Fully additive / non-breaking — legacy slots still work via dual-read while the new path takes over.

What's included
Data model — ISlotBooking (per-day record: date, from/to, overnight, kind, status, hoursReserved) + SlotBookingKind/SlotBookingStatus enums; dailyBaseAllowance course setting; ISlotBookingRepository + Mongo provider (slotBookings, indexed) + DI.
SlotBookingService — book / cancel / list, enforcing hard capacity cap + daily allowance, with overnight windows; getSlotDemand (booked + remaining per window).
API — POST /slot-bookings/book, /cancel; GET /slot-bookings/my/..., /slot-bookings/demand/... (instructor).
Access gate (dual-read) — canStudentAccessCourse grants access if a new slotBooking or a legacy assignedTimeSlot covers now; queries today + yesterday so overnight windows past midnight work.
Write-path migration (dual-write) — both student chooseTimeSlot and teacher addTimeSlots mirror into slotBookings (shared idempotent recordSlotBooking), so existing UIs populate the new collection and the demand view counts everyone.
Toggle-preserve — disabling time slots now keeps slots/allowance/bookings (restored on re-enable); teacher confirmation copy corrected.
Tests
35 setting-module unit tests pass (gate dual-read incl. overnight, capacity cap, daily allowance, dual-write on choose/assign, toggle-preserve). Backend typecheck clean on all changed files.