### PR TITLE
feat(timeslots): instructor-granted extra committed hours

### DIFF
--- a/backend/src/modules/setting/controllers/TimeSlotController.ts
+++ b/backend/src/modules/setting/controllers/TimeSlotController.ts
@@ -387,6 +387,30 @@ class TimeSlotController {
   }
 
   @OpenAPI({
+    summary: 'Check time-slot access for the current student',
+    description:
+      "Returns whether the calling student can currently access the course under its time-slot rules. Used by the player to poll for a live cut-off when a booked window ends.",
+  })
+  @Authorized()
+  @Get('/check-access/:courseId/:courseVersionId')
+  @HttpCode(200)
+  async checkTimeSlotAccess(
+    @Param('courseId') courseId: string,
+    @Param('courseVersionId') courseVersionId: string,
+    @CurrentUser() user: IUser,
+  ): Promise<{ canAccess: boolean; message?: string }> {
+    try {
+      return await this.timeSlotService.canStudentAccessCourse(
+        user._id.toString(),
+        courseId,
+        courseVersionId,
+      );
+    } catch (error) {
+      throw new InternalServerError(`Failed to check time slot access: ${error}`);
+    }
+  }
+
+  @OpenAPI({
     summary: 'Set the per-course hours budget',
     description:
       "Computes and stores the students' committed-hours budget from the instructor's per-category time estimates (minutes per item) and the course's item counts. Captured when the feature is enabled.",

--- a/backend/src/modules/setting/controllers/TimeSlotController.ts
+++ b/backend/src/modules/setting/controllers/TimeSlotController.ts
@@ -91,6 +91,14 @@ class SetHoursBudgetRequestBody {
   hoursFactor?: number;
 }
 
+// Request body for granting a student extra committed hours.
+class ExtendStudentHoursRequestBody {
+  courseId: string;
+  courseVersionId: string;
+  studentId: string;
+  extraHours: number;
+}
+
 // Response for time slot operations
 class TimeSlotResponse {
   success: boolean;
@@ -422,6 +430,54 @@ class TimeSlotController {
         throw error;
       }
       throw new InternalServerError(`Failed to set hours budget: ${error}`);
+    }
+  }
+
+  @OpenAPI({
+    summary: 'Grant a student extra committed hours',
+    description:
+      "Adds extra hours to a student's committed-hours budget (instructor action when a student has used up their hours).",
+  })
+  @Authorized()
+  @Put('/extend')
+  @HttpCode(200)
+  @ResponseSchema(TimeSlotResponse, {
+    description: 'Extra hours granted successfully',
+  })
+  async extendStudentHours(
+    @Body() body: ExtendStudentHoursRequestBody,
+    @CurrentUser() user: IUser,
+    @Ability(getItemAbility) { ability },
+  ): Promise<TimeSlotResponse> {
+    const itemResource = subject('Item', { versionId: body.courseVersionId });
+    if (!ability.can(ItemActions.Modify, itemResource)) {
+      throw new ForbiddenError(
+        'You do not have permission to modify this item',
+      );
+    }
+
+    try {
+      const data = await this.timeSlotService.extendStudentHours(
+        body.courseId,
+        body.courseVersionId,
+        body.studentId,
+        body.extraHours,
+        user._id.toString(),
+      );
+      return {
+        success: true,
+        message: 'Extra hours granted successfully',
+        data,
+      };
+    } catch (error) {
+      if (
+        error instanceof BadRequestError ||
+        error instanceof NotFoundError ||
+        error instanceof ForbiddenError
+      ) {
+        throw error;
+      }
+      throw new InternalServerError(`Failed to grant extra hours: ${error}`);
     }
   }
 

--- a/backend/src/modules/setting/services/SlotBookingService.ts
+++ b/backend/src/modules/setting/services/SlotBookingService.ts
@@ -153,24 +153,28 @@ export class SlotBookingService extends BaseService {
 
       const hoursReserved = this.slotHours(slot.from, slot.to);
 
-      // Per-course hours budget — the "committed hours" ceiling. A booking
-      // reserves its hours; the student can't exceed their total budget.
-      // Undefined budget = unlimited.
+      // Per-course hours budget — the "committed hours" ceiling, plus any extra
+      // hours an instructor has granted this student. A booking reserves its
+      // hours; the student can't exceed their budget. Undefined = unlimited.
       if (timeslots.totalBudgetHours != null) {
+        const budget =
+          timeslots.totalBudgetHours +
+          ((enrollment as {commitmentExtraHours?: number})
+            .commitmentExtraHours ?? 0);
         const consumed = await this.slotBookingRepo.sumReservedHoursForStudent(
           userId,
           courseId,
           courseVersionId,
           session,
         );
-        if (consumed + hoursReserved > timeslots.totalBudgetHours) {
+        if (consumed + hoursReserved > budget) {
           const remaining = Math.max(
             0,
-            Math.round((timeslots.totalBudgetHours - consumed) * 100) / 100,
+            Math.round((budget - consumed) * 100) / 100,
           );
           throw new BadRequestError(
             `This booking (${hoursReserved}h) exceeds your committed hours for this course. ` +
-              `You have ${remaining}h of ${timeslots.totalBudgetHours}h remaining.`,
+              `You have ${remaining}h of ${budget}h remaining.`,
           );
         }
       }

--- a/backend/src/modules/setting/services/TimeSlotService.ts
+++ b/backend/src/modules/setting/services/TimeSlotService.ts
@@ -524,6 +524,30 @@ export class TimeSlotService extends BaseService {
   }
 
   /**
+   * Grant a student extra committed hours on top of the course budget
+   * (instructor action when a student has exhausted their hours).
+   */
+  async extendStudentHours(
+    courseId: string,
+    courseVersionId: string,
+    studentId: string,
+    extraHours: number,
+    userId: string,
+  ): Promise<{ commitmentExtraHours: number }> {
+    if (!extraHours || extraHours <= 0) {
+      throw new BadRequestError('extraHours must be greater than 0.');
+    }
+    const commitmentExtraHours =
+      await this.enrollmentService.grantCommitmentExtraHours(
+        studentId,
+        courseId,
+        courseVersionId,
+        extraHours,
+      );
+    return { commitmentExtraHours };
+  }
+
+  /**
    * Update existing time slot
    */
   async updateTimeSlot(

--- a/backend/src/modules/setting/tests/SlotBookingService.test.ts
+++ b/backend/src/modules/setting/tests/SlotBookingService.test.ts
@@ -208,6 +208,16 @@ describe('SlotBookingService.bookSlot', () => {
     expect(slotBookingRepo.createBooking).not.toHaveBeenCalled();
   });
 
+  it('counts instructor-granted extra hours toward the budget', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      timeslots: {isActive: true, slots: budgetSlots, totalBudgetHours: 2},
+      enrollment: {_id: 'enroll-1', commitmentExtraHours: 2}, // budget = 2 + 2 = 4
+      reservedHours: 1, // 1 + 2 = 3 <= 4
+    });
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT);
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+  });
+
   it('does not enforce a budget when none is configured (unlimited)', async () => {
     const {svc, slotBookingRepo} = makeService({
       timeslots: {isActive: true, slots: budgetSlots}, // no totalBudgetHours

--- a/backend/src/modules/setting/tests/TimeSlotService.test.ts
+++ b/backend/src/modules/setting/tests/TimeSlotService.test.ts
@@ -57,6 +57,7 @@ function makeService(
     findEnrollment: vi.fn().mockResolvedValue(enrollment),
     addMultipleTimeSlotsToStudent: vi.fn().mockResolvedValue(true),
     updateStudentTimeSlot: vi.fn().mockResolvedValue(true),
+    grantCommitmentExtraHours: vi.fn().mockResolvedValue(5),
   };
   const slotBookingRepo = {
     // Date-aware: return only the bookings whose date matches the queried day.
@@ -501,5 +502,37 @@ describe('TimeSlotService.configureHoursBudget', () => {
     await expect(
       svc.configureHoursBudget(COURSE, VERSION, { VIDEO: 6 }, undefined, 't1'),
     ).rejects.toThrowError(/version not found/i);
+  });
+});
+
+describe('TimeSlotService.extendStudentHours', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('grants extra hours and returns the new total', async () => {
+    const { svc, enrollmentService } = makeService();
+
+    const res = await svc.extendStudentHours(
+      COURSE,
+      VERSION,
+      'student-9',
+      3,
+      'teacher-1',
+    );
+
+    expect(enrollmentService.grantCommitmentExtraHours).toHaveBeenCalledWith(
+      'student-9',
+      COURSE,
+      VERSION,
+      3,
+    );
+    expect(res.commitmentExtraHours).toBe(5);
+  });
+
+  it('rejects a non-positive amount', async () => {
+    const { svc, enrollmentService } = makeService();
+    await expect(
+      svc.extendStudentHours(COURSE, VERSION, 'student-9', 0, 'teacher-1'),
+    ).rejects.toThrowError(/greater than 0/i);
+    expect(enrollmentService.grantCommitmentExtraHours).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -2042,6 +2042,38 @@ export class EnrollmentService extends BaseService {
   }
 
   /**
+   * Grant a student extra committed hours (instructor action). Returns the
+   * enrollment's new total commitmentExtraHours.
+   */
+  async grantCommitmentExtraHours(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    extraHours: number,
+    session?: ClientSession,
+  ): Promise<number> {
+    const execute = async (session: ClientSession) => {
+      const enrollment = await this.enrollmentRepo.findActiveEnrollment(
+        userId,
+        courseId,
+        courseVersionId,
+        null,
+        session,
+      );
+      if (!enrollment) {
+        throw new NotFoundError('Enrollment not found for this student.');
+      }
+      return this.enrollmentRepo.addCommitmentExtraHours(
+        enrollment._id?.toString(),
+        extraHours,
+        session,
+      );
+    };
+
+    return session ? execute(session) : this._withTransaction(execute);
+  }
+
+  /**
    * Remove assigned time slot from student enrollment
    */
   async removeStudentTimeSlot(

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -4270,6 +4270,29 @@ export class EnrollmentRepository {
   }
 
   /**
+   * Add (increment) extra committed hours on an enrollment and return the new
+   * total. Used when an instructor grants a student more hours budget.
+   */
+  async addCommitmentExtraHours(
+    enrollmentId: string,
+    extraHours: number,
+    session?: ClientSession,
+  ): Promise<number> {
+    await this.init();
+
+    const updated = await this.enrollmentCollection.findOneAndUpdate(
+      { _id: new ObjectId(enrollmentId) },
+      {
+        $inc: { commitmentExtraHours: extraHours },
+        $set: { updatedAt: new Date() },
+      },
+      { session, returnDocument: 'after' },
+    );
+
+    return (updated as any)?.commitmentExtraHours ?? 0;
+  }
+
+  /**
    * Remove a specific time slot from enrollment's assigned time slots
    */
   async removeEnrollmentTimeSlot(

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -410,6 +410,9 @@ export interface IEnrollment {
     from: string; // HH:MM format in IST
     to: string; // HH:MM format in IST
   }>;
+  // Extra committed hours granted to this student by an instructor, added on
+  // top of the course's totalBudgetHours when enforcing the hours budget.
+  commitmentExtraHours?: number;
   isDeleted?: boolean;
   deletedAt?: Date;
   unenrolledAt?: Date;

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -14,7 +14,7 @@ import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { ThemeToggle } from "@/components/theme-toggle";
-import { useCourseVersionById, useUserProgress, useItemsBySectionId, useItemById, useProctoringSettings, useGetProcotoringSettings, useSubmitFlag, enqueueNavigation, useSkipOptionalItem, useRecalculateStudentProgress, useInvites, useAcceptInvite } from "@/hooks/hooks";
+import { useCourseVersionById, useUserProgress, useItemsBySectionId, useItemById, useProctoringSettings, useGetProcotoringSettings, useSubmitFlag, enqueueNavigation, useSkipOptionalItem, useRecalculateStudentProgress, useInvites, useAcceptInvite, useCheckTimeSlotAccess } from "@/hooks/hooks";
 import { useAuthStore } from "@/store/auth-store";
 import { useCourseStore } from "@/store/course-store";
 import { Link, Navigate, useRouter } from "@tanstack/react-router";
@@ -234,6 +234,20 @@ export default function CoursePage() {
   const [isNavigatingToNext, setIsNavigatingToNext] = useState<boolean>(false);
   const [rewindVid, setRewindVid] = useState<boolean>(false);
   const [pauseVid, setPauseVid] = useState<boolean>(false);
+  // Live cut-off: poll the time-slot gate while an item is open so the student
+  // is blocked the moment their booked window ends (not just on the next fetch).
+  const { data: liveAccess } = useCheckTimeSlotAccess(
+    COURSE_ID || undefined,
+    VERSION_ID || undefined,
+    !!COURSE_ID && !!VERSION_ID && !!selectedItemId,
+    60000, // poll every 60s
+  );
+  useEffect(() => {
+    if (liveAccess && liveAccess.canAccess === false) {
+      setTimeSlotBlock(liveAccess.message || "Your booked time slot has ended.");
+      setPauseVid(true);
+    }
+  }, [liveAccess]);
   const [quizPassed, setQuizPassed] = useState(2);
   const [anomalies, setAnomalies] = useState<string[]>([]);
   const [isQuizSkipped, setIsQuizSkipped] = useState(false);

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -5697,10 +5697,12 @@ export function useSetHoursBudget() {
 }
 
 // GET /timeslots/check-access/{courseId}/{courseVersionId}
+// Pass pollMs to poll for a live cut-off when a booked window ends.
 export function useCheckTimeSlotAccess(
   courseId: string | undefined,
   courseVersionId: string | undefined,
-  enabled: boolean = true
+  enabled: boolean = true,
+  pollMs: number = 0
 ): {
   data: { canAccess: boolean; message?: string } | undefined,
   isLoading: boolean,
@@ -5718,7 +5720,8 @@ export function useCheckTimeSlotAccess(
     {
       enabled: !!courseId && !!courseVersionId && enabled,
       retry: 1,
-      refetchOnWindowFocus: false
+      refetchOnWindowFocus: false,
+      refetchInterval: pollMs > 0 ? pollMs : false
     }
   );
 


### PR DESCRIPTION
Completes the hours-budget loop — when a student exhausts their committed hours, an instructor can grant more.

- IEnrollment.commitmentExtraHours (per-student extra hours).
- EnrollmentRepository.addCommitmentExtraHours ($inc) + EnrollmentService.grantCommitmentExtraHours (find active enrollment, increment, return new total).
- TimeSlotService.extendStudentHours -> PUT /timeslots/extend (instructor-only).
- bookSlot budget check now uses totalBudgetHours + commitmentExtraHours, so granted hours immediately unlock more bookings.
- Tests: +3 (extra hours count toward budget; grant returns new total; rejects <= 0). 45 setting-module tests pass.

