### PR TITLE
fix: prevent whitespace-only name submission during signup (#579)

### DIFF
--- a/frontend/src/components/Auth/AuthPage.tsx
+++ b/frontend/src/components/Auth/AuthPage.tsx
@@ -263,8 +263,9 @@ export default function AuthPage({ role }: AuthPageProps) {
     // else if (!/^[A-Za-z ]+$/.test(fullName)) errors.fullName = "Name can only contain letters and spaces";
 
     if (isSignUp) {
-      if (!fullName) errors.fullName = "Name is required";
-      else if (!/^[A-Za-z ]+$/.test(fullName)) {
+      if (!fullName || !fullName.trim()) {
+        errors.fullName = "Name is required";
+      } else if (!/^[A-Za-z ]+$/.test(fullName.trim())) {
         errors.fullName = "Name can only contain letters and spaces";
       }
     }
@@ -275,7 +276,7 @@ export default function AuthPage({ role }: AuthPageProps) {
     if (!password) errors.password = "Password is required";
     else if (isSignUp && password.length < 8) errors.password = "Password must be at least 8 characters";
 
-    if (isSignUp && !fullName) errors.fullName = "Full name is required";
+    if (isSignUp && (!fullName || !fullName.trim())) errors.fullName = "Full name is required";
 
     setFormErrors(errors);
     return Object.keys(errors).length === 0;


### PR DESCRIPTION
The validateForm() function checked !fullName to detect empty names, but this evaluates to false for strings containing only whitespace
like '   '. Furthermore, the regex /^[A-Za-z ]+$/ also matches
whitespace-only strings since spaces are included in the character
class.

This fix adds a .trim() check before both the falsy guard and the regex test, ensuring that names consisting solely of whitespace characters are correctly rejected with a 'Name is required' error.

Changes:
- Added !fullName.trim() to falsy check for empty name detection
- Applied fullName.trim() before the regex test to catch space-only inputs
- Updated the duplicate guard at line 279 with the same fix

Closes #579

<!-- Description -->

<!-- 
Mention any related issues here. 
Use the following sytax:

Closes #ISSUE-NUMBER 
-->
