### PR TITLE
refactor(timeslots): gate access at course entry, drop item-level gates

### DIFF
--- a/backend/src/modules/courses/controllers/ItemController.ts
+++ b/backend/src/modules/courses/controllers/ItemController.ts
@@ -224,28 +224,6 @@ export class ItemController {
       );
     }
 
-    // Time-slot ("commitment") gate: a student may only load section content
-    // during a booked window. Instructors/managers/TAs bypass. This mirrors the
-    // gate on getItem — without it, the player can fetch full item content here
-    // and skip the per-item check entirely.
-    const canManageGate = ability.can(
-      ItemActions.Modify,
-      subject('Item', {versionId}),
-    );
-    if (!canManageGate) {
-      const access =
-        await this.timeSlotService.canStudentAccessCourseByVersion(
-          user._id.toString(),
-          versionId,
-          cohortId,
-        );
-      if (!access.canAccess) {
-        throw new TimeSlotAccessError(
-          access.message || 'Time slot access denied',
-        );
-      }
-    }
-
     const items = await this.itemService.readAllItems(
       versionId,
       moduleId,

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -14,7 +14,7 @@ import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { ThemeToggle } from "@/components/theme-toggle";
-import { useCourseVersionById, useUserProgress, useItemsBySectionId, useItemById, useProctoringSettings, useGetProcotoringSettings, useSubmitFlag, enqueueNavigation, useSkipOptionalItem, useRecalculateStudentProgress, useInvites, useAcceptInvite, useCheckTimeSlotAccess } from "@/hooks/hooks";
+import { useCourseVersionById, useUserProgress, useItemsBySectionId, useItemById, useProctoringSettings, useGetProcotoringSettings, useSubmitFlag, enqueueNavigation, useSkipOptionalItem, useRecalculateStudentProgress, useInvites, useAcceptInvite } from "@/hooks/hooks";
 import { useAuthStore } from "@/store/auth-store";
 import { useCourseStore } from "@/store/course-store";
 import { Link, Navigate, useRouter } from "@tanstack/react-router";
@@ -234,20 +234,6 @@ export default function CoursePage() {
   const [isNavigatingToNext, setIsNavigatingToNext] = useState<boolean>(false);
   const [rewindVid, setRewindVid] = useState<boolean>(false);
   const [pauseVid, setPauseVid] = useState<boolean>(false);
-  // Live cut-off: poll the time-slot gate while an item is open so the student
-  // is blocked the moment their booked window ends (not just on the next fetch).
-  const { data: liveAccess } = useCheckTimeSlotAccess(
-    COURSE_ID || undefined,
-    VERSION_ID || undefined,
-    !!COURSE_ID && !!VERSION_ID && !!selectedItemId,
-    60000, // poll every 60s
-  );
-  useEffect(() => {
-    if (liveAccess && liveAccess.canAccess === false) {
-      setTimeSlotBlock(liveAccess.message || "Your booked time slot has ended.");
-      setPauseVid(true);
-    }
-  }, [liveAccess]);
   const [quizPassed, setQuizPassed] = useState(2);
   const [anomalies, setAnomalies] = useState<string[]>([]);
   const [isQuizSkipped, setIsQuizSkipped] = useState(false);

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -8,7 +8,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useLeaderboard, useCourseVersionById } from "@/hooks/hooks";
+import { useLeaderboard, useCourseVersionById, useCheckTimeSlotAccessOnDemand } from "@/hooks/hooks";
+import { toast } from "sonner";
 import { useCourseStore } from "@/store/course-store";
 import { useNavigate } from "@tanstack/react-router";
 import { useState, lazy, useEffect } from "react";
@@ -73,6 +74,7 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
 
   const { setCurrentCourse } = useCourseStore();
   const navigate = useNavigate();
+  const { check: checkTimeSlotAccess } = useCheckTimeSlotAccessOnDemand();
   const [isFlipped, setIsFlipped] = useState(false);
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const [isTimeslotModalOpen, setIsTimeslotModalOpen] = useState(false);
@@ -153,7 +155,7 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
    
   })
 
-  const handleContinue = () => {
+  const handleContinue = async () => {
     if (variant === 'available') {
       navigate({
         to: "/student/course-registration/$versionId/{-$cohort}",
@@ -162,7 +164,13 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
       return;
     }
 
-   
+    // Time-slot ("commitment") gate at entry: only let the student in during a
+    // booked window. The backend getItem gate is the safety net.
+    const access = await checkTimeSlotAccess(courseId, versionId);
+    if (!access.canAccess) {
+      toast.error(access.message || "You can only access this course during your booked time slot.");
+      return;
+    }
 
     // Pass both courseId and versionId to the store
     setCurrentCourse({

--- a/frontend/src/components/course/CourseListCard.tsx
+++ b/frontend/src/components/course/CourseListCard.tsx
@@ -2,7 +2,8 @@ import { Clock, Info, Play, Trophy, Headphones, MessageCircle, ExternalLink, Use
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { useCourseVersionById, useLeaderboard } from "@/hooks/hooks";
+import { useCourseVersionById, useLeaderboard, useCheckTimeSlotAccessOnDemand } from "@/hooks/hooks";
+import { toast } from "sonner";
 import { useCourseStore } from "@/store/course-store";
 import { useNavigate } from "@tanstack/react-router";
 import { useState, lazy, Suspense, useEffect } from "react";
@@ -54,6 +55,7 @@ export const CourseListCard = ({ enrollment, index, isLoading: _isLoading, varia
   const { data: courseVersionData } = useCourseVersionById(versionId, variant !== 'available', cohortId || undefined);
   const { setCurrentCourse } = useCourseStore();
   const navigate = useNavigate();
+  const { check: checkTimeSlotAccess } = useCheckTimeSlotAccessOnDemand();
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const [isTimeslotModalOpen, setIsTimeslotModalOpen] = useState(false);
   const [isLeaderboardOpen, setIsLeaderboardOpen] = useState(false);
@@ -79,10 +81,17 @@ export const CourseListCard = ({ enrollment, index, isLoading: _isLoading, varia
   const quizCount = Number((contentCounts as any).quizzes ?? itemCounts.QUIZ ?? versionItemCounts.QUIZ ?? 0);
 
 
-  const handleContinue = (e?: React.MouseEvent) => {
+  const handleContinue = async (e?: React.MouseEvent) => {
     e?.stopPropagation();
     if (variant === 'available') {
       navigate({ to: "/student/course-registration/$versionId/{-$cohort}", params: { versionId, cohort: cohortId } });
+      return;
+    }
+    // Time-slot ("commitment") gate at entry: only let the student in during a
+    // booked window. The backend getItem gate is the safety net.
+    const access = await checkTimeSlotAccess(courseId, versionId);
+    if (!access.canAccess) {
+      toast.error(access.message || "You can only access this course during your booked time slot.");
       return;
     }
     setCurrentCourse({

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -5735,6 +5735,31 @@ export function useGrantExtraHours() {
   return { grantExtraHours, loading, error };
 }
 
+// Imperative check used to gate entry on the "Continue Learning" click.
+// Returns { canAccess, message }. Fails OPEN (allows) on any network/error so a
+// transient failure never locks a student out — the backend gate is the backstop.
+export function useCheckTimeSlotAccessOnDemand() {
+  const check = async (
+    courseId: string,
+    courseVersionId: string,
+  ): Promise<{ canAccess: boolean; message?: string }> => {
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/timeslots/check-access/${courseId}/${courseVersionId}`;
+      const res = await fetch(url, {
+        headers: {
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+      });
+      if (!res.ok) return { canAccess: true };
+      const data = await res.json().catch(() => ({ canAccess: true }));
+      return { canAccess: data?.canAccess !== false, message: data?.message };
+    } catch {
+      return { canAccess: true };
+    }
+  };
+  return { check };
+}
+
 // GET /timeslots/check-access/{courseId}/{courseVersionId}
 // Pass pollMs to poll for a live cut-off when a booked window ends.
 export function useCheckTimeSlotAccess(


### PR DESCRIPTION
Simplify the commitment gate to a single check at the "Continue Learning" entry plus one backend safety net, instead of policing every content fetch.

- Frontend entry gate: handleContinue (CourseCard + CourseListCard) checks GET /timeslots/check-access before entering the course; outside the window it shows the message and does not navigate. New imperative hook useCheckTimeSlotAccessOnDemand (fails open on network errors).
- Remove the readAll (section-items) gate in ItemController; keep getItem as the single backend safety net.
- Remove the live-cutoff polling + pause effect in course-page.

Matches the resource-optimization goal (control when a session starts) and removes the per-content gates, the quiz->version resolver path, and the polling that made the gate complex.