### PR TITLE
feat(timeslot): advance booking window (D-2 9AM to D 9AM IST)

### DIFF
--- a/backend/src/modules/setting/controllers/SlotBookingController.ts
+++ b/backend/src/modules/setting/controllers/SlotBookingController.ts
@@ -30,6 +30,9 @@ class BookSlotRequestBody {
   courseVersionId: string;
   timeSlot: {from: string; to: string};
   cohortId?: string;
+  // Study day to book (YYYY-MM-DD IST). Defaults to today. Must fall inside the
+  // booking window: opens 9 AM IST on D-2, closes 9 AM IST on D.
+  date?: string;
 }
 
 class CancelBookingRequestBody {
@@ -54,7 +57,7 @@ class SlotBookingController {
   @OpenAPI({
     summary: 'Book a time slot',
     description:
-      'A student books a time slot for the current IST day, subject to the slot capacity cap and their daily allowance.',
+      'A student books a time slot for a study day (default today). Booking for day D is open from 9 AM IST on D-2 until 9 AM IST on D, subject to the slot capacity cap and their per-day allowance.',
   })
   @Authorized()
   @Post('/book')
@@ -70,6 +73,7 @@ class SlotBookingController {
         body.courseVersionId,
         body.timeSlot,
         body.cohortId,
+        body.date,
       );
       return {
         success: true,

--- a/backend/src/modules/setting/services/SlotBookingService.ts
+++ b/backend/src/modules/setting/services/SlotBookingService.ts
@@ -46,13 +46,56 @@ export class SlotBookingService extends BaseService {
     super(mongoDatabase);
   }
 
+  /** How many days before the study day booking opens. */
+  private static readonly BOOKING_OPEN_LEAD_DAYS = 2;
+  /** Hour (IST) at which booking opens on D-2 and closes on D. */
+  private static readonly BOOKING_CUTOFF_HOUR = 9;
+
+  /** IST "now" as epoch ms whose UTC fields read as the IST wall clock. */
+  private getISTNowMs(): number {
+    return Date.now() + 5.5 * 60 * 60 * 1000;
+  }
+
+  /** Format an IST-space epoch ms (UTC fields = IST wall clock) as YYYY-MM-DD. */
+  private formatISTDate(istMs: number): string {
+    const ist = new Date(istMs);
+    const y = ist.getUTCFullYear();
+    const m = String(ist.getUTCMonth() + 1).padStart(2, '0');
+    const d = String(ist.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
   /** Current calendar date in IST as YYYY-MM-DD. */
   private getCurrentISTDate(): string {
-    const istNow = new Date(Date.now() + 5.5 * 60 * 60 * 1000);
-    const y = istNow.getUTCFullYear();
-    const m = String(istNow.getUTCMonth() + 1).padStart(2, '0');
-    const d = String(istNow.getUTCDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
+    return this.formatISTDate(this.getISTNowMs());
+  }
+
+  /** The IST calendar date a Date was created on (for the per-day allowance). */
+  private istDateOf(d: Date): string {
+    return this.formatISTDate(d.getTime() + 5.5 * 60 * 60 * 1000);
+  }
+
+  /**
+   * Booking window for study day D: opens at 09:00 IST on D-2 and closes at
+   * 09:00 IST on D. So at any moment a student may book today (only before
+   * 9 AM), tomorrow (all day), and the day after tomorrow (only from 9 AM).
+   * Returns the open/close instants as IST-space epoch ms.
+   */
+  private bookingWindowForDate(date: string): {openMs: number; closeMs: number} {
+    const [y, m, d] = date.split('-').map(Number);
+    const closeMs = Date.UTC(
+      y,
+      m - 1,
+      d,
+      SlotBookingService.BOOKING_CUTOFF_HOUR,
+      0,
+      0,
+      0,
+    );
+    const openMs =
+      closeMs -
+      SlotBookingService.BOOKING_OPEN_LEAD_DAYS * 24 * 60 * 60 * 1000;
+    return {openMs, closeMs};
   }
 
   private toMinutes(time: string): number {
@@ -73,9 +116,11 @@ export class SlotBookingService extends BaseService {
   }
 
   /**
-   * Book a time slot for the current IST day. Enforces: feature active, the slot
-   * is offered, no duplicate, the student's daily allowance, and the slot's hard
-   * capacity cap.
+   * Book a time slot for a study day (defaults to today). A booking for day D is
+   * only accepted inside D's booking window — 09:00 IST on D-2 through 09:00 IST
+   * on D. Enforces: feature active, the slot is offered, the booking window, no
+   * duplicate, the student's per-day allowance, the slot's hard capacity cap, and
+   * the course hours budget.
    */
   async bookSlot(
     userId: string,
@@ -83,6 +128,7 @@ export class SlotBookingService extends BaseService {
     courseVersionId: string,
     slot: {from: string; to: string},
     cohortId?: string,
+    targetDate?: string,
   ): Promise<ISlotBooking> {
     return this._withTransaction(async (session) => {
       const timeslots = await this.settingsRepo.readTimeslotsSettings(
@@ -125,21 +171,56 @@ export class SlotBookingService extends BaseService {
         throw new NotFoundError('You are not enrolled in this course.');
       }
 
-      const date = this.getCurrentISTDate();
-      const myBookings = await this.slotBookingRepo.findActiveForStudent(
+      const today = this.getCurrentISTDate();
+      const date = targetDate ?? today;
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        throw new BadRequestError('Invalid booking date.');
+      }
+
+      // The booking window: opens 09:00 IST on D-2, closes 09:00 IST on D.
+      const {openMs, closeMs} = this.bookingWindowForDate(date);
+      const nowMs = this.getISTNowMs();
+      if (nowMs < openMs) {
+        throw new BadRequestError(
+          `Booking for ${date} hasn't opened yet. ` +
+            `It opens at 9:00 AM IST on ${this.formatISTDate(openMs)}.`,
+        );
+      }
+      if (nowMs >= closeMs) {
+        throw new BadRequestError(
+          `Booking for ${date} has closed. ` +
+            'Bookings close at 9:00 AM IST on the study day.',
+        );
+      }
+
+      // All of the student's active bookings on this course (any study day).
+      const allBookings = await this.slotBookingRepo.findActiveForStudent(
         userId,
         courseId,
         courseVersionId,
-        date,
+        undefined,
         session,
       );
 
-      if (myBookings.some(b => b.from === slot.from && b.to === slot.to)) {
-        throw new BadRequestError('You have already booked this slot today.');
+      if (
+        allBookings.some(
+          b => b.date === date && b.from === slot.from && b.to === slot.to,
+        )
+      ) {
+        throw new BadRequestError(
+          'You have already booked this slot for that day.',
+        );
       }
 
+      // Allowance is per CALENDAR DAY the booking is made (not per study day):
+      // every booking a student creates today shares one daily allowance.
       const allowance = timeslots.dailyBaseAllowance ?? 1;
-      if (myBookings.length >= allowance) {
+      const madeToday = allBookings.filter(
+        b =>
+          (b.bookedOnDate ??
+            (b.createdAt ? this.istDateOf(b.createdAt) : undefined)) === today,
+      );
+      if (madeToday.length >= allowance) {
         throw new BadRequestError(
           `You have used your ${allowance} booking(s) for today.`,
         );
@@ -197,6 +278,7 @@ export class SlotBookingService extends BaseService {
         courseVersionId,
         cohortId: cohortId ?? undefined,
         date,
+        bookedOnDate: today,
         from: slot.from,
         to: slot.to,
         overnight: this.isOvernight(slot.from, slot.to),

--- a/backend/src/modules/setting/tests/SlotBookingService.test.ts
+++ b/backend/src/modules/setting/tests/SlotBookingService.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {SlotBookingService} from '../services/SlotBookingService.js';
 import {
   SlotBookingKind,
@@ -20,6 +20,12 @@ const COURSE = 'course-1';
 const VERSION = 'version-1';
 
 const SLOT = {from: '13:00', to: '15:00'}; // 2h, same-day
+
+// Frozen clock: 2026-06-20 08:00 IST (= 02:30 UTC), before the 9 AM cutoff, so
+// booking for "today" is inside its window. Keeps the booking-window check
+// deterministic regardless of when the suite runs.
+const FROZEN_UTC = '2026-06-20T02:30:00.000Z';
+const TODAY = '2026-06-20';
 
 function makeService(
   opts: {
@@ -76,7 +82,12 @@ function makeService(
 }
 
 describe('SlotBookingService.bookSlot', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FROZEN_UTC));
+  });
+  afterEach(() => vi.useRealTimers());
 
   it('rejects when the time-slot feature is inactive', async () => {
     const {svc} = makeService({timeslots: {isActive: false, slots: []}});
@@ -117,15 +128,19 @@ describe('SlotBookingService.bookSlot', () => {
   });
 
   it('rejects double-booking the same slot', async () => {
-    const {svc} = makeService({myBookings: [{from: '13:00', to: '15:00'}]});
+    const {svc} = makeService({
+      myBookings: [{date: TODAY, from: '13:00', to: '15:00'}],
+    });
     await expect(
       svc.bookSlot(USER, COURSE, VERSION, SLOT),
     ).rejects.toThrowError(/already booked/i);
   });
 
   it('rejects when the daily allowance is used up', async () => {
-    // One booking already today (a different slot), allowance = 1.
-    const {svc} = makeService({myBookings: [{from: '09:00', to: '10:00'}]});
+    // One booking already made today (a different slot), allowance = 1.
+    const {svc} = makeService({
+      myBookings: [{bookedOnDate: TODAY, from: '09:00', to: '10:00'}],
+    });
     await expect(
       svc.bookSlot(USER, COURSE, VERSION, SLOT),
     ).rejects.toThrowError(/booking\(s\) for today/i);
@@ -185,7 +200,8 @@ describe('SlotBookingService.bookSlot', () => {
         ],
         dailyBaseAllowance: 2,
       },
-      myBookings: [{from: '09:00', to: '10:00'}], // already has 1 of 2
+      // already made 1 of 2 bookings today
+      myBookings: [{bookedOnDate: TODAY, from: '09:00', to: '10:00'}],
     });
 
     await svc.bookSlot(USER, COURSE, VERSION, SLOT);
@@ -243,6 +259,65 @@ describe('SlotBookingService.bookSlot', () => {
     await svc.bookSlot(USER, COURSE, VERSION, SLOT);
     expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
     expect(slotBookingRepo.sumReservedHoursForStudent).not.toHaveBeenCalled();
+  });
+});
+
+describe('SlotBookingService.bookSlot — booking window (D-2 9AM → D 9AM IST)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  // 2026-06-20 08:00 IST — before the 9 AM cutoff.
+  const at = (utc: string) => vi.setSystemTime(new Date(utc));
+
+  it('books tomorrow at any time of day', async () => {
+    at('2026-06-20T08:30:00.000Z'); // 14:00 IST on 06-20
+    const {svc, slotBookingRepo} = makeService();
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT, undefined, '2026-06-21');
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+    const saved = slotBookingRepo.createBooking.mock.calls[0][0];
+    expect(saved.date).toBe('2026-06-21'); // study day
+    expect(saved.bookedOnDate).toBe('2026-06-20'); // calendar day booked
+  });
+
+  it('rejects booking for today once past the 9 AM cutoff', async () => {
+    at('2026-06-20T04:30:00.000Z'); // 10:00 IST on 06-20
+    const {svc} = makeService();
+    await expect(
+      svc.bookSlot(USER, COURSE, VERSION, SLOT, undefined, '2026-06-20'),
+    ).rejects.toThrowError(/has closed/i);
+  });
+
+  it('allows booking for today before the 9 AM cutoff', async () => {
+    at('2026-06-20T02:30:00.000Z'); // 08:00 IST on 06-20
+    const {svc, slotBookingRepo} = makeService();
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT, undefined, '2026-06-20');
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+  });
+
+  it('rejects the day-after-tomorrow before its 9 AM open time', async () => {
+    at('2026-06-20T02:30:00.000Z'); // 08:00 IST on 06-20 — D-2 window opens at 09:00
+    const {svc} = makeService();
+    await expect(
+      svc.bookSlot(USER, COURSE, VERSION, SLOT, undefined, '2026-06-22'),
+    ).rejects.toThrowError(/hasn't opened/i);
+  });
+
+  it('allows the day-after-tomorrow from its 9 AM open time', async () => {
+    at('2026-06-20T03:30:00.000Z'); // 09:00 IST on 06-20 — D-2 window just opened
+    const {svc, slotBookingRepo} = makeService();
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT, undefined, '2026-06-22');
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a day too far in the future (outside the window)', async () => {
+    at('2026-06-20T02:30:00.000Z');
+    const {svc} = makeService();
+    await expect(
+      svc.bookSlot(USER, COURSE, VERSION, SLOT, undefined, '2026-06-25'),
+    ).rejects.toThrowError(/hasn't opened/i);
   });
 });
 

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -616,7 +616,8 @@ export interface ISlotBooking {
   courseId: ID;
   courseVersionId: ID;
   cohortId?: ID;
-  date: string; // YYYY-MM-DD in IST — the day this booking applies to
+  date: string; // YYYY-MM-DD in IST — the study day this booking applies to
+  bookedOnDate?: string; // YYYY-MM-DD IST — the calendar day the booking was MADE (drives the per-day allowance, which is counted per booking-day, not per study day)
   from: string; // HH:MM IST
   to: string; // HH:MM IST
   overnight: boolean; // window crosses midnight (from > to)

--- a/frontend/src/components/course/StudentTimeslotModal.tsx
+++ b/frontend/src/components/course/StudentTimeslotModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -9,9 +10,31 @@ import {
   useSlotAvailability,
   useBookSlot,
   useCancelBooking,
+  bookableStudyDates,
+  istToday,
   type MyBooking,
 } from "@/hooks/hooks";
 import { cn } from "@/utils/utils";
+
+// Friendly label for a YYYY-MM-DD study day relative to IST today.
+const dayLabel = (date: string): string => {
+  const today = istToday();
+  if (date === today) return "Today";
+  const [y, m, d] = date.split("-").map(Number);
+  const ms = Date.UTC(y, m - 1, d);
+  const todayMs = (() => {
+    const [ty, tm, td] = today.split("-").map(Number);
+    return Date.UTC(ty, tm - 1, td);
+  })();
+  const diff = Math.round((ms - todayMs) / (24 * 60 * 60 * 1000));
+  if (diff === 1) return "Tomorrow";
+  return new Date(ms).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+};
 
 interface StudentTimeslotModalProps {
   isOpen: boolean;
@@ -41,6 +64,15 @@ export default function StudentTimeslotModal({
   cohortId,
 }: StudentTimeslotModalProps) {
   const { data: timeSlotsData, isLoading } = useGetTimeSlots(courseId, courseVersionId, isOpen);
+
+  // Study days a student may book right now (today before 9 AM / tomorrow /
+  // day-after from 9 AM IST). The first open day is selected by default.
+  const studyDates = bookableStudyDates();
+  const [selectedDate, setSelectedDate] = useState<string>(studyDates[0]);
+  const activeDate = studyDates.includes(selectedDate) ? selectedDate : studyDates[0];
+
+  // All of the student's active bookings (any study day) — drives both the
+  // per-booking-day allowance meter and the per-date "Booked" state.
   const {
     data: myBookings,
     isLoading: bookingsLoading,
@@ -49,7 +81,7 @@ export default function StudentTimeslotModal({
   const { data: availability, refetch: refetchAvailability } = useSlotAvailability(
     courseId,
     courseVersionId,
-    undefined,
+    activeDate,
     isOpen,
   );
   const { book, loading: booking } = useBookSlot();
@@ -66,15 +98,17 @@ export default function StudentTimeslotModal({
   const allowance = (timeSlotsData as { dailyBaseAllowance?: number } | null | undefined)
     ?.dailyBaseAllowance ?? 1;
   const bookings: MyBooking[] = myBookings ?? [];
-  const bookedCount = bookings.length;
+  // Allowance is per calendar day the booking is MADE — count bookings created today.
+  const today = istToday();
+  const bookedCount = bookings.filter(b => (b.bookedOnDate ?? b.date) === today).length;
 
   const bookingFor = (slot: { from: string; to: string }): MyBooking | undefined =>
-    bookings.find(b => b.from === slot.from && b.to === slot.to);
+    bookings.find(b => b.date === activeDate && b.from === slot.from && b.to === slot.to);
 
   const handleBook = async (slot: { from: string; to: string }) => {
-    const res = await book(courseId, courseVersionId, { from: slot.from, to: slot.to }, cohortId);
+    const res = await book(courseId, courseVersionId, { from: slot.from, to: slot.to }, cohortId, activeDate);
     if (res.success) {
-      toast.success('Slot booked for today.');
+      toast.success(`Slot booked for ${dayLabel(activeDate)}.`);
       refresh();
     } else {
       toast.error(res.message || 'Could not book this slot.');
@@ -131,13 +165,25 @@ export default function StudentTimeslotModal({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="w-full max-w-2xl mx-auto max-h-[80vh] overflow-y-auto">
         <DialogHeader className="pb-2">
-          <DialogTitle className="text-lg font-semibold">Book your study time — today</DialogTitle>
+          <DialogTitle className="text-lg font-semibold">Book your study time</DialogTitle>
           <p className="text-sm text-muted-foreground">
-            Pick when you'll study today. You can open the course <span className="font-medium text-foreground">only during a window you've booked</span>.
+            Pick a day and when you'll study. You can open the course <span className="font-medium text-foreground">only during a window you've booked</span>.
           </p>
-          <div className="mt-1">
+          <div className="mt-2 flex flex-wrap gap-2">
+            {studyDates.map(d => (
+              <Button
+                key={d}
+                size="sm"
+                variant={d === activeDate ? "default" : "outline"}
+                onClick={() => setSelectedDate(d)}
+              >
+                {dayLabel(d)}
+              </Button>
+            ))}
+          </div>
+          <div className="mt-2">
             <span className="inline-flex items-center rounded-full bg-primary/10 text-primary px-2.5 py-0.5 text-xs font-medium">
-              {bookedCount} of {allowance} daily booking{allowance !== 1 ? 's' : ''} used
+              {bookedCount} of {allowance} booking{allowance !== 1 ? 's' : ''} used today
             </span>
           </div>
         </DialogHeader>
@@ -256,7 +302,8 @@ export default function StudentTimeslotModal({
 
         <div className="mt-4 pt-4 border-t">
           <div className="text-xs text-muted-foreground space-y-0.5">
-            <p>• Bookings are per day — your allowance resets each day.</p>
+            <p>• Booking for a day opens at 9:00 AM IST two days before, and closes at 9:00 AM IST on the day itself.</p>
+            <p>• Your booking allowance resets each calendar day — it counts every booking you make today, for any day.</p>
             <p>• Need a different window? Cancel a booking to free up your allowance, then book another.</p>
             <p>• Access to the course is allowed during a window you've booked.</p>
             <p>• Time slots are in IST (Indian Standard Time, UTC+5:30).</p>

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -5845,6 +5845,7 @@ export function useSlotDemand(
 export interface MyBooking {
   _id: string;
   date: string;
+  bookedOnDate?: string;
   from: string;
   to: string;
   kind?: string;
@@ -5856,6 +5857,44 @@ export interface MyBooking {
 // daily-allowance math lines up regardless of the viewer's local timezone.
 export function istToday(): string {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' });
+}
+
+// Current hour (0-23) in IST, used to gate which study days are bookable now.
+export function istHour(): number {
+  return parseInt(
+    new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'Asia/Kolkata',
+      hour: '2-digit',
+      hour12: false,
+    }).format(new Date()),
+    10,
+  ) % 24;
+}
+
+// Add `days` calendar days to a YYYY-MM-DD date string (UTC-safe arithmetic).
+export function addDays(date: string, days: number): string {
+  const [y, m, d] = date.split('-').map(Number);
+  const ms = Date.UTC(y, m - 1, d) + days * 24 * 60 * 60 * 1000;
+  const dt = new Date(ms);
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${yy}-${mm}-${dd}`;
+}
+
+// The study days a student may book *right now*, given the rule that booking for
+// day D opens 9 AM IST on D-2 and closes 9 AM IST on D:
+//   • today        — only before 9 AM IST
+//   • tomorrow     — all day
+//   • day-after    — only from 9 AM IST
+export function bookableStudyDates(): string[] {
+  const today = istToday();
+  const hour = istHour();
+  const dates: string[] = [];
+  if (hour < 9) dates.push(today); // today, before the 9 AM cutoff
+  dates.push(addDays(today, 1)); // tomorrow, always open
+  if (hour >= 9) dates.push(addDays(today, 2)); // day-after, opens at 9 AM
+  return dates;
 }
 
 // GET /slot-bookings/my/course/{courseId}/version/{courseVersionId}?date=
@@ -5914,6 +5953,7 @@ export function useBookSlot() {
     courseVersionId: string,
     timeSlot: { from: string; to: string },
     cohortId?: string,
+    date?: string,
   ): Promise<{ success: boolean; message?: string }> => {
     setLoading(true);
     try {
@@ -5924,7 +5964,7 @@ export function useBookSlot() {
           'Content-Type': 'application/json',
           authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
         },
-        body: JSON.stringify({ courseId, courseVersionId, timeSlot, cohortId }),
+        body: JSON.stringify({ courseId, courseVersionId, timeSlot, cohortId, date }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {


### PR DESCRIPTION
Booking for study day D opens at 09:00 IST on D-2 and closes at 09:00 IST on D, so a student can book today (before 9AM), tomorrow (all day), and the day after tomorrow (from 9AM). The daily allowance is now counted per calendar day the booking is MADE, not per study day.

- ISlotBooking.bookedOnDate records the IST day a booking was created
- bookSlot takes an optional targetDate; validates the booking window and counts allowance over bookedOnDate; capacity/duplicate keyed on study day
- SlotBookingController.book accepts date
- frontend: bookableStudyDates/istHour/addDays helpers, useBookSlot date arg, StudentTimeslotModal day-selector tabs + per-booking-day allowance meter
- 6 new booking-window unit tests (frozen clock); 33 SlotBookingService pass