### PR TITLE
fix: wrap handleQuizeProgressAfterSubmission in transaction and fix i…

### DIFF
--- a/backend/src/modules/quizzes/services/AttemptService.ts
+++ b/backend/src/modules/quizzes/services/AttemptService.ts
@@ -690,8 +690,8 @@ class AttemptService extends BaseService {
     /* -------------------- UPDATE SUBMISSION (SMALL WRITE) -------------------- */
 
     await this.submissionRepository.update(submissionId, { gradingResult });
-    if (!isSkipped && !isItemCompleted) {
-      const isPassed = gradingResult.gradingStatus === "PASSED"
+    const isPassed = gradingResult.gradingStatus === "PASSED"
+    if (!isSkipped && (!isItemCompleted || isPassed)) {
       await this.progressService.handleQuizeProgressAfterSubmission(userId, quizId, courseId, courseVersionId, isPassed, watchItemId, cohortId);
     }
 

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -3140,10 +3140,11 @@ class ProgressService extends BaseService {
     watchItemId?: string,
     cohortId?: string,
   ) {
-    // Fetch progress and course version in parallel
-    const [progress, courseVersion] = await Promise.all([
-      this.progressRepository.findProgress(userId, courseId, courseVersionId, cohortId),
-      this.courseRepo.readVersion(courseVersionId),
+    return this._withTransaction(async session => {
+      // Fetch progress and course version in parallel
+      const [progress, courseVersion] = await Promise.all([
+        this.progressRepository.findProgress(userId, courseId, courseVersionId, cohortId, session),
+        this.courseRepo.readVersion(courseVersionId),
     ]);
 
     if (!progress || !courseVersion) {
@@ -3184,6 +3185,7 @@ class ProgressService extends BaseService {
           courseVersionId,
           newProgress,
           cohortId,
+          session,
         );
       } else {
         const newProgress = {
@@ -3198,6 +3200,7 @@ class ProgressService extends BaseService {
           courseVersionId,
           newProgress,
           cohortId,
+          session,
         );
       }
     } else {
@@ -3221,6 +3224,7 @@ class ProgressService extends BaseService {
           courseVersionId,
           previousProgress,
           cohortId,
+          session,
         );
       }
     }
@@ -3238,6 +3242,7 @@ class ProgressService extends BaseService {
           courseId,
           courseVersionId,
           cohortId,
+          session,
         );
         
         if (activeWatchTimes && activeWatchTimes.length > 0) {
@@ -3272,12 +3277,14 @@ class ProgressService extends BaseService {
         cohortId,
       )
 
-      if (!isItemCompleted && resolvedWatchItemId) {
-        await this.progressRepository.stopItemTracking(
-          resolvedWatchItemId,
-        );
+        if (!isItemCompleted && resolvedWatchItemId) {
+          await this.progressRepository.stopItemTracking(
+            resolvedWatchItemId,
+            session,
+          );
+        }
       }
-    }
+    }); // close transaction
   }
 
   // Admin Level Endpoint


### PR DESCRIPTION
## Problem
Two bugs were causing lesson locked issues for students after passing a quiz.

1. The cursor advance and endTime writes inside `handleQuizeProgressAfterSubmission` were two separate non-transactional writes. If either failed silently, the cursor and completion state would go out of sync.

2. A guard in `AttemptService` was blocking cursor advancement if `isItemCompleted` returned true. Once endTime was set from the first pass, all subsequent passes were completely skipped — even if the student passed again.

## Fix
- Wrapped `handleQuizeProgressAfterSubmission` in `_withTransaction` so cursor advance and endTime write always succeed or fail together.
- Changed the guard from `!isItemCompleted` to `(!isItemCompleted || isPassed)` so cursor always advances when a quiz is passed regardless of existing endTime.
