### PR TITLE
fix(security): guard photo-preview img src to clear CodeQL DOM-XSS

### DIFF
--- a/frontend/src/components/Auth/AuthPage.tsx
+++ b/frontend/src/components/Auth/AuthPage.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/utils/utils";
 import { useSignup } from "@/hooks/hooks.ts";
 import ReCAPTCHA from "react-google-recaptcha";
 import { LeftHeroSection } from "@/components/Auth/LeftHeroSection";
+import { safeImagePreviewSrc } from "@/lib/imagePreview";
 
 type AuthPageProps = {
   role?: "teacher" | "student";
@@ -1183,7 +1184,7 @@ export default function AuthPage({ role }: AuthPageProps) {
                           ) : (
                             <div className="space-y-3">
                               <img
-                                src={studentPhotoPreview}
+                                src={safeImagePreviewSrc(studentPhotoPreview)}
                                 alt="Student preview"
                                 className="h-56 w-full rounded-lg object-cover"
                               />
@@ -1351,7 +1352,7 @@ export default function AuthPage({ role }: AuthPageProps) {
                 ) : (
                   <div className="space-y-3">
                     <img
-                      src={studentPhotoPreview}
+                      src={safeImagePreviewSrc(studentPhotoPreview)}
                       alt="Student preview"
                       className="h-56 w-full rounded-lg object-cover"
                     />
@@ -1473,7 +1474,7 @@ export default function AuthPage({ role }: AuthPageProps) {
                 ) : (
                   <div className="space-y-3">
                     <img
-                      src={studentPhotoPreview}
+                      src={safeImagePreviewSrc(studentPhotoPreview)}
                       alt="Student preview"
                       className="h-56 w-full rounded-lg object-cover"
                     />

--- a/frontend/src/components/ai/FaceRegistrationModal.tsx
+++ b/frontend/src/components/ai/FaceRegistrationModal.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Button } from "@/components/ui/button";
 import { Camera, Upload, RefreshCcw, X, AlertCircle } from "lucide-react";
 import { toast } from "sonner";
+import { safeImagePreviewSrc } from "@/lib/imagePreview";
 
 interface FaceRegistrationModalProps {
   isOpen: boolean;
@@ -367,7 +368,7 @@ export const FaceRegistrationModal: React.FC<FaceRegistrationModalProps> = ({
             ) : (
               <div className="space-y-3">
                 <img
-                  src={studentPhotoPreview}
+                  src={safeImagePreviewSrc(studentPhotoPreview)}
                   alt="Student preview"
                   className="h-56 w-full rounded-lg object-cover"
                 />

--- a/frontend/src/lib/imagePreview.ts
+++ b/frontend/src/lib/imagePreview.ts
@@ -6,8 +6,29 @@
  * `<img src={...}>` photo previews.
  */
 export function safeImagePreviewSrc(url: string | null | undefined): string {
-  if (typeof url === "string" && (url.startsWith("data:image/") || url.startsWith("blob:"))) {
-    return url;
+  if (typeof url !== "string" || url.trim() === "") return "";
+
+  try {
+    const parsed = new URL(url, window.location.origin);
+
+    // Object URLs created by URL.createObjectURL(file)
+    if (parsed.protocol === "blob:") {
+      return url;
+    }
+
+    // Data URLs from canvas.toDataURL("image/jpeg", ...)
+    if (parsed.protocol === "data:") {
+      const commaIndex = url.indexOf(",");
+      if (commaIndex <= 5) return "";
+      const metadata = url.slice(5, commaIndex).toLowerCase(); // strip "data:"
+      const mimeType = metadata.split(";")[0].trim();
+      if (mimeType.startsWith("image/")) {
+        return url;
+      }
+    }
+  } catch {
+    return "";
   }
+
   return "";
 }

--- a/frontend/src/lib/imagePreview.ts
+++ b/frontend/src/lib/imagePreview.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns `url` only if it is a locally-generated image preview — a
+ * `data:image/*` URL (canvas.toDataURL) or a `blob:` URL (URL.createObjectURL).
+ * Anything else collapses to "" so it can never be reinterpreted as HTML or an
+ * unexpected scheme. Defense-in-depth; also clears CodeQL js/xss-through-dom on
+ * `<img src={...}>` photo previews.
+ */
+export function safeImagePreviewSrc(url: string | null | undefined): string {
+  if (typeof url === "string" && (url.startsWith("data:image/") || url.startsWith("blob:"))) {
+    return url;
+  }
+  return "";
+}


### PR DESCRIPTION
CodeQL js/xss-through-dom (High) flagged the `<img src={studentPhotoPreview}>` photo previews in AuthPage and FaceRegistrationModal as "DOM text reinterpreted as HTML". The value only ever holds a locally-generated data:image/* URL (canvas.toDataURL) or blob: URL (URL.createObjectURL), so it is not actually exploitable, but the open High alert blocks merges.

Add a small shared safeImagePreviewSrc() helper that allow-lists the data:image/ and blob: schemes and collapses anything else to "". This breaks CodeQL's taint flow and adds defense-in-depth at the 4 preview sites (1 in FaceRegistrationModal, 3 in AuthPage).