### PR TITLE
chore(timeslots): keep only the entry gate; remove all content-path g…

### DIFF
--- a/backend/src/modules/courses/controllers/ItemController.ts
+++ b/backend/src/modules/courses/controllers/ItemController.ts
@@ -63,23 +63,8 @@ import {
 } from '#root/modules/auditTrails/interfaces/IAuditTrails.js';
 import {setAuditTrail} from '#root/utils/setAuditTrail.js';
 import {ObjectId} from 'mongodb';
-import {SETTING_TYPES} from '#root/modules/setting/types.js';
-import {TimeSlotService} from '#root/modules/setting/services/TimeSlotService.js';
 import {EnrollmentService} from '#root/modules/users/services/EnrollmentService.js';
 import {USERS_TYPES} from '#root/modules/users/types.js';
-
-/**
- * Distinct 403 for the time-slot / commitment gate so the frontend can tell it apart
- * from a generic ForbiddenError (e.g. linear-progression locks) and surface the right
- * "book a time slot" message + CTA instead of the generic "lesson locked" notice.
- */
-export class TimeSlotAccessError extends ForbiddenError {
-  constructor(message?: string) {
-    super(message);
-    this.name = 'TimeSlotAccessDenied';
-    Object.setPrototypeOf(this, TimeSlotAccessError.prototype);
-  }
-}
 
 @OpenAPI({
   tags: ['Course Items'],
@@ -92,8 +77,6 @@ export class ItemController {
     private readonly itemService: ItemService,
     @inject(QUIZZES_TYPES.QuizService)
     private readonly quizService: QuizService,
-    @inject(SETTING_TYPES.TimeSlotService)
-    private readonly timeSlotService: TimeSlotService,
     @inject(USERS_TYPES.EnrollmentService)
     private readonly enrollmentService: EnrollmentService,
   ) {}
@@ -717,45 +700,11 @@ Access control logic:
   })
   async getItem(
     @Params() params: GetItemParams,
-    @Ability(getItemAbility) { ability },
     @CurrentUser() user: { _id: string },
     @QueryParam('cohortId') cohortId?: string,
   ) {
     const {versionId, itemId, courseId, moduleId, sectionId} = params;
     const {_id: userId} = user;
-
-    // Check if user is instructor/manager/TA - they should bypass time slot validation
-    const sampleItemResource = subject('Item', {versionId});
-    const canManage = ability.can(ItemActions.Modify, sampleItemResource);
-
-    if (!canManage) {
-      // Only apply time slot validation for students
-      try {
-        const timeSlotAccess =
-          await this.timeSlotService.canStudentAccessCourse(
-            userId.toString(),
-            courseId,
-            versionId,
-            cohortId,
-          );
-
-        if (!timeSlotAccess.canAccess) {
-          throw new TimeSlotAccessError(
-            timeSlotAccess.message || 'Time slot access denied',
-          );
-        }
-      } catch (error) {
-        // Re-throw our intended 403s (time-slot block or any ForbiddenError) untouched
-        // so the frontend can distinguish them by name.
-        if (
-          error.name === 'TimeSlotAccessDenied' ||
-          error.name === 'ForbiddenError'
-        ) {
-          throw error;
-        }
-        throw new ForbiddenError('Time slot access check failed');
-      }
-    }
 
     // Create an item resource object for permission checking
     const itemResource = subject('Item', {courseId, versionId, itemId});

--- a/backend/src/modules/quizzes/services/AttemptService.ts
+++ b/backend/src/modules/quizzes/services/AttemptService.ts
@@ -68,8 +68,6 @@ import {
   IStudentSegmentQuestion,
 } from '#root/modules/studentQuestions/classes/transformers/StudentSegmentQuestion.js';
 import { STUDENT_QUESTION_TYPES } from '#root/modules/studentQuestions/types.js';
-import { SETTING_TYPES } from '#root/modules/setting/types.js';
-import { TimeSlotService } from '#root/modules/setting/services/TimeSlotService.js';
 
 const PEER_QUESTION_DEFAULT_POINTS = 0;
 const PEER_QUESTION_DEFAULT_TIME_LIMIT_SECONDS = 60;
@@ -116,42 +114,10 @@ class AttemptService extends BaseService {
     @inject(STUDENT_QUESTION_TYPES.StudentQuestionRepo)
     private readonly studentQuestionRepo: StudentQuestionRepository,
 
-    @inject(SETTING_TYPES.TimeSlotService)
-    private readonly timeSlotService: TimeSlotService,
-
     @inject(GLOBAL_TYPES.Database)
     private readonly database: MongoDatabase,
   ) {
     super(database);
-  }
-
-  /**
-   * Time-slot ("commitment") gate for starting a quiz — a student may only
-   * enter a quiz during a booked window. Resolves the course version from the
-   * quiz (quiz → items-group → version) and applies the access gate. No-op when
-   * the feature is inactive or the version can't be resolved.
-   */
-  private async assertTimeSlotAccessForQuiz(
-    userId: string,
-    quizId: string,
-    cohortId?: string,
-  ): Promise<void> {
-    const itemsGroup = await this.itemRepo.findItemsGroupByItemId(quizId);
-    if (!itemsGroup?._id) return;
-    const version = await this.courseRepo.findVersionByItemGroupId(
-      itemsGroup._id.toString(),
-    );
-    if (!version?._id || !version.courseId) return;
-
-    const access = await this.timeSlotService.canStudentAccessCourse(
-      userId,
-      version.courseId.toString(),
-      version._id.toString(),
-      cohortId,
-    );
-    if (!access.canAccess) {
-      throw new ForbiddenError(access.message || 'Time slot access denied');
-    }
   }
 
   private async _getQuestionsForAttempt(quiz: QuizItem): Promise<{
@@ -458,14 +424,6 @@ class AttemptService extends BaseService {
     quizId: string,
     cohortId?: string
   ): Promise<{ attemptId: string; questionRenderViews: IQuestionRenderView[] }> {
-    // Gate quiz entry by the student's time-slot booking (does nothing when the
-    // feature is off). Runs before the transaction — it's a read-only check.
-    await this.assertTimeSlotAccessForQuiz(
-      userId.toString(),
-      quizId,
-      cohortId,
-    );
-
     return this._withTransaction(async session => {
 
 

--- a/frontend/src/app/pages/student/course-page.tsx
+++ b/frontend/src/app/pages/student/course-page.tsx
@@ -304,8 +304,6 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
   const {
     data: currentSectionItems,
     isLoading: itemsLoading,
-    error: sectionItemsError,
-    errorName: sectionItemsErrorName
   } = useItemsBySectionId(
     shouldFetchItems ? VERSION_ID : '',
     shouldFetchItems ? activeSectionInfo!.moduleId : '',
@@ -407,14 +405,6 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
   ]);
 
 
-  // The section-items endpoint is the other (ungated-until-now) content path.
-  // If it returns the time-slot block, surface the same persistent notice.
-  useEffect(() => {
-    if (sectionItemsErrorName === "TimeSlotAccessDenied" && sectionItemsError) {
-      setTimeSlotBlock(sectionItemsError);
-    }
-  }, [sectionItemsErrorName, sectionItemsError]);
-
   // Separate effect for handling item errors - prevents circular dependencies
   useEffect(() => {
     if (!itemError) return;
@@ -423,34 +413,6 @@ const [backgroundSectionInfo, setBackgroundSectionInfo] = useState<{
     if (itemError.includes("auth/id-token-expired")) {
       logout();
       Navigate({ to: '/auth' });
-      return;
-    }
-
-    // Time-slot / commitment gate — distinct from a linear-progression ForbiddenError.
-    // Show a persistent, actionable notice instead of the generic "lesson locked" card.
-    if (itemError && selectedItemId && itemErrorName === "TimeSlotAccessDenied") {
-      setIsNavigatingToNext(false);
-      setIsItemForbidden(false);
-      setTimeSlotBlock(itemError);
-
-      // Revert to the last valid item so the player isn't stuck on a blocked item.
-      if (previousValidItem) {
-        setSelectedModuleId(previousValidItem.moduleId);
-        setSelectedSectionId(previousValidItem.sectionId);
-        setSelectedItemId(previousValidItem.itemId);
-        if (!sectionItems[previousValidItem.sectionId]) {
-          setActiveSectionInfo({
-            moduleId: previousValidItem.moduleId,
-            sectionId: previousValidItem.sectionId,
-          });
-        }
-        updateCourseNavigation(
-          previousValidItem.moduleId,
-          previousValidItem.sectionId,
-          previousValidItem.itemId,
-        );
-      }
-      // Persistent on purpose — the student must book a slot or wait for their window.
       return;
     }
 
@@ -1965,13 +1927,6 @@ return false;
                                   const isSectionExpanded = expandedSections[sectionId];
                                   const isCurrentSection = sectionId === selectedSectionId;
                                   const isLoadingItems = activeSectionInfo?.sectionId === sectionId && itemsLoading;
-                                  // The items fetch is scoped to the active section, so a
-                                  // time-slot block only applies to that one section — never
-                                  // mislabel other expanded sections' empty state with it.
-                                  const isTimeSlotBlockedSection =
-                                    activeSectionInfo?.sectionId === sectionId &&
-                                    sectionItemsErrorName === "TimeSlotAccessDenied" &&
-                                    !sectionItems[sectionId];
 
                                   return (
                                     <SidebarMenuSubItem 
@@ -2072,12 +2027,6 @@ return false;
                                                 </SidebarMenuSubItem>
                                               );
                                             })
-                                          ) : isTimeSlotBlockedSection ? (
-                                            <div className="p-3 text-center">
-                                              <div className="text-xs text-muted-foreground">
-                                                {sectionItemsError || "Content is locked outside your booked time slot."}
-                                              </div>
-                                            </div>
                                           ) : (
                                             <div className="p-3 text-center">
                                               <div className="text-xs text-muted-foreground">No items found</div>


### PR DESCRIPTION
…ating

The commitment gate now lives solely at the "Continue Learning" entry click (frontend handleContinue -> GET /timeslots/check-access). Every per-content enforcement point is removed so a student is never gated mid-course:

- ItemController.getItem: drop the canStudentAccessCourse gate + the TimeSlotAccessError class + the now-unused TimeSlotService injection/import.
- AttemptService.attempt: drop the quiz-entry gate (assertTimeSlotAccessForQuiz)
  + its TimeSlotService injection/import.
- course-page: remove the now-dead TimeSlotAccessDenied reactions (section + item effects) and the blocked-section sidebar branch.

canStudentAccessCourse stays (it backs the check-access endpoint that powers the entry gate). No backend content path enforces the window anymore.