### PR TITLE
fix: resolve quiz's actual moduleId/sectionId for cross-module rollover

### DIFF
--- a/backend/src/modules/quizzes/services/AttemptService.ts
+++ b/backend/src/modules/quizzes/services/AttemptService.ts
@@ -723,18 +723,42 @@ class AttemptService extends BaseService {
     };
 
     const isItemCompleted = await this.progressRepository.isItemCompleted(
-        userId.toString(),
-        courseId,
-        courseVersionId,
-        quizId,
-        cohortId,
-      )
+      userId.toString(),
+      courseId,
+      courseVersionId,
+      quizId,
+      cohortId,
+    )
     /* -------------------- UPDATE SUBMISSION (SMALL WRITE) -------------------- */
-
     await this.submissionRepository.update(submissionId, { gradingResult });
     const isPassed = gradingResult.gradingStatus === "PASSED"
     if (!isSkipped && (!isItemCompleted || isPassed)) {
-      await this.progressService.handleQuizeProgressAfterSubmission(userId, quizId, courseId, courseVersionId, isPassed, watchItemId, cohortId);
+      // Resolve the quiz's actual moduleId/sectionId rather than trusting
+      // progress.currentModule/currentSection, which can be stale if the
+      // student's cursor has drifted ahead via optimistic UI. Without this,
+      // getNextItemInSequence checks "is this the last item" against the
+      // wrong section and never rolls over into the next module.
+      let quizModuleId: string | undefined;
+      let quizSectionId: string | undefined;
+      const quizItemsGroup = await this.itemRepo.findItemsGroupByItemId(quizId);
+      if (quizItemsGroup?._id) {
+        const quizVersion = await this.courseRepo.findVersionByItemGroupId(
+          quizItemsGroup._id.toString(),
+        );
+        if (quizVersion) {
+          for (const mod of quizVersion.modules) {
+            const sec = mod.sections.find(
+              s => s.itemsGroupId?.toString() === quizItemsGroup._id.toString(),
+            );
+            if (sec) {
+              quizModuleId = mod.moduleId?.toString();
+              quizSectionId = sec.sectionId?.toString();
+              break;
+            }
+          }
+        }
+      }
+      await this.progressService.handleQuizeProgressAfterSubmission(userId, quizId, courseId, courseVersionId, isPassed, watchItemId, cohortId, quizModuleId, quizSectionId);
     }
 
     /* -------------------- RETURN BASED ON QUIZ SETTINGS -------------------- */

--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -3184,6 +3184,8 @@ class ProgressService extends BaseService {
     isPassed: boolean,
     watchItemId?: string,
     cohortId?: string,
+    quizModuleId?: string,
+    quizSectionId?: string,
   ) {
     return this._withTransaction(async session => {
       // Fetch progress and course version in parallel
@@ -3198,13 +3200,18 @@ class ProgressService extends BaseService {
 
     // const courseVersion = await this.courseRepo.readVersion(courseVersionId);
 
-    if (isPassed) {
-      const nextItemDetails = await this.getNextItemInSequence(
-        courseVersion,
-        progress.currentModule.toString(),
-        progress.currentSection.toString(),
-        quizId,
-      );
+      if (isPassed) {
+        // Prefer the quiz's actual module/section over the cursor's current
+        // position — the cursor can be stale if it drifted ahead via optimistic
+        // UI, which would make getNextItemInSequence check "is this the last
+        // item" against the wrong section and silently fail to roll over into
+        // the next module.
+        const nextItemDetails = await this.getNextItemInSequence(
+          courseVersion,
+          quizModuleId || progress.currentModule.toString(),
+          quizSectionId || progress.currentSection.toString(),
+          quizId,
+        );
 
       if (!nextItemDetails) {
         // Course completed → reset to first item


### PR DESCRIPTION
handleQuizeProgressAfterSubmission used progress.currentModule/currentSection (the student's saved cursor) to find the next item after a quiz pass. If the cursor had drifted ahead of the quiz's actual section, getNextItemInSequence checked isLastItem against the wrong section and never rolled over into the next module — cursor stuck, next module locked, even though the quiz was passed.
Now resolves the quiz's real moduleId/sectionId from its own itemsGroup before calling the handler, and uses that instead of the cursor when calling getNextItemInSequence, falling back to the old cursor-based values if the lookup doesn't resolve.