### PR TITLE
fix: prevent face detection bypass via spacebar hold and click propag…

### DIFF
--- a/frontend/src/components/video.tsx
+++ b/frontend/src/components/video.tsx
@@ -327,12 +327,16 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
       // Prevent playing if current time is at or beyond endTime
       if (endTimeSeconds > 0 && currentTime >= endTimeSeconds) {
         return;
-      }else{
-        player.playVideo();
       }
+      // Block resuming if any proctoring anomalies or gesture prompts are active
+      if (pauseVid || rewindVid || doGesture) {
+        console.log("🔒 Play blocked: Anomaly or gesture prompt active");
+        return;
+      }
+      player.playVideo();
       setTimeout(() => { playerRef.current?.setPlaybackRate?.(playbackRate); }, 50);
     }
-  }, [playing, endTimeSeconds, currentTime, isSkipping, isStopFailed, isStopping, playbackRate]);
+  }, [playing, endTimeSeconds, currentTime, isSkipping, isStopFailed, isStopping, playbackRate, pauseVid, rewindVid, doGesture]);
 
   const handleBackward = () => {
     const player = playerRef.current;
@@ -989,6 +993,10 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
         if (rawEvent.code === 'Space') {
           rawEvent.preventDefault();
           rawEvent.stopImmediatePropagation();
+          if (rawEvent.repeat) {
+            // Ignore held down spacebar to prevent rapid play/pause bypass
+            return;
+          }
           handlePlayPause();
           return;
         }
@@ -1354,6 +1362,10 @@ export default function Video({ URL, startTime, nextItemId, endTime, points, ano
                 <div
 
                   className='shadow-2xl'
+
+                  onClick={(e) => e.stopPropagation()}
+
+                  onMouseDown={(e) => e.stopPropagation()}
 
                   style={{
 
@@ -2095,6 +2107,8 @@ export function NavigatingOverlay({
   return (
     <div
       className={`absolute z-50 animate-in slide-in-from-right-3 duration-300 ${positionClasses[position]}`}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
     >
       <Card className={`shadow-lg backdrop-blur-md ${styles.card}`}>
         <CardContent className="flex items-center gap-3 px-4 py-3">
@@ -2152,6 +2166,8 @@ export function ConfirmOverlay({
   return (
     <div
       className={`absolute z-50 animate-in slide-in-from-right-3 duration-300 ${positionClasses[position]}`}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
     >
       <Card className={`border-red-400/40 ${message === "Invalid watch time" ? "bg-yellow-600/95": "bg-red-600/95"} text-red-50 shadow-lg backdrop-blur-md w-80`}>
         <CardContent className="flex flex-col gap-3 p-4">


### PR DESCRIPTION
…ation (#515)

- Added a check in handlePlayPause() to block resuming playback when an anomaly is active (pauseVid || rewindVid || doGesture).
- Ignored repeated Spacebar keydown events (event.repeat === true) in the window keydown listener.
- Blocked click/mousedown event propagation on the Anomaly overlay wrapper, ConfirmOverlay, and NavigatingOverlay to prevent them from bubbling up and toggling playback.

<!-- Description -->

<!-- 
Mention any related issues here. 
Use the following sytax:

Closes #ISSUE-NUMBER 
-->
