### PR TITLE
feat(timeslots): per-course hours budget from instructor category est…

### DIFF
--- a/backend/src/modules/setting/controllers/TimeSlotController.ts
+++ b/backend/src/modules/setting/controllers/TimeSlotController.ts
@@ -76,6 +76,21 @@ class ToggleTimeSlotsRequestBody {
   isActive: boolean;
 }
 
+// Request body for configuring the per-course hours budget from the
+// instructor's per-category time estimates (minutes per item).
+class SetHoursBudgetRequestBody {
+  courseId: string;
+  courseVersionId: string;
+  estimatesMinutes: {
+    VIDEO?: number;
+    QUIZ?: number;
+    BLOG?: number;
+    PROJECT?: number;
+    FEEDBACK?: number;
+  };
+  hoursFactor?: number;
+}
+
 // Response for time slot operations
 class TimeSlotResponse {
   success: boolean;
@@ -360,6 +375,53 @@ class TimeSlotController {
         throw error;
       }
       throw new InternalServerError(`Failed to update time slot: ${error}`);
+    }
+  }
+
+  @OpenAPI({
+    summary: 'Set the per-course hours budget',
+    description:
+      "Computes and stores the students' committed-hours budget from the instructor's per-category time estimates (minutes per item) and the course's item counts. Captured when the feature is enabled.",
+  })
+  @Authorized()
+  @Put('/budget')
+  @HttpCode(200)
+  @ResponseSchema(TimeSlotResponse, {
+    description: 'Hours budget configured successfully',
+  })
+  async setHoursBudget(
+    @Body() body: SetHoursBudgetRequestBody,
+    @CurrentUser() user: IUser,
+    @Ability(getItemAbility) { ability },
+  ): Promise<TimeSlotResponse> {
+    const itemResource = subject('Item', { versionId: body.courseVersionId });
+    if (!ability.can(ItemActions.Modify, itemResource)) {
+      throw new ForbiddenError(
+        'You do not have permission to modify this item',
+      );
+    }
+
+    try {
+      const data = await this.timeSlotService.configureHoursBudget(
+        body.courseId,
+        body.courseVersionId,
+        body.estimatesMinutes ?? {},
+        body.hoursFactor,
+        user._id.toString(),
+      );
+      return {
+        success: true,
+        message: 'Hours budget configured successfully',
+        data,
+      };
+    } catch (error) {
+      if (
+        error instanceof BadRequestError ||
+        error instanceof NotFoundError
+      ) {
+        throw error;
+      }
+      throw new InternalServerError(`Failed to set hours budget: ${error}`);
     }
   }
 

--- a/backend/src/modules/setting/services/SlotBookingService.ts
+++ b/backend/src/modules/setting/services/SlotBookingService.ts
@@ -151,6 +151,30 @@ export class SlotBookingService extends BaseService {
         }
       }
 
+      const hoursReserved = this.slotHours(slot.from, slot.to);
+
+      // Per-course hours budget — the "committed hours" ceiling. A booking
+      // reserves its hours; the student can't exceed their total budget.
+      // Undefined budget = unlimited.
+      if (timeslots.totalBudgetHours != null) {
+        const consumed = await this.slotBookingRepo.sumReservedHoursForStudent(
+          userId,
+          courseId,
+          courseVersionId,
+          session,
+        );
+        if (consumed + hoursReserved > timeslots.totalBudgetHours) {
+          const remaining = Math.max(
+            0,
+            Math.round((timeslots.totalBudgetHours - consumed) * 100) / 100,
+          );
+          throw new BadRequestError(
+            `This booking (${hoursReserved}h) exceeds your committed hours for this course. ` +
+              `You have ${remaining}h of ${timeslots.totalBudgetHours}h remaining.`,
+          );
+        }
+      }
+
       const now = new Date();
       const booking: ISlotBooking = {
         userId,
@@ -164,7 +188,7 @@ export class SlotBookingService extends BaseService {
         overnight: this.isOvernight(slot.from, slot.to),
         kind: SlotBookingKind.BASE,
         status: SlotBookingStatus.BOOKED,
-        hoursReserved: this.slotHours(slot.from, slot.to),
+        hoursReserved,
         createdAt: now,
         updatedAt: now,
       };

--- a/backend/src/modules/setting/services/TimeSlotService.ts
+++ b/backend/src/modules/setting/services/TimeSlotService.ts
@@ -447,6 +447,83 @@ export class TimeSlotService extends BaseService {
   }
 
   /**
+   * Set the per-course hours budget from the instructor's per-category time
+   * estimates (minutes per item), captured when the feature is enabled. The
+   * budget = Σ(itemCount[category] × estimate[category]) hours × factor.
+   */
+  async configureHoursBudget(
+    courseId: string,
+    courseVersionId: string,
+    estimatesMinutes: {
+      VIDEO?: number;
+      QUIZ?: number;
+      BLOG?: number;
+      PROJECT?: number;
+      FEEDBACK?: number;
+    },
+    hoursFactor: number | undefined,
+    userId: string,
+  ): Promise<{
+    totalBudgetHours: number;
+    estimatedEffortHours: number;
+    itemCounts: Record<string, number>;
+  }> {
+    return this._withTransaction(async (session) => {
+      const version = await this.courseRepo.readVersion(
+        courseVersionId,
+        session,
+      );
+      if (!version) {
+        throw new NotFoundError('Course version not found.');
+      }
+
+      const counts = (version.itemCounts ?? {}) as Record<string, number>;
+      const categories = ['VIDEO', 'QUIZ', 'BLOG', 'PROJECT', 'FEEDBACK'] as const;
+
+      let totalMinutes = 0;
+      for (const cat of categories) {
+        const n = counts[cat] ?? 0;
+        const est = estimatesMinutes[cat] ?? 0;
+        if (est < 0) {
+          throw new BadRequestError(
+            `Invalid time estimate for ${cat}: ${est}. Must be >= 0.`,
+          );
+        }
+        totalMinutes += n * est;
+      }
+
+      const factor = hoursFactor && hoursFactor > 0 ? hoursFactor : 1;
+      const estimatedEffortHours = Math.round((totalMinutes / 60) * 100) / 100;
+      const totalBudgetHours =
+        Math.round(estimatedEffortHours * factor * 100) / 100;
+
+      const existing = await this.settingsRepo.readTimeslotsSettings(
+        courseId,
+        courseVersionId,
+        session,
+      );
+      const updated = {
+        ...(existing ?? { isActive: true, slots: [] }),
+        categoryTimeEstimatesMinutes: estimatesMinutes,
+        hoursFactor: factor,
+        totalBudgetHours,
+      };
+
+      const result = await this.settingsRepo.updateTimeslotsSettings(
+        courseId,
+        courseVersionId,
+        updated,
+        session,
+      );
+      if (!result) {
+        throw new InternalServerError('Failed to save the hours budget.');
+      }
+
+      return { totalBudgetHours, estimatedEffortHours, itemCounts: counts };
+    });
+  }
+
+  /**
    * Update existing time slot
    */
   async updateTimeSlot(

--- a/backend/src/modules/setting/tests/SlotBookingService.test.ts
+++ b/backend/src/modules/setting/tests/SlotBookingService.test.ts
@@ -28,6 +28,7 @@ function makeService(
     myBookings?: any[];
     slotCount?: number;
     bookingById?: any;
+    reservedHours?: number;
   } = {},
 ) {
   const {
@@ -40,11 +41,13 @@ function makeService(
     myBookings = [],
     slotCount = 0,
     bookingById = null,
+    reservedHours = 0,
   } = opts;
 
   const slotBookingRepo = {
     findActiveForStudent: vi.fn().mockResolvedValue(myBookings),
     countActiveInSlot: vi.fn().mockResolvedValue(slotCount),
+    sumReservedHoursForStudent: vi.fn().mockResolvedValue(reservedHours),
     createBooking: vi
       .fn()
       .mockImplementation((b: any) => Promise.resolve({...b, _id: 'booking-new'})),
@@ -170,6 +173,49 @@ describe('SlotBookingService.bookSlot', () => {
 
     await svc.bookSlot(USER, COURSE, VERSION, SLOT);
     expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+  });
+
+  // --- per-course hours budget (SLOT is 13:00–15:00 = 2h) ---
+
+  const budgetSlots = [{from: '13:00', to: '15:00', studentIds: []}];
+
+  it('books when within the committed hours budget', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      timeslots: {isActive: true, slots: budgetSlots, totalBudgetHours: 4},
+      reservedHours: 1, // 1 + 2 = 3 <= 4
+    });
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT);
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+  });
+
+  it('allows booking that lands exactly on the budget', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      timeslots: {isActive: true, slots: budgetSlots, totalBudgetHours: 2},
+      reservedHours: 0, // 0 + 2 = 2 <= 2
+    });
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT);
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a booking that would exceed the committed hours budget', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      timeslots: {isActive: true, slots: budgetSlots, totalBudgetHours: 2},
+      reservedHours: 1, // 1 + 2 = 3 > 2
+    });
+    await expect(
+      svc.bookSlot(USER, COURSE, VERSION, SLOT),
+    ).rejects.toThrowError(/committed hours/i);
+    expect(slotBookingRepo.createBooking).not.toHaveBeenCalled();
+  });
+
+  it('does not enforce a budget when none is configured (unlimited)', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      timeslots: {isActive: true, slots: budgetSlots}, // no totalBudgetHours
+      reservedHours: 999,
+    });
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT);
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+    expect(slotBookingRepo.sumReservedHoursForStudent).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/src/modules/setting/tests/TimeSlotService.test.ts
+++ b/backend/src/modules/setting/tests/TimeSlotService.test.ts
@@ -34,7 +34,7 @@ function makeService(
       _id?: string;
       assignedTimeSlots?: { from: string; to: string }[];
     } | null;
-    version?: { courseId: string } | null;
+    version?: { courseId: string; itemCounts?: Record<string, number> } | null;
     bookings?: { date: string; from: string; to: string }[];
   } = {},
 ) {
@@ -444,5 +444,62 @@ describe('TimeSlotService.addTimeSlots (teacher dual-write)', () => {
       kind: SlotBookingKind.BASE,
       status: SlotBookingStatus.BOOKED,
     });
+  });
+});
+
+describe('TimeSlotService.configureHoursBudget', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('computes the budget from per-category estimates × item counts', async () => {
+    const { svc, settingsRepo } = makeService({
+      version: {
+        courseId: COURSE,
+        itemCounts: { VIDEO: 10, QUIZ: 4, BLOG: 6, PROJECT: 1 },
+      },
+      timeslots: { isActive: true, slots: [] },
+    });
+
+    // 10*12 + 4*15 + 6*20 + 1*120 = 420 min = 7h
+    const res = await svc.configureHoursBudget(
+      COURSE,
+      VERSION,
+      { VIDEO: 12, QUIZ: 15, BLOG: 20, PROJECT: 120 },
+      undefined,
+      'teacher-1',
+    );
+
+    expect(res.estimatedEffortHours).toBe(7);
+    expect(res.totalBudgetHours).toBe(7);
+    const saved = settingsRepo.updateTimeslotsSettings.mock.calls[0][2];
+    expect(saved.totalBudgetHours).toBe(7);
+    expect(saved.categoryTimeEstimatesMinutes).toEqual({
+      VIDEO: 12,
+      QUIZ: 15,
+      BLOG: 20,
+      PROJECT: 120,
+    });
+  });
+
+  it('applies the hours factor', async () => {
+    const { svc } = makeService({
+      version: { courseId: COURSE, itemCounts: { VIDEO: 10 } },
+    });
+    // 10*6 = 60 min = 1h × 1.5 = 1.5h
+    const res = await svc.configureHoursBudget(
+      COURSE,
+      VERSION,
+      { VIDEO: 6 },
+      1.5,
+      'teacher-1',
+    );
+    expect(res.estimatedEffortHours).toBe(1);
+    expect(res.totalBudgetHours).toBe(1.5);
+  });
+
+  it('rejects when the course version is not found', async () => {
+    const { svc } = makeService({ version: null });
+    await expect(
+      svc.configureHoursBudget(COURSE, VERSION, { VIDEO: 6 }, undefined, 't1'),
+    ).rejects.toThrowError(/version not found/i);
   });
 });

--- a/backend/src/shared/database/interfaces/ISettingRepository.ts
+++ b/backend/src/shared/database/interfaces/ISettingRepository.ts
@@ -250,7 +250,7 @@ export interface ISettingRepository {
   updateTimeslotsSettings(
     courseId: string,
     courseVersionId: string,
-    timeslots: {isActive: boolean; slots: ITimeSlot[]; dailyBaseAllowance?: number},
+    timeslots: NonNullable<ISettings['timeslots']>,
     session?: ClientSession,
   ): Promise<UpdateResult | null>;
 
@@ -265,7 +265,7 @@ export interface ISettingRepository {
     courseId: string,
     courseVersionId: string,
     session?: ClientSession,
-  ): Promise<{isActive: boolean; slots: ITimeSlot[]; dailyBaseAllowance?: number} | null>;
+  ): Promise<NonNullable<ISettings['timeslots']> | null>;
 
   getSettingsByVersionIds(
     courseVersionIds: ObjectId[],

--- a/backend/src/shared/database/interfaces/ISlotBookingRepository.ts
+++ b/backend/src/shared/database/interfaces/ISlotBookingRepository.ts
@@ -39,6 +39,17 @@ export interface ISlotBookingRepository {
     session?: ClientSession,
   ): Promise<number>;
 
+  /**
+   * Total `hoursReserved` across a student's active (non-cancelled) bookings on
+   * a course version — i.e. the hours they've consumed from their budget.
+   */
+  sumReservedHoursForStudent(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<number>;
+
   /** Mark a booking cancelled (student re-book or instructor removal). */
   cancelBooking(
     bookingId: string,

--- a/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SettingRepository.ts
@@ -820,7 +820,7 @@ export class SettingRepository implements ISettingRepository {
   async updateTimeslotsSettings(
     courseId: string,
     courseVersionId: string,
-    timeslots: {isActive: boolean; slots: ITimeSlot[]; dailyBaseAllowance?: number},
+    timeslots: NonNullable<ISettings['timeslots']>,
     session?: ClientSession,
   ): Promise<UpdateResult | null> {
     await this.init();
@@ -845,7 +845,7 @@ export class SettingRepository implements ISettingRepository {
     courseId: string,
     courseVersionId: string,
     session?: ClientSession,
-  ): Promise<{isActive: boolean; slots: ITimeSlot[]; dailyBaseAllowance?: number} | null> {
+  ): Promise<NonNullable<ISettings['timeslots']> | null> {
     await this.init();
 
     const courseSettings = await this.courseSettingsCollection.findOne(

--- a/backend/src/shared/database/providers/mongo/repositories/SlotBookingRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SlotBookingRepository.ts
@@ -130,6 +130,33 @@ export class SlotBookingRepository implements ISlotBookingRepository {
     );
   }
 
+  async sumReservedHoursForStudent(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<number> {
+    await this.init();
+    const result = await this.slotBookingsCollection
+      .aggregate(
+        [
+          {
+            $match: {
+              userId: new ObjectId(userId),
+              courseId: new ObjectId(courseId),
+              courseVersionId: new ObjectId(courseVersionId),
+              status: {$ne: SlotBookingStatus.CANCELLED},
+              isDeleted: {$ne: true},
+            },
+          },
+          {$group: {_id: null, total: {$sum: '$hoursReserved'}}},
+        ],
+        {session},
+      )
+      .toArray();
+    return result.length > 0 ? (result[0] as any).total ?? 0 : 0;
+  }
+
   async cancelBooking(
     bookingId: string,
     session?: ClientSession,

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -651,6 +651,22 @@ export interface ISettings {
     // How many base bookings a student gets per day (default 1). Bonuses add on
     // top via fulfillment in later phases.
     dailyBaseAllowance?: number;
+    // Total committed hours a student may book across this course (their hours
+    // budget). Bookings consume their `hoursReserved` against it; undefined =
+    // unlimited. Computed from the instructor's per-category estimates × counts.
+    totalBudgetHours?: number;
+    // Optional multiplier applied to the estimated effort (default 1).
+    hoursFactor?: number;
+    // Instructor's estimated time PER ITEM (minutes) for each item category,
+    // captured when the feature is enabled. Combined with the course version's
+    // item counts to compute totalBudgetHours.
+    categoryTimeEstimatesMinutes?: {
+      VIDEO?: number;
+      QUIZ?: number;
+      BLOG?: number;
+      PROJECT?: number;
+      FEEDBACK?: number;
+    };
   };
   // When a student completes this course version, automatically create an
   // exclusive invite to the configured follow-up course.


### PR DESCRIPTION
Phase 2 of the commitment scheme — the "committed hours" budget.

- Instructor input: when enabling time slots, the instructor gives a per-item time estimate (minutes) for each item category (VIDEO/QUIZ/BLOG/PROJECT/ FEEDBACK). TimeSlotService.configureHoursBudget combines those with the course version's item counts to compute totalBudgetHours = Σ(itemCount[cat] × estimate[cat]) hours × hoursFactor, and stores the estimates + budget on the course timeslots settings. Exposed via PUT /timeslots/budget (instructor-only).
- Enforcement: SlotBookingService.bookSlot rejects a booking when the student's reserved hours + this slot would exceed totalBudgetHours (undefined budget = unlimited). New repo aggregation sumReservedHoursForStudent sums hoursReserved over active bookings.
- Refactor: the repo timeslots config type now reuses the canonical NonNullable<ISettings['timeslots']> instead of repeated inline literals.
- Tests: +3 budget-compute, +4 enforcement (42 setting-module tests pass).

Backend only; the toggle-on UI to capture the estimates is next.

