### PR TITLE
Feat/timeslot capacity derived caps

### DIFF
--- a/backend/src/modules/setting/classes/validators/TimeSlotValidators.ts
+++ b/backend/src/modules/setting/classes/validators/TimeSlotValidators.ts
@@ -6,6 +6,8 @@ import {
   IsArray,
   IsBoolean,
   IsOptional,
+  IsInt,
+  Min,
   validate,
   ValidationError,
 } from 'class-validator';
@@ -23,6 +25,14 @@ export class TimeSlotDto implements ITimeSlot {
   @IsNotEmpty()
   @IsArray()
   studentIds: string[];
+
+  // Optional manual per-slot cap. Normally DERIVED via PUT /timeslots/capacity
+  // (Option A), but accepted here so a slot can also carry a hand-set ceiling
+  // instead of being silently stripped by validation. Undefined = unlimited.
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  maxStudents?: number;
 }
 
 export class AddTimeSlotsDto {

--- a/backend/src/modules/setting/controllers/TimeSlotController.ts
+++ b/backend/src/modules/setting/controllers/TimeSlotController.ts
@@ -100,6 +100,14 @@ class SetFulfillmentConfigRequestBody {
   bonusOnFulfillment?: boolean;
 }
 
+// Request body for capacity-derived per-slot caps (Option A).
+class SetCapacityConfigRequestBody {
+  courseId: string;
+  courseVersionId: string;
+  targetConcurrentStudents: number; // total students the backend is provisioned for
+  headroomFactor?: number; // 0 < x <= 1, default 0.7
+}
+
 // Request body for granting a student extra committed hours.
 class ExtendStudentHoursRequestBody {
   courseId: string;
@@ -507,6 +515,48 @@ class TimeSlotController {
       throw new InternalServerError(
         `Failed to set fulfillment settings: ${error}`,
       );
+    }
+  }
+
+  @OpenAPI({
+    summary: 'Set the booking capacity budget',
+    description:
+      "Derives each time slot's maxStudents from a single capacity knob — the total students the backend is provisioned to serve at once — so per-slot caps stay within the infra budget. perSlotCap = floor(targetConcurrentStudents × headroomFactor ÷ maxOverlappingWindows). A slot is never capped below its already-booked count.",
+  })
+  @Authorized()
+  @Put('/capacity')
+  @HttpCode(200)
+  @ResponseSchema(TimeSlotResponse, {
+    description: 'Capacity settings configured successfully',
+  })
+  async setCapacityConfig(
+    @Body() body: SetCapacityConfigRequestBody,
+    @Ability(getItemAbility) { ability },
+  ): Promise<TimeSlotResponse> {
+    const itemResource = subject('Item', { versionId: body.courseVersionId });
+    if (!ability.can(ItemActions.Modify, itemResource)) {
+      throw new ForbiddenError(
+        'You do not have permission to modify this item',
+      );
+    }
+
+    try {
+      const data = await this.timeSlotService.configureCapacity(
+        body.courseId,
+        body.courseVersionId,
+        body.targetConcurrentStudents,
+        body.headroomFactor,
+      );
+      return {
+        success: true,
+        message: 'Capacity settings configured successfully',
+        data,
+      };
+    } catch (error) {
+      if (error instanceof BadRequestError || error instanceof NotFoundError) {
+        throw error;
+      }
+      throw new InternalServerError(`Failed to set capacity settings: ${error}`);
     }
   }
 

--- a/backend/src/modules/setting/services/TimeSlotService.ts
+++ b/backend/src/modules/setting/services/TimeSlotService.ts
@@ -86,6 +86,60 @@ export class TimeSlotService extends BaseService {
   }
 
   /**
+   * Maximum number of slots simultaneously active at any instant on a 24-hour
+   * IST clock, treating each slot as a half-open [from, to) minute interval.
+   * Overnight slots (to <= from) wrap past midnight, covering [from, 24:00) and
+   * [00:00, to) — so they correctly overlap early-morning slots. This is the
+   * divisor for capacity planning: real peak concurrency is the SUM of the caps
+   * of all windows overlapping at the same clock time, so dividing the budget by
+   * this keeps that sum within budget. Half-open intervals mean back-to-back
+   * slots (one ending exactly when the next starts) do NOT overlap. At least 1.
+   */
+  private computeMaxOverlappingWindows(
+    slots: {from: string; to: string}[],
+  ): number {
+    if (!slots || slots.length === 0) return 1;
+    const coverage = new Array<number>(24 * 60).fill(0);
+    const mark = (a: number, b: number) => {
+      for (let i = a; i < b; i++) coverage[i] += 1;
+    };
+    for (const s of slots) {
+      const start = this.toMinutes(s.from);
+      const end = this.toMinutes(s.to);
+      if (end > start) {
+        mark(start, end);
+      } else {
+        // Overnight (or full-day when equal): wraps across midnight.
+        mark(start, 24 * 60);
+        mark(0, end);
+      }
+    }
+    let max = 0;
+    for (const c of coverage) if (c > max) max = c;
+    return Math.max(1, max);
+  }
+
+  /** Per-slot booking cap derived from the capacity budget. At least 1. */
+  private deriveSlotCapacity(
+    targetConcurrentStudents: number,
+    headroomFactor: number,
+    maxOverlappingWindows: number,
+  ): number {
+    const bookable = targetConcurrentStudents * headroomFactor;
+    return Math.max(1, Math.floor(bookable / maxOverlappingWindows));
+  }
+
+  /** IST study dates currently inside the advance-booking window (today..+2). */
+  private openBookingDates(): string[] {
+    const istNow = new Date(Date.now() + 5.5 * 60 * 60 * 1000);
+    const fmt = (d: Date) =>
+      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+    return [0, 1, 2].map((n) =>
+      fmt(new Date(istNow.getTime() + n * 24 * 60 * 60 * 1000)),
+    );
+  }
+
+  /**
    * Migration dual-write: record a slot choice/assignment as a slotBooking for
    * the current IST day. Idempotent — skips if the student already has an
    * active booking for this slot today.
@@ -572,6 +626,118 @@ export class TimeSlotService extends BaseService {
       return {
         fulfillmentThresholdPct: threshold,
         bonusOnFulfillment: !!bonusOnFulfillment,
+      };
+    });
+  }
+
+  /**
+   * Capacity planning (Option A): derive each slot's maxStudents from a single
+   * knob — the total students the backend is provisioned to serve at once —
+   * instead of hand-setting caps. perSlotCap = floor(target × headroom ÷
+   * maxOverlappingWindows), so the sum of caps over any overlapping set stays
+   * within budget. A slot's cap is never lowered below the count it has ALREADY
+   * committed across the open booking window (today..+2), so live bookings are
+   * never invalidated.
+   */
+  async configureCapacity(
+    courseId: string,
+    courseVersionId: string,
+    targetConcurrentStudents: number,
+    headroomFactor: number | undefined,
+  ): Promise<{
+    targetConcurrentStudents: number;
+    capacityHeadroomFactor: number;
+    maxOverlappingWindows: number;
+    derivedPerSlotCap: number;
+    slots: {from: string; to: string; maxStudents: number}[];
+  }> {
+    return this._withTransaction(async (session) => {
+      if (
+        typeof targetConcurrentStudents !== 'number' ||
+        Number.isNaN(targetConcurrentStudents) ||
+        targetConcurrentStudents <= 0
+      ) {
+        throw new BadRequestError(
+          `Invalid targetConcurrentStudents: ${targetConcurrentStudents}. Must be greater than 0.`,
+        );
+      }
+      const headroom = headroomFactor ?? 0.7;
+      if (
+        typeof headroom !== 'number' ||
+        Number.isNaN(headroom) ||
+        headroom <= 0 ||
+        headroom > 1
+      ) {
+        throw new BadRequestError(
+          `Invalid headroom factor: ${headroomFactor}. Must be between 0 (exclusive) and 1 (inclusive).`,
+        );
+      }
+
+      const existing = await this.settingsRepo.readTimeslotsSettings(
+        courseId,
+        courseVersionId,
+        session,
+      );
+      if (!existing || !existing.slots || existing.slots.length === 0) {
+        throw new NotFoundError(
+          'No time slots are defined for this course; add slots before configuring capacity.',
+        );
+      }
+
+      const maxOverlap = this.computeMaxOverlappingWindows(existing.slots);
+      const derivedCap = this.deriveSlotCapacity(
+        targetConcurrentStudents,
+        headroom,
+        maxOverlap,
+      );
+
+      // Guard: never set a slot's cap below what it has already committed across
+      // the open booking window, or live bookings would exceed the new cap.
+      const openDates = this.openBookingDates();
+      const slots = await Promise.all(
+        existing.slots.map(async (slot) => {
+          let booked = 0;
+          for (const date of openDates) {
+            const n = await this.slotBookingRepo.countActiveInSlot(
+              courseId,
+              courseVersionId,
+              date,
+              {from: slot.from, to: slot.to},
+              session,
+            );
+            if (n > booked) booked = n;
+          }
+          return {...slot, maxStudents: Math.max(derivedCap, booked)};
+        }),
+      );
+
+      const updated = {
+        ...existing,
+        slots,
+        targetConcurrentStudents,
+        capacityHeadroomFactor: headroom,
+      };
+
+      const result = await this.settingsRepo.updateTimeslotsSettings(
+        courseId,
+        courseVersionId,
+        updated,
+        session,
+      );
+      if (!result) {
+        throw new InternalServerError('Failed to save the capacity settings.');
+      }
+
+      return {
+        targetConcurrentStudents,
+        capacityHeadroomFactor: headroom,
+        maxOverlappingWindows: maxOverlap,
+        derivedPerSlotCap: derivedCap,
+        slots: slots.map((s) => ({
+          from: s.from,
+          to: s.to,
+          maxStudents: s.maxStudents as number,
+        })),
       };
     });
   }

--- a/backend/src/modules/setting/tests/TimeSlotService.test.ts
+++ b/backend/src/modules/setting/tests/TimeSlotService.test.ts
@@ -67,6 +67,9 @@ function makeService(
         Promise.resolve(bookings.filter(b => !date || b.date === date)),
       ),
     createBooking: vi.fn().mockResolvedValue({_id: 'booking-new'}),
+    // Capacity guard: how many active bookings a slot already holds. Default 0;
+    // override per-test to exercise the "don't cap below booked" clamp.
+    countActiveInSlot: vi.fn().mockResolvedValue(0),
   };
   const db = {} as any;
 
@@ -535,6 +538,118 @@ describe('TimeSlotService.configureFulfillment', () => {
     await expect(
       svc.configureFulfillment(COURSE, VERSION, 150, true),
     ).rejects.toThrowError(/between 0 and 100/i);
+  });
+});
+
+describe('TimeSlotService.configureCapacity', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('derives per-slot caps from the budget, dividing by max overlap', async () => {
+    // Two slots overlap (09–11 and 10–12) → maxOverlap 2. One disjoint (14–15).
+    const { svc, settingsRepo } = makeService({
+      timeslots: {
+        isActive: true,
+        slots: [
+          { from: '09:00', to: '11:00' },
+          { from: '10:00', to: '12:00' },
+          { from: '14:00', to: '15:00' },
+        ] as any,
+        dailyBaseAllowance: 2,
+      },
+    });
+
+    // 1000 × 0.7 / 2 = 350
+    const res = await svc.configureCapacity(COURSE, VERSION, 1000, 0.7);
+
+    expect(res.maxOverlappingWindows).toBe(2);
+    expect(res.derivedPerSlotCap).toBe(350);
+    expect(res.slots.every(s => s.maxStudents === 350)).toBe(true);
+
+    const saved = settingsRepo.updateTimeslotsSettings.mock.calls[0][2];
+    expect(saved).toMatchObject({
+      targetConcurrentStudents: 1000,
+      capacityHeadroomFactor: 0.7,
+      dailyBaseAllowance: 2, // preserved
+    });
+    expect(saved.slots.every((s: any) => s.maxStudents === 350)).toBe(true);
+  });
+
+  it('defaults the headroom factor to 0.7', async () => {
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [{ from: '09:00', to: '10:00' }] as any },
+    });
+    // disjoint single slot → overlap 1 → 200 × 0.7 / 1 = 140
+    const res = await svc.configureCapacity(COURSE, VERSION, 200, undefined);
+    expect(res.capacityHeadroomFactor).toBe(0.7);
+    expect(res.derivedPerSlotCap).toBe(140);
+  });
+
+  it('never caps a slot below its already-booked count', async () => {
+    const { svc, slotBookingRepo } = makeService({
+      timeslots: { isActive: true, slots: [{ from: '09:00', to: '10:00' }] as any },
+    });
+    // derived would be 10 × 0.7 / 1 = 7, but the slot already has 12 booked.
+    slotBookingRepo.countActiveInSlot.mockResolvedValue(12);
+
+    const res = await svc.configureCapacity(COURSE, VERSION, 10, 0.7);
+
+    expect(res.derivedPerSlotCap).toBe(7);
+    expect(res.slots[0].maxStudents).toBe(12); // clamped up to booked
+  });
+
+  it('treats back-to-back slots as non-overlapping (overlap 1)', async () => {
+    const { svc } = makeService({
+      timeslots: {
+        isActive: true,
+        slots: [
+          { from: '09:00', to: '10:00' },
+          { from: '10:00', to: '11:00' },
+        ] as any,
+      },
+    });
+    const res = await svc.configureCapacity(COURSE, VERSION, 100, 1);
+    expect(res.maxOverlappingWindows).toBe(1);
+    expect(res.derivedPerSlotCap).toBe(100);
+  });
+
+  it('counts an overnight slot as overlapping the early-morning window', async () => {
+    // 22:00→02:00 (overnight) overlaps 01:00→03:00 between 01:00 and 02:00.
+    const { svc } = makeService({
+      timeslots: {
+        isActive: true,
+        slots: [
+          { from: '22:00', to: '02:00' },
+          { from: '01:00', to: '03:00' },
+        ] as any,
+      },
+    });
+    const res = await svc.configureCapacity(COURSE, VERSION, 100, 1);
+    expect(res.maxOverlappingWindows).toBe(2);
+  });
+
+  it('rejects a non-positive target', async () => {
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [{ from: '09:00', to: '10:00' }] as any },
+    });
+    await expect(
+      svc.configureCapacity(COURSE, VERSION, 0, 0.7),
+    ).rejects.toThrowError(/greater than 0/i);
+  });
+
+  it('rejects a headroom factor outside (0, 1]', async () => {
+    const { svc } = makeService({
+      timeslots: { isActive: true, slots: [{ from: '09:00', to: '10:00' }] as any },
+    });
+    await expect(
+      svc.configureCapacity(COURSE, VERSION, 100, 1.5),
+    ).rejects.toThrowError(/between 0/i);
+  });
+
+  it('rejects when no slots are defined', async () => {
+    const { svc } = makeService({ timeslots: { isActive: true, slots: [] } });
+    await expect(
+      svc.configureCapacity(COURSE, VERSION, 100, 0.7),
+    ).rejects.toThrowError(/No time slots/i);
   });
 });
 

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -652,6 +652,19 @@ export interface ISettings {
   timeslots?: {
     isActive: boolean;
     slots: ITimeSlot[];
+    // Capacity planning (Option A): the single knob ops sets — the total number
+    // of students the backend is provisioned to serve at once. Each slot's
+    // maxStudents is DERIVED from this at config time (not hand-set):
+    //   perSlotCap = floor(targetConcurrentStudents × capacityHeadroomFactor
+    //                      ÷ maxOverlappingWindows)
+    // so the sum of caps over any set of overlapping windows stays within the
+    // provisioned budget. Undefined = no capacity-derived cap (slots fall back
+    // to any manually-set maxStudents, else unlimited).
+    targetConcurrentStudents?: number;
+    // Fraction of targetConcurrentStudents actually offered as bookable seats,
+    // reserving headroom for the booking rush, slot-boundary pile-up, non-slot
+    // and cron traffic, and per-student cost variance. Default 0.7.
+    capacityHeadroomFactor?: number;
     // How many base bookings a student gets per day (default 1). Bonuses add on
     // top via fulfillment (Phase 3) when bonusOnFulfillment is enabled.
     dailyBaseAllowance?: number;

--- a/frontend/src/app/pages/teacher/components/TimeSlotsModal.tsx
+++ b/frontend/src/app/pages/teacher/components/TimeSlotsModal.tsx
@@ -19,6 +19,7 @@ import {
   useSetHoursBudget,
   useGrantExtraHours,
   useSetFulfillmentConfig,
+  useSetCapacityConfig,
   useSlotDemand,
 } from "@/hooks/hooks";
 import { ClockTimePicker } from "./ClockTimePicker";
@@ -158,6 +159,15 @@ function TimeSlotsModal({ isOpen, onClose, courseId, courseVersionId }: TimeSlot
   // Phase 3: fulfillment threshold (active share of a window) + bonus toggle.
   const [fulfillmentThresholdPct, setFulfillmentThresholdPct] = useState<number>(90);
   const [bonusOnFulfillment, setBonusOnFulfillment] = useState<boolean>(false);
+  // Capacity planning (Option A): one knob — total students the backend is
+  // provisioned to serve at once — from which each slot's seat cap is derived.
+  // Headroom is shown as a percent to the instructor; sent as a 0–1 factor.
+  const [targetConcurrentStudents, setTargetConcurrentStudents] = useState<number>(0);
+  const [headroomPct, setHeadroomPct] = useState<number>(70);
+  const [capacityResult, setCapacityResult] = useState<{
+    maxOverlappingWindows: number;
+    derivedPerSlotCap: number;
+  } | null>(null);
 
   // Hooks
   const { data: timeSlotsData, refetch: refetchTimeSlots } = useGetTimeSlots(
@@ -177,6 +187,7 @@ function TimeSlotsModal({ isOpen, onClose, courseId, courseVersionId }: TimeSlot
   const { setHoursBudget, loading: budgetLoading } = useSetHoursBudget();
   const { grantExtraHours, loading: extendLoading } = useGrantExtraHours();
   const { setFulfillmentConfig, loading: fulfillmentLoading } = useSetFulfillmentConfig();
+  const { setCapacityConfig, loading: capacityLoading } = useSetCapacityConfig();
 
   // Seed any saved budget/estimates when the modal loads.
   useEffect(() => {
@@ -192,6 +203,12 @@ function TimeSlotsModal({ isOpen, onClose, courseId, courseVersionId }: TimeSlot
     }
     if (typeof ts?.bonusOnFulfillment === 'boolean') {
       setBonusOnFulfillment(ts.bonusOnFulfillment);
+    }
+    if (typeof ts?.targetConcurrentStudents === 'number') {
+      setTargetConcurrentStudents(ts.targetConcurrentStudents);
+    }
+    if (typeof ts?.capacityHeadroomFactor === 'number') {
+      setHeadroomPct(Math.round(ts.capacityHeadroomFactor * 100));
     }
   }, [timeSlotsData]);
 
@@ -211,6 +228,31 @@ function TimeSlotsModal({ isOpen, onClose, courseId, courseVersionId }: TimeSlot
       );
     } catch (error: any) {
       toast.error(error?.message || 'Failed to set fulfillment settings');
+    }
+  };
+
+  const handleSaveCapacity = async () => {
+    try {
+      const result = await setCapacityConfig(
+        courseId,
+        courseVersionId,
+        targetConcurrentStudents,
+        Math.max(0.01, Math.min(1, headroomPct / 100)),
+      );
+      setTargetConcurrentStudents(result.targetConcurrentStudents);
+      setHeadroomPct(Math.round(result.capacityHeadroomFactor * 100));
+      setCapacityResult({
+        maxOverlappingWindows: result.maxOverlappingWindows,
+        derivedPerSlotCap: result.derivedPerSlotCap,
+      });
+      toast.success(
+        `Capacity set: ${result.derivedPerSlotCap} seats/slot ` +
+          `(${result.maxOverlappingWindows} overlapping window${
+            result.maxOverlappingWindows === 1 ? '' : 's'
+          })`,
+      );
+    } catch (error: any) {
+      toast.error(error?.message || 'Failed to set capacity settings');
     }
   };
 
@@ -762,6 +804,80 @@ function TimeSlotsModal({ isOpen, onClose, courseId, courseVersionId }: TimeSlot
                             <Save className="h-4 w-4 mr-2" />
                           )}
                           Save fulfillment
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  {/* Booking capacity (Option A: capacity-derived seat caps) */}
+                  <Card className="border shadow-sm">
+                    <CardContent className="p-4 space-y-3">
+                      <div>
+                        <h3 className="text-lg font-semibold flex items-center gap-2">
+                          <Clock className="h-5 w-5" />
+                          Booking capacity
+                        </h3>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Set how many students the backend can serve at once. Each slot's seat cap is derived automatically as <span className="font-medium">target × headroom ÷ overlapping windows</span>, so concurrent load stays within budget. Headroom reserves room for booking rushes and other traffic.
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap items-end gap-4">
+                        <div className="w-48">
+                          <Label className="text-xs">Target concurrent students</Label>
+                          <Input
+                            type="number"
+                            min={1}
+                            value={targetConcurrentStudents || ""}
+                            onChange={(e) =>
+                              setTargetConcurrentStudents(
+                                Math.max(0, Number(e.target.value)),
+                              )
+                            }
+                            className="mt-1"
+                            placeholder="e.g. 1000"
+                          />
+                        </div>
+                        <div className="w-32">
+                          <Label className="text-xs">Headroom (%)</Label>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={100}
+                            value={headroomPct}
+                            onChange={(e) =>
+                              setHeadroomPct(
+                                Math.max(1, Math.min(100, Number(e.target.value))),
+                              )
+                            }
+                            className="mt-1"
+                          />
+                        </div>
+                      </div>
+                      {capacityResult && (
+                        <p className="text-xs text-muted-foreground">
+                          Derived:{" "}
+                          <span className="font-medium text-foreground">
+                            {capacityResult.derivedPerSlotCap}
+                          </span>{" "}
+                          seats per slot across{" "}
+                          {capacityResult.maxOverlappingWindows} overlapping
+                          window
+                          {capacityResult.maxOverlappingWindows === 1 ? "" : "s"}.
+                          Slots already fuller than this keep their booked count.
+                        </p>
+                      )}
+                      <div>
+                        <Button
+                          size="sm"
+                          onClick={handleSaveCapacity}
+                          disabled={capacityLoading || !targetConcurrentStudents}
+                        >
+                          {capacityLoading ? (
+                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          ) : (
+                            <Save className="h-4 w-4 mr-2" />
+                          )}
+                          Apply capacity
                         </Button>
                       </div>
                     </CardContent>

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -5744,6 +5744,60 @@ export function useSetFulfillmentConfig() {
   return { setFulfillmentConfig, loading, error };
 }
 
+// PUT /timeslots/capacity — derive each slot's maxStudents from a single
+// capacity knob (total students the backend is provisioned for) so per-slot
+// caps stay within the infra budget (raw fetch).
+export function useSetCapacityConfig() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setCapacityConfig = async (
+    courseId: string,
+    courseVersionId: string,
+    targetConcurrentStudents: number,
+    headroomFactor: number,
+  ): Promise<{
+    targetConcurrentStudents: number;
+    capacityHeadroomFactor: number;
+    maxOverlappingWindows: number;
+    derivedPerSlotCap: number;
+    slots: { from: string; to: string; maxStudents: number }[];
+  }> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/timeslots/capacity`;
+      const res = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+        body: JSON.stringify({
+          courseId,
+          courseVersionId,
+          targetConcurrentStudents,
+          headroomFactor,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          data?.message || `Failed to set capacity settings: ${res.status}`,
+        );
+      }
+      return data?.data;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { setCapacityConfig, loading, error };
+}
+
 // PUT /timeslots/extend — grant a student extra committed hours (raw fetch).
 export function useGrantExtraHours() {
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
Derives each slot's maxStudents from one knob — target concurrent students — so booking caps keep concurrent load within the backend budget:

perSlotCap = floor(targetConcurrentStudents × headroom(0.7) ÷ maxOverlappingWindows)
Backend: configureCapacity() + PUT /timeslots/capacity; overlap computed on a circular clock (overnight wraps, back-to-back don't overlap); never caps below already-booked count; maxStudents added to the slot DTO (was silently stripped).
Frontend: "Booking capacity" card in the teacher TimeSlotsModal (target + headroom %, shows derived seats/slot).
Tests: 37/37 pass, tsc clean.
Enables capacity bounding; doesn't replace Cloud Run autoscaling until instructors set the knob in production.