### PR TITLE
fix(timeslots): don't block enrolled students on cohortId mismatch

### DIFF
--- a/backend/src/modules/setting/services/TimeSlotService.ts
+++ b/backend/src/modules/setting/services/TimeSlotService.ts
@@ -890,12 +890,24 @@ export class TimeSlotService extends BaseService {
       }
 
       // Get student enrollment
-      const enrollment = await this.enrollmentService.findEnrollment(
+      let enrollment = await this.enrollmentService.findEnrollment(
         userId,
         courseId,
         courseVersionId,
         cohortId,
       );
+
+      // The enrollment row's cohortId may be null or differ from the course's
+      // cohortId, which makes the strict cohort match above miss an otherwise
+      // valid enrollment. We're verifying enrollment here, not the cohort, so
+      // retry cohort-agnostic before declaring the student "not enrolled".
+      if (!enrollment && cohortId) {
+        enrollment = await this.enrollmentService.findEnrollment(
+          userId,
+          courseId,
+          courseVersionId,
+        );
+      }
 
       if (!enrollment) {
         return { canAccess: false, message: 'Student not enrolled in this course.' };

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -1979,6 +1979,13 @@ return false;
                                   const isSectionExpanded = expandedSections[sectionId];
                                   const isCurrentSection = sectionId === selectedSectionId;
                                   const isLoadingItems = activeSectionInfo?.sectionId === sectionId && itemsLoading;
+                                  // The items fetch is scoped to the active section, so a
+                                  // time-slot block only applies to that one section — never
+                                  // mislabel other expanded sections' empty state with it.
+                                  const isTimeSlotBlockedSection =
+                                    activeSectionInfo?.sectionId === sectionId &&
+                                    sectionItemsErrorName === "TimeSlotAccessDenied" &&
+                                    !sectionItems[sectionId];
 
                                   return (
                                     <SidebarMenuSubItem 
@@ -2079,6 +2086,12 @@ return false;
                                                 </SidebarMenuSubItem>
                                               );
                                             })
+                                          ) : isTimeSlotBlockedSection ? (
+                                            <div className="p-3 text-center">
+                                              <div className="text-xs text-muted-foreground">
+                                                {sectionItemsError || "Content is locked outside your booked time slot."}
+                                              </div>
+                                            </div>
                                           ) : (
                                             <div className="p-3 text-center">
                                               <div className="text-xs text-muted-foreground">No items found</div>


### PR DESCRIPTION
The PR #1072 time-slot gate on the section-items endpoint looked up the student's enrollment with a strict cohortId equality. When an enrollment row's cohortId is null or differs from the course's cohortId, the lookup returned null and the gate denied access as "Student not enrolled", rendering "No items found" for every section.

Retry the enrollment lookup cohort-agnostic before declaring the student not enrolled — we're verifying enrollment here, not the cohort. Also surface the actual time-slot block message (scoped to the active section) instead of the generic "No items found" empty state.

