### PR TITLE
Fix/next item resolver graceful

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -1221,15 +1221,14 @@ class ProgressService extends BaseService {
 
       return {};
     } catch (error: any) {
+      // Best-effort only: this method just *widens* the allowed set so a student
+      // can move past an exhausted-attempt quiz. If the next item can't be
+      // resolved — e.g. an orphaned itemsGroup whose section can't be
+      // reverse-mapped (getItemGroupInfo -> null) — degrade to "no next item"
+      // instead of throwing. A failed next-item lookup must never 404 the whole
+      // course view (which surfaced to learners as "No items found").
       console.error('Error in next-item permission processing:', error);
-
-      if (error instanceof NotFoundError) {
-        throw error;
-      }
-
-      throw new InternalServerError(
-        'Failed to determine next allowed item: ' + error?.message,
-      );
+      return {};
     }
   }
   private async findNextPlayableItem(

--- a/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
@@ -548,19 +548,28 @@ export class CourseRepository implements ICourseRepository {
     itemGroupId: ID,
     session?: ClientSession,
   ): Promise<IItemGroupInfo | null> {
+    if (!itemGroupId) return null;
+    // section.itemsGroupId is stored as an ObjectId (SectionService), but callers
+    // pass the id as a string and a Mongo $match does NOT coerce string<->ObjectId.
+    // A string-only match silently returned null here, which 404'd the next-item
+    // resolver ("Module/Section not found for itemGroupId"). Match both forms.
+    const idStr = itemGroupId.toString();
+    const idVariants: (string | ObjectId)[] = ObjectId.isValid(idStr)
+      ? [idStr, new ObjectId(idStr)]
+      : [idStr];
     const result = await this.courseVersionCollection
       .aggregate<IItemGroupInfo>(
         [
           {
             $match: {
-              'modules.sections.itemsGroupId': itemGroupId,
+              'modules.sections.itemsGroupId': { $in: idVariants },
             },
           },
           { $unwind: '$modules' },
           { $unwind: '$modules.sections' },
           {
             $match: {
-              'modules.sections.itemsGroupId': itemGroupId,
+              'modules.sections.itemsGroupId': { $in: idVariants },
             },
           },
           {


### PR DESCRIPTION
Problem: Learners saw "No items found" — items/item calls 404'd with NotFoundError: "Module/Section not found for itemGroupId". Chain: getItemAbility (on readAll + getItem) → determineNextAllowedItem → getItemGroupInfo returns null → 404. Null because section.itemsGroupId is stored as ObjectId but the lookup matched a string, and Mongo $match doesn't coerce the two. Latent for everyone; exposed only when the current item is a quiz with 0 attempts left.

Fix: (1) determineNextAllowedItem degrades to "no next item" instead of throwing — best-effort widening must never 404 the view (not a progression-rule change). (2) getItemGroupInfo matches $in: [str, ObjectId] so the reverse lookup resolves. No data repair needed — the ids were valid; the query was wrong.