### PR TITLE
fix(courses): don't show "No items found" on a cohortId mismatch

### DIFF
--- a/backend/src/modules/courses/services/CourseVersionService.ts
+++ b/backend/src/modules/courses/services/CourseVersionService.ts
@@ -221,13 +221,25 @@ export class CourseVersionService extends BaseService {
 
       const courseId = readVersion.courseId.toString();
 
-      const enrollment =
+      let enrollment =
         await this.enrollmentService.getUserEnrollmentsByCourseVersion(
           userId,
           courseId,
           courseVersionId,
           cohortId,
         );
+
+      // The enrollment row's cohortId may be null or differ from the
+      // client-sent cohortId; identify the enrolled user, not the cohort, so
+      // retry cohort-agnostic before failing (mirrors #1081 / ItemService).
+      if (!enrollment && cohortId) {
+        enrollment =
+          await this.enrollmentService.getUserEnrollmentsByCourseVersion(
+            userId,
+            courseId,
+            courseVersionId,
+          );
+      }
 
       if (!enrollment) {
         throw new NotFoundError(

--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -378,12 +378,32 @@ export class ItemService extends BaseService {
       throw new NotFoundError(`Course for version ${versionId} not found.`);
     }
 
-    const user = await this.enrollmentRepo.getUserEnrollmentsByCourseVersion(
+    let user = await this.enrollmentRepo.getUserEnrollmentsByCourseVersion(
       userId,
       course.courseId.toString(),
       versionId,
       cohortId
     );
+
+    // The enrollment row's cohortId may be null or differ from the course's
+    // cohortId, which makes the strict cohort match miss an otherwise valid
+    // enrollment. We're identifying the enrolled user here, not the cohort, so
+    // retry cohort-agnostic before treating them as not enrolled (mirrors the
+    // gate fix in #1081). Without this, the null `user` below crashed on
+    // `user.role`, surfacing as "No items found" for every section.
+    if (!user && cohortId) {
+      user = await this.enrollmentRepo.getUserEnrollmentsByCourseVersion(
+        userId,
+        course.courseId.toString(),
+        versionId,
+      );
+    }
+
+    if (!user) {
+      throw new NotFoundError(
+        `User ${userId} is not enrolled in course version ${versionId}.`,
+      );
+    }
 
     // Only filter hidden items for students
     if (user.role === 'STUDENT') {
@@ -544,12 +564,23 @@ export class ItemService extends BaseService {
     
 
     // Fetch enrollment early
-    const enrollment = await this.enrollmentRepo.findEnrollment(
+    let enrollment = await this.enrollmentRepo.findEnrollment(
       userId,
       courseId,
       versionId,
       cohortId
     );
+
+    // Same cohortId-mismatch guard as readAllItems (#1081): a null or
+    // different cohortId on the enrollment row must not read as "not enrolled"
+    // when opening an item.
+    if (!enrollment && cohortId) {
+      enrollment = await this.enrollmentRepo.findEnrollment(
+        userId,
+        courseId,
+        versionId,
+      );
+    }
 
     if (!enrollment) {
       throw new UnauthorizedError(

--- a/backend/src/modules/setting/services/SlotBookingService.ts
+++ b/backend/src/modules/setting/services/SlotBookingService.ts
@@ -105,12 +105,22 @@ export class SlotBookingService extends BaseService {
         );
       }
 
-      const enrollment = await this.enrollmentService.findEnrollment(
+      let enrollment = await this.enrollmentService.findEnrollment(
         userId,
         courseId,
         courseVersionId,
         cohortId,
       );
+      // The enrollment row's cohortId may be null or differ from the
+      // client-sent cohortId; identify the enrolled user, not the cohort, so
+      // retry cohort-agnostic before failing (mirrors #1081 / ItemService).
+      if (!enrollment && cohortId) {
+        enrollment = await this.enrollmentService.findEnrollment(
+          userId,
+          courseId,
+          courseVersionId,
+        );
+      }
       if (!enrollment) {
         throw new NotFoundError('You are not enrolled in this course.');
       }

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -429,6 +429,38 @@ class ProgressService extends BaseService {
     );
   }
 
+  // Resolve the user's enrollment for identity. The enrollment row's cohortId
+  // may be null or differ from the client-sent cohortId; a strict cohort match
+  // then misses an otherwise valid enrollment and surfaces as "enrollment not
+  // found" (which breaks progress tracking and content access). We're
+  // identifying the enrolled user here, not validating the cohort, so retry
+  // cohort-agnostic before giving up (mirrors the gate fix in #1081).
+  private async resolveEnrollment(
+    userId: string | ObjectId,
+    courseId: string,
+    courseVersionId: string,
+    cohortId?: string,
+    session?: ClientSession,
+  ): Promise<IEnrollment | null> {
+    let enrollment = await this.enrollmentRepo.findEnrollment(
+      userId,
+      courseId,
+      courseVersionId,
+      cohortId,
+      session,
+    );
+    if (!enrollment && cohortId) {
+      enrollment = await this.enrollmentRepo.findEnrollment(
+        userId,
+        courseId,
+        courseVersionId,
+        undefined,
+        session,
+      );
+    }
+    return enrollment;
+  }
+
   async updateEnrollmentProgressPercent(
     userId: string,
     courseId: string,
@@ -439,12 +471,12 @@ class ProgressService extends BaseService {
     completedItemCount?: number,
     cohort?: string,
   ): Promise<void> {
-    let enrollment = await this.enrollmentRepo.findEnrollment(
+    let enrollment = await this.resolveEnrollment(
       userId,
       courseId,
       courseVersionId,
       cohort,
-      session
+      session,
     );
 
     if (!enrollment) {
@@ -1620,7 +1652,7 @@ class ProgressService extends BaseService {
           session,
         );
 
-      const enrollment = await this.enrollmentRepo.findEnrollment(
+      const enrollment = await this.resolveEnrollment(
         userId,
         courseId,
         courseVersionId,
@@ -1659,7 +1691,7 @@ class ProgressService extends BaseService {
 
       await this.verifyDetails(userId, courseId, courseVersionId);
 
-      const enrollment = await this.enrollmentRepo.findEnrollment(
+      const enrollment = await this.resolveEnrollment(
         userId,
         courseId,
         courseVersionId,
@@ -2490,7 +2522,7 @@ class ProgressService extends BaseService {
       // ----------------------------------------------------
       // 7. ENROLLMENT LOOKUP
       // ----------------------------------------------------
-      const enrollment = await this.enrollmentRepo.findEnrollment(
+      const enrollment = await this.resolveEnrollment(
         userId,
         courseId,
         courseVersionId,
@@ -4404,7 +4436,7 @@ class ProgressService extends BaseService {
     const [completedItemIds, courseVersion, enrollment] = await Promise.all([
       this.progressRepository.getCompletedItems(userId, courseId, versionId, cohortId),
       this.courseRepo.readVersion(versionId),
-      this.enrollmentRepo.findEnrollment(userId, courseId, versionId, cohortId),
+      this.resolveEnrollment(userId, courseId, versionId, cohortId),
     ]);
 
     if (!courseVersion) {


### PR DESCRIPTION
readAllItems and the single-item fetch looked up the student's enrollment with a strict cohortId equality. When an enrollment row's cohortId is null or differs from the one the client sends, the lookup returns null — readAllItems then crashed on `user.role` (500 -> the sidebar's "No items found" for every section), and the item fetch wrongly threw "not enrolled".

Retry the enrollment lookup cohort-agnostic before failing — we're identifying the enrolled user here, not validating the cohort. Mirrors the gate fix in #1081, which only covered the TimeSlotService copy; the same strict lookup remained in ItemService and became the live path once the section-items gate was removed (#1083).

