### PR TITLE
fix: prevent stale nextItemId in stop API calls via ref

### DIFF
--- a/frontend/src/components/quiz.tsx
+++ b/frontend/src/components/quiz.tsx
@@ -93,6 +93,10 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
   // ===== REFS AND CONSTANTS =====
   const itemStartedRef = useRef(false);
   const quizAttemptedRef = useRef(false);
+  const nextItemIdRef = useRef(nextItemId);
+  useEffect(() => {
+    nextItemIdRef.current = nextItemId;
+  }, [nextItemId]);
   const processedQuizId = bufferToHex(quizId);
 
   // ===== HOOKS =====
@@ -506,13 +510,13 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
         sectionId: currentCourse.sectionId ?? '',
         attemptId,
         isSkipped,
-        nextItemId,
+        nextItemId: nextItemIdRef.current,
         cohortId: currentCourse.cohortId ?? '',
       }
     });
     completedItemIdsRef.current.add(currentCourse.itemId);
     itemStartedRef.current = false;
-  }, [currentCourse, stopItem, attemptId, isAlreadyWatched, completedItemIdsRef]);
+  }, [currentCourse, stopItem, attemptId, isAlreadyWatched, completedItemIdsRef, nextItemId]);
 
 
   const stopItemAsync = useCallback(
@@ -540,14 +544,14 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
           sectionId: currentCourse.sectionId ?? '',
           attemptId,
           isSkipped,
-          nextItemId,
+          nextItemId: nextItemIdRef.current,
           cohortId: currentCourse.cohortId ?? '',
         },
       });
 
       itemStartedRef.current = false;
     },
-    [currentCourse, stopItem, attemptId]
+    [currentCourse, stopItem, attemptId, nextItemId]
   );
 
   useEffect(() => {
@@ -1197,7 +1201,7 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
             sectionId: currentCourse.sectionId ?? '',
             attemptId,
             isSkipped: false,
-            nextItemId,
+            nextItemId: nextItemIdRef.current,
             cohortId: currentCourse.cohortId ?? '',
           }
         });
@@ -1216,7 +1220,7 @@ const Quiz = forwardRef<QuizRef, QuizProps>(({
         questionId: currentQuestion?.id
       };
     }
-  }), [stopItem, currentCourse, attemptId, resetQuiz, currentQuestion]);
+  }), [stopItem, currentCourse, attemptId, resetQuiz, currentQuestion, nextItemId]);
 
   // ===== RENDER LOGIC =====
 

--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -97,6 +97,10 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
   const progressStoppedRef = useRef(false);
   const watchItemIdRef = useRef<string | null>(null);
   const stopInFlightRef = useRef(false);
+   const nextItemIdRef = useRef(nextItemId);
+  useEffect(() => {
+    nextItemIdRef.current = nextItemId;
+  }, [nextItemId]);
 
   // subtitlesEnabled is persisted in the player store (see usePlayerStore above).
   const [subtitlesAvailable, setSubtitlesAvailable] = useState(false);
@@ -416,7 +420,7 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
                 moduleId: currentCourse!.moduleId ?? '',
                 sectionId: currentCourse!.sectionId ?? '',
                 seekForwardEnabled,
-                nextItemId,
+                nextItemId: nextItemIdRef.current,
                 cohortId: currentCourse!.cohortId || undefined,
               },
             });


### PR DESCRIPTION
Updated video and quiz stop flows to use the latest nextItemId while sending stop requests.

Previously, stale next-item values could be retained during item transitions, especially around section boundaries. This change ensures stop requests always use the most recent next-item information, improving progression handling during video and quiz completion flows.