### PR TITLE
Feat/student dashboard redesign

### DIFF
--- a/frontend/src/app/pages/student/courses.tsx
+++ b/frontend/src/app/pages/student/courses.tsx
@@ -166,14 +166,13 @@ export default function StudentCourses() {
         <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-4">
           <div className="flex md:flex-row flex-col items-center justify-between gap-2">
             <div className="relative flex-1 md:max-w-md w-full">
-              <div className="absolute inset-0 bg-gradient-to-r from-primary/10 to-accent/10 rounded-lg blur-sm"></div>
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
                   placeholder="Search courses..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-10 bg-background border-border focus:border-primary focus:ring-primary/20 transition-all duration-300"
+                  className="pl-10 h-11 bg-background border-border dark:bg-white/[0.05] dark:border-white/15 dark:hover:border-white/25 dark:placeholder:text-white/40 focus:border-primary focus:ring-primary/20 transition-all duration-300"
                 />
               </div>
               <div className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground">

--- a/frontend/src/app/pages/student/dashboard.tsx
+++ b/frontend/src/app/pages/student/dashboard.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "@tanstack/react-router";
 // Import components
 import { StatCard } from "@/components/ui/StatCard";
 import { CourseSection } from "@/components/course/CourseSection";
-import { DashboardSidebar } from "@/components/dashboard/DashboardSidebar";
+// import { DashboardSidebar } from "@/components/dashboard/DashboardSidebar"; // Hidden: Learning Checklist sidebar (commented out, not removed)
 import { EmptyState } from "@/components/ui/EmptyState";
 import { getGreeting } from "@/utils/helpers";
 import type { CourseCardProps } from '@/types/course.types';
@@ -474,11 +474,12 @@ function DashboardContent() {
             </Tabs>
 
           </main>
-          <aside className="w-full lg:w-80">
+          {/* Hidden: Learning Checklist sidebar (commented out, not removed) */}
+          {/* <aside className="w-full lg:w-80">
             <div className="sticky top-6">
               <DashboardSidebar enrollments={enrollments} />
             </div>
-          </aside>
+          </aside> */}
         </div>
       </div>
     </>

--- a/frontend/src/app/pages/student/dashboard.tsx
+++ b/frontend/src/app/pages/student/dashboard.tsx
@@ -17,7 +17,7 @@ import { CourseCard } from "@/components/course/CourseCard";
 import { CourseListCard } from "@/components/course/CourseListCard";
 import { FollowUpInvitesBanner } from "@/components/course/FollowUpInvitesBanner";
 import { NewAnnouncementsPopup } from "@/components/announcements/NewAnnouncementsPopup";
-import { BookOpen, Clock, Target, GraduationCap, LayoutGrid, List } from "lucide-react";
+import { BookOpen, Target, GraduationCap, LayoutGrid, List } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -149,8 +149,8 @@ function DashboardContent() {
     isLoading: publicCoursesLoading
   } = usePublicCourses(1, 5, !!token);
 
-  // Total watch time (seconds) — used to surface "Hours Invested".
-  const { data: watchTimeSeconds, isLoading: watchTimeLoading } = useWatchtimeTotal();
+  // Keep the watch-time query warm (preserves original prefetch behaviour); not displayed.
+  useWatchtimeTotal();
   const { data: statsData, isLoading: statsLoading } = useUserEnrollmentStats(!!token);
 
 
@@ -164,14 +164,6 @@ function DashboardContent() {
   }, [enrollments]);
 
   const totalProgress = statsData?.overallProgress ?? 0;
-
-  // Derive a friendly "hours invested" figure from the raw watch-time seconds.
-  const watchHours = (watchTimeSeconds ?? 0) / 3600;
-  const hoursDisplay = watchHours <= 0
-    ? "0"
-    : watchHours < 10
-      ? `${Math.round(watchHours * 10) / 10}`
-      : `${Math.round(watchHours)}`;
 
   const enrolledCount = statsData?.totalCourses ?? totalEnrollments;
   const completedCount = statsData?.completedCourses ?? completedEnrollments.length;
@@ -242,7 +234,7 @@ function DashboardContent() {
                 </p>
               </div>
 
-              <div className="relative mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              <div className="relative mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
                 <StatCard
                   tone="amber"
                   icon={<BookOpen className="h-5 w-5" />}
@@ -250,14 +242,6 @@ function DashboardContent() {
                   label="Enrolled Courses"
                   sublabel="In your catalog"
                   decoration="📚"
-                />
-                <StatCard
-                  tone="blue"
-                  icon={<Clock className="h-5 w-5" />}
-                  value={watchTimeLoading ? "—" : hoursDisplay}
-                  label="Hours Invested"
-                  sublabel="Total learning time"
-                  decoration="⏱️"
                 />
                 <StatCard
                   tone="emerald"

--- a/frontend/src/app/pages/student/dashboard.tsx
+++ b/frontend/src/app/pages/student/dashboard.tsx
@@ -206,18 +206,7 @@ function DashboardContent() {
       {/* Auto-popup any announcements the student hasn't seen yet */}
       <NewAnnouncementsPopup />
       <div className="container mx-auto px-0 sm:px-6 lg:px-8 xl:px-0 py-6">
-        {/*
-          Dashboard "screen": a glossy dark-GRAY surface in dark mode (never pure
-          black) and a clean light surface in light mode. Scoped here so the rest
-          of the app's theme is untouched.
-        */}
-        <div
-          className={cn(
-            "flex flex-col gap-6 rounded-[28px] p-3 transition-colors duration-300 sm:p-4 lg:flex-row lg:p-5",
-            "bg-transparent",
-            "dark:border dark:border-white/[0.05] dark:bg-gradient-to-b dark:from-[#202024] dark:via-[#1b1b1f] dark:to-[#171719] dark:shadow-xl dark:shadow-black/30"
-          )}
-        >
+        <div className="flex flex-col gap-6 lg:flex-row">
           <main className="w-full min-w-0 flex-1 space-y-6">
             {/* Hero + Stat Cards Section */}
             <section className="relative overflow-hidden rounded-3xl border border-neutral-200/70 bg-white p-6 shadow-sm ring-1 ring-black/[0.02] dark:border-white/[0.06] dark:bg-white/[0.03] dark:ring-white/[0.04] sm:p-8">
@@ -241,7 +230,6 @@ function DashboardContent() {
                   value={statsLoading ? "—" : `${enrolledCount}`}
                   label="Enrolled Courses"
                   sublabel="In your catalog"
-                  decoration="📚"
                 />
                 <StatCard
                   tone="emerald"
@@ -249,7 +237,6 @@ function DashboardContent() {
                   value={statsLoading ? "—" : `${totalProgress}%`}
                   label="Overall Progress"
                   sublabel="Across all courses"
-                  decoration="🎯"
                 />
                 <StatCard
                   tone="violet"
@@ -257,7 +244,6 @@ function DashboardContent() {
                   value={statsLoading ? "—" : `${completedCount}`}
                   label="Courses Completed"
                   sublabel="Successfully finished"
-                  decoration="✅"
                 />
               </div>
             </section>

--- a/frontend/src/app/pages/student/dashboard.tsx
+++ b/frontend/src/app/pages/student/dashboard.tsx
@@ -17,9 +17,59 @@ import { CourseCard } from "@/components/course/CourseCard";
 import { CourseListCard } from "@/components/course/CourseListCard";
 import { FollowUpInvitesBanner } from "@/components/course/FollowUpInvitesBanner";
 import { NewAnnouncementsPopup } from "@/components/announcements/NewAnnouncementsPopup";
-import { BookOpen, TrendingUp, LayoutGrid, List } from "lucide-react";
+import { BookOpen, Clock, Target, GraduationCap, LayoutGrid, List } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+/**
+ * Cards / List view switcher. Extracted so the three course tabs share one
+ * implementation. Behaviour (and the persisted `viewMode`) is unchanged — this
+ * only renders the toggle and calls back into the parent's `setViewMode`.
+ */
+function ViewSwitcher({ viewMode, setViewMode }: { viewMode: 'grid' | 'list'; setViewMode: (mode: 'grid' | 'list') => void }) {
+  const baseBtn = "h-8 gap-1.5 rounded-lg px-2.5 text-xs font-semibold transition-all duration-300";
+  const active = "bg-white text-foreground shadow-sm dark:bg-white/10 dark:text-white";
+  const inactive = "text-muted-foreground hover:text-foreground";
+
+  return (
+    <div className="flex items-center gap-1 rounded-xl border border-neutral-200/70 bg-neutral-100/80 p-1 dark:border-white/[0.07] dark:bg-white/[0.04]">
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="Card view"
+              aria-pressed={viewMode === 'grid'}
+              onClick={() => setViewMode('grid')}
+              className={cn(baseBtn, viewMode === 'grid' ? active : inactive)}
+            >
+              <LayoutGrid className="h-4 w-4" />
+              <span className="hidden sm:inline">Cards</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent><p>Card view</p></TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="List view"
+              aria-pressed={viewMode === 'list'}
+              onClick={() => setViewMode('list')}
+              className={cn(baseBtn, viewMode === 'list' ? active : inactive)}
+            >
+              <List className="h-4 w-4" />
+              <span className="hidden sm:inline">List</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent><p>List view</p></TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+}
 
 export default function Page() {
   useEffect(() => {
@@ -88,8 +138,8 @@ function DashboardContent() {
     isLoading: enrollmentsLoading,
   } = useUserEnrollments(1, 100, !!token); // Fetching 100 to get a good list for client-side filtering safely for now
 
-  // Cast to CourseCardProps['enrollment'][] to satisfy type checker if needed, 
-  // but simpler to let TS infer from usage if types match. 
+  // Cast to CourseCardProps['enrollment'][] to satisfy type checker if needed,
+  // but simpler to let TS infer from usage if types match.
   // Explicitly casting here to be safe given previous type errors.
   const enrollments = (enrollmentsData?.enrollments || []) as unknown as CourseCardProps['enrollment'][];
   const totalEnrollments = enrollmentsData?.totalDocuments || 0;
@@ -99,7 +149,8 @@ function DashboardContent() {
     isLoading: publicCoursesLoading
   } = usePublicCourses(1, 5, !!token);
 
-  useWatchtimeTotal();
+  // Total watch time (seconds) — used to surface "Hours Invested".
+  const { data: watchTimeSeconds, isLoading: watchTimeLoading } = useWatchtimeTotal();
   const { data: statsData, isLoading: statsLoading } = useUserEnrollmentStats(!!token);
 
 
@@ -113,6 +164,17 @@ function DashboardContent() {
   }, [enrollments]);
 
   const totalProgress = statsData?.overallProgress ?? 0;
+
+  // Derive a friendly "hours invested" figure from the raw watch-time seconds.
+  const watchHours = (watchTimeSeconds ?? 0) / 3600;
+  const hoursDisplay = watchHours <= 0
+    ? "0"
+    : watchHours < 10
+      ? `${Math.round(watchHours * 10) / 10}`
+      : `${Math.round(watchHours)}`;
+
+  const enrolledCount = statsData?.totalCourses ?? totalEnrollments;
+  const completedCount = statsData?.completedCourses ?? completedEnrollments.length;
 
   // Tab State
   const [activeTab, setActiveTab] = useState("available");
@@ -151,332 +213,273 @@ function DashboardContent() {
     <>
       {/* Auto-popup any announcements the student hasn't seen yet */}
       <NewAnnouncementsPopup />
-      <div className="container mx-auto px-0 sm:px-6 lg:px-8 xl:px-0 py-6 flex flex-col lg:flex-row gap-6 transition-all duration-300">
-        <main className="flex-1 w-full space-y-8">
-          {/* Greeting and Stat Cards Section */}
-          <div className="bg-background rounded-lg lg:px-6 py-6 px-0">
-            <h1 className="text-3xl font-bold mb-2">
-              {greeting}, {studentName} 👋
-            </h1>
-            <p className="text-muted-foreground mb-8 text-lg">
-              Welcome to your learning dashboard, check your priority learning.
-            </p>
+      <div className="container mx-auto px-0 sm:px-6 lg:px-8 xl:px-0 py-6">
+        {/*
+          Dashboard "screen": a glossy dark-GRAY surface in dark mode (never pure
+          black) and a clean light surface in light mode. Scoped here so the rest
+          of the app's theme is untouched.
+        */}
+        <div
+          className={cn(
+            "flex flex-col gap-6 rounded-[28px] p-3 transition-colors duration-300 sm:p-4 lg:flex-row lg:p-5",
+            "bg-transparent",
+            "dark:border dark:border-white/[0.05] dark:bg-gradient-to-b dark:from-[#202024] dark:via-[#1b1b1f] dark:to-[#171719] dark:shadow-xl dark:shadow-black/30"
+          )}
+        >
+          <main className="w-full min-w-0 flex-1 space-y-6">
+            {/* Hero + Stat Cards Section */}
+            <section className="relative overflow-hidden rounded-3xl border border-neutral-200/70 bg-white p-6 shadow-sm ring-1 ring-black/[0.02] dark:border-white/[0.06] dark:bg-white/[0.03] dark:ring-white/[0.04] sm:p-8">
+              {/* Ambient gloss */}
+              <div aria-hidden className="pointer-events-none absolute -right-16 -top-24 h-64 w-64 rounded-full bg-primary/10 blur-3xl" />
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 items-stretch w-full max-w-2xl">
-               <StatCard
-                icon={<BookOpen className="h-5 w-5" />}
-                value={statsLoading ? "—" : `${statsData?.totalCourses ?? totalEnrollments}`}
-                label="Enrolled Courses"
-              />
-              <StatCard
-                icon={<TrendingUp className="h-5 w-5 text-green-500" />}
-                value={statsLoading ? "—" : `${totalProgress}%`}
-                label="Completion Percentage"
-              />
+              <div className="relative">
+                <p className="mb-1 text-sm font-semibold tracking-wide text-primary">Your Learning Journey</p>
+                <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+                  {greeting}, {studentName} 👋
+                </h1>
+                <p className="mt-2 text-base text-muted-foreground sm:text-lg">
+                  Welcome back — here's your progress at a glance.
+                </p>
+              </div>
+
+              <div className="relative mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                <StatCard
+                  tone="amber"
+                  icon={<BookOpen className="h-5 w-5" />}
+                  value={statsLoading ? "—" : `${enrolledCount}`}
+                  label="Enrolled Courses"
+                  sublabel="In your catalog"
+                  decoration="📚"
+                />
+                <StatCard
+                  tone="blue"
+                  icon={<Clock className="h-5 w-5" />}
+                  value={watchTimeLoading ? "—" : hoursDisplay}
+                  label="Hours Invested"
+                  sublabel="Total learning time"
+                  decoration="⏱️"
+                />
+                <StatCard
+                  tone="emerald"
+                  icon={<Target className="h-5 w-5" />}
+                  value={statsLoading ? "—" : `${totalProgress}%`}
+                  label="Overall Progress"
+                  sublabel="Across all courses"
+                  decoration="🎯"
+                />
+                <StatCard
+                  tone="violet"
+                  icon={<GraduationCap className="h-5 w-5" />}
+                  value={statsLoading ? "—" : `${completedCount}`}
+                  label="Courses Completed"
+                  sublabel="Successfully finished"
+                  decoration="✅"
+                />
+              </div>
+            </section>
+
+            {/* Exclusive follow-up course invites unlocked by completing a course */}
+            <FollowUpInvitesBanner />
+
+            <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full space-y-6">
+              <TabsList className="w-full md:w-fit flex h-auto p-1 bg-slate-100/80 dark:bg-white/[0.04] rounded-full border border-slate-200/50 dark:border-white/[0.07] overflow-x-auto scrollbar-hide">
+                <TabsTrigger
+                  value="available"
+                  className="rounded-full py-2 px-3 md:py-2.5 md:px-6 text-xs md:text-sm font-semibold transition-all duration-300 data-[state=active]:bg-white dark:data-[state=active]:bg-white/10 data-[state=active]:text-primary data-[state=active]:shadow-sm whitespace-nowrap"
+                >
+                  Available
+                  {(publicCoursesData?.totalDocuments || 0) > 0 && (
+                    <span className="ml-1.5 md:ml-2 px-1.5 py-0.5 text-[9px] md:text-[10px] font-bold rounded-full bg-primary/10 text-primary border border-primary/20">
+                      {publicCoursesData?.totalDocuments}
+                    </span>
+                  )}
+                </TabsTrigger>
+                <TabsTrigger
+                  value="enrolled"
+                  className="rounded-full py-2 px-3 md:py-2.5 md:px-6 text-xs md:text-sm font-semibold transition-all duration-300 data-[state=active]:bg-white dark:data-[state=active]:bg-white/10 data-[state=active]:text-primary data-[state=active]:shadow-sm whitespace-nowrap"
+                >
+                  Enrolled
+                  {activeEnrollments.length > 0 && (
+                    <span className="ml-1.5 md:ml-2 px-1.5 py-0.5 text-[9px] md:text-[10px] font-bold rounded-full bg-blue-100 text-blue-600 border border-blue-200 dark:bg-blue-500/15 dark:text-blue-400 dark:border-blue-500/20">
+                      {activeEnrollments.length}
+                    </span>
+                  )}
+                </TabsTrigger>
+                <TabsTrigger
+                  value="completed"
+                  className="rounded-full py-2 px-3 md:py-2.5 md:px-6 text-xs md:text-sm font-semibold transition-all duration-300 data-[state=active]:bg-white dark:data-[state=active]:bg-white/10 data-[state=active]:text-primary data-[state=active]:shadow-sm whitespace-nowrap"
+                >
+                  Completed
+                  {completedEnrollments.length > 0 && (
+                    <span className="ml-1.5 md:ml-2 px-1.5 py-0.5 text-[9px] md:text-[10px] font-bold rounded-full bg-green-100 text-green-600 border border-green-200 dark:bg-green-500/15 dark:text-green-400 dark:border-green-500/20">
+                      {completedEnrollments.length}
+                    </span>
+                  )}
+                </TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="available" className="mt-6 space-y-4 animate-in fade-in-50 duration-300 slide-in-from-left-2">
+                <div className="flex items-center justify-between gap-3 mb-2">
+                  <div className="min-w-0">
+                    <h2 className="text-2xl font-bold tracking-tight">Recommended for you</h2>
+                    <p className="text-sm text-muted-foreground">Hand-picked courses to start next</p>
+                  </div>
+                  <ViewSwitcher viewMode={viewMode} setViewMode={setViewMode} />
+                </div>
+                <CourseSection
+                  title=""
+                  viewMode={viewMode}
+                  enrollments={publicCoursesData?.courses?.map((course: any) => ({
+                    courseId: course.courseId,
+                    courseVersionId: course.courseVersionId,
+                    course: {
+                      name: course.courseName,
+                      description: course.courseDescription,
+                      instructors: course.instructors
+                    },
+                    cohortId: course.cohortId,
+                    cohortName: course.cohortName,
+                  })) || []}
+                  isLoading={publicCoursesLoading}
+                  showViewAll
+                  onViewAll={() => navigate({ to: '/student/courses' })}
+                  variant="dashboard"
+                  cardVariant="available"
+                  emptyStateConfig={{
+                    title: "Discover new courses",
+                    description: "Explore our course catalog to find your next learning adventure",
+                    actionText: "Browse All Courses",
+                    onAction: () => navigate({ to: '/student/courses' })
+                  }}
+                />
+              </TabsContent>
+
+              <TabsContent value="enrolled" className="mt-6 space-y-4 animate-in fade-in-50 duration-300 slide-in-from-left-2">
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <h2 className="text-2xl font-bold tracking-tight">Active Courses</h2>
+                      <p className="text-sm text-muted-foreground">
+                        {activeEnrollments.length} in progress &bull; {completedEnrollments.length} completed
+                      </p>
+                    </div>
+                    <ViewSwitcher viewMode={viewMode} setViewMode={setViewMode} />
+                  </div>
+
+                  {enrollmentsLoading ? (
+                    <div className={cn(
+                      "grid gap-6",
+                      viewMode === 'grid' ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : "grid-cols-1"
+                    )}>
+                      {Array.from({ length: 3 }).map((_, i) => (
+                        <div key={i} className={cn(
+                          "w-full bg-muted animate-pulse",
+                          viewMode === 'grid' ? "h-[400px] rounded-[24px]" : "h-32 rounded-2xl"
+                        )} />
+                      ))}
+                    </div>
+                  ) : activeEnrollments.length > 0 ? (
+                    <div className={cn(
+                      "grid gap-6",
+                      viewMode === 'grid' ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : "grid-cols-1"
+                    )}>
+                      {activeEnrollments.map((enrollment, index) => (
+                        viewMode === 'grid' ? (
+                          <CourseCard
+                            key={enrollment._id || index}
+                            enrollment={enrollment}
+                            index={index}
+                            isLoading={false}
+                            variant="dashboard"
+                          />
+                        ) : (
+                          <CourseListCard
+                            key={enrollment._id || index}
+                            enrollment={enrollment}
+                            index={index}
+                            isLoading={false}
+                            variant="dashboard"
+                          />
+                        )
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState
+                      title="No active courses"
+                      description="You don't have any active courses at the moment."
+                      actionText="Browse Available Courses"
+                      onAction={() => setActiveTab("available")}
+                    />
+                  )}
+                </div>
+              </TabsContent>
+
+              <TabsContent value="completed" className="mt-6 space-y-4 animate-in fade-in-50 duration-300 slide-in-from-left-2">
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <h2 className="text-2xl font-bold tracking-tight">Completed Courses</h2>
+                      <p className="text-sm text-muted-foreground">Your finished learning &amp; certificates</p>
+                    </div>
+                    <ViewSwitcher viewMode={viewMode} setViewMode={setViewMode} />
+                  </div>
+
+                  {enrollmentsLoading ? (
+                    <div className={cn(
+                      "grid gap-6",
+                      viewMode === 'grid' ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : "grid-cols-1"
+                    )}>
+                      {Array.from({ length: 2 }).map((_, i) => (
+                        <div key={i} className={cn(
+                          "w-full bg-muted animate-pulse",
+                          viewMode === 'grid' ? "h-[400px] rounded-[24px]" : "h-32 rounded-2xl"
+                        )} />
+                      ))}
+                    </div>
+                  ) : completedEnrollments.length > 0 ? (
+                    <div className={cn(
+                      "grid gap-6",
+                      viewMode === 'grid' ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : "grid-cols-1"
+                    )}>
+                      {completedEnrollments.map((enrollment, index) => (
+                        viewMode === 'grid' ? (
+                          <CourseCard
+                            key={enrollment._id || index}
+                            enrollment={enrollment}
+                            index={index}
+                            isLoading={false}
+                            variant="dashboard"
+                          />
+                        ) : (
+                          <CourseListCard
+                            key={enrollment._id || index}
+                            enrollment={enrollment}
+                            index={index}
+                            isLoading={false}
+                            variant="dashboard"
+                          />
+                        )
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState
+                      title="No completed courses yet"
+                      description="Finish a course to see it here and claim your certificate!"
+                      actionText="Go to Enrolled Courses"
+                      onAction={() => setActiveTab("enrolled")}
+                    />
+                  )}
+                </div>
+              </TabsContent>
+            </Tabs>
+
+          </main>
+          <aside className="w-full lg:w-80">
+            <div className="sticky top-6">
+              <DashboardSidebar enrollments={enrollments} />
             </div>
-          </div>
-
-          {/* Exclusive follow-up course invites unlocked by completing a course */}
-          <FollowUpInvitesBanner />
-
-          <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6 w-full">
-            <TabsList className="w-full md:w-fit flex h-auto p-1 bg-slate-100/80 dark:bg-slate-800/50 rounded-full border border-slate-200/50 dark:border-slate-700/50 overflow-x-auto scrollbar-hide">
-              <TabsTrigger
-                value="available"
-                className="rounded-full py-2 px-3 md:py-2.5 md:px-6 text-xs md:text-sm font-semibold transition-all duration-300 data-[state=active]:bg-white dark:data-[state=active]:bg-slate-700 data-[state=active]:text-primary data-[state=active]:shadow-sm whitespace-nowrap"
-              >
-                Available
-                {(publicCoursesData?.totalDocuments || 0) > 0 && (
-                  <span className="ml-1.5 md:ml-2 px-1.5 py-0.5 text-[9px] md:text-[10px] font-bold rounded-full bg-primary/10 text-primary border border-primary/20">
-                    {publicCoursesData?.totalDocuments}
-                  </span>
-                )}
-              </TabsTrigger>
-              <TabsTrigger
-                value="enrolled"
-                className="rounded-full py-2 px-3 md:py-2.5 md:px-6 text-xs md:text-sm font-semibold transition-all duration-300 data-[state=active]:bg-white dark:data-[state=active]:bg-slate-700 data-[state=active]:text-primary data-[state=active]:shadow-sm whitespace-nowrap"
-              >
-                Enrolled
-                {activeEnrollments.length > 0 && (
-                  <span className="ml-1.5 md:ml-2 px-1.5 py-0.5 text-[9px] md:text-[10px] font-bold rounded-full bg-blue-100 text-blue-600 border border-blue-200">
-                    {activeEnrollments.length}
-                  </span>
-                )}
-              </TabsTrigger>
-              <TabsTrigger
-                value="completed"
-                className="rounded-full py-2 px-3 md:py-2.5 md:px-6 text-xs md:text-sm font-semibold transition-all duration-300 data-[state=active]:bg-white dark:data-[state=active]:bg-slate-700 data-[state=active]:text-primary data-[state=active]:shadow-sm whitespace-nowrap"
-              >
-                Completed
-                {completedEnrollments.length > 0 && (
-                  <span className="ml-1.5 md:ml-2 px-1.5 py-0.5 text-[9px] md:text-[10px] font-bold rounded-full bg-green-100 text-green-600 border border-green-200">
-                    {completedEnrollments.length}
-                  </span>
-                )}
-              </TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="available" className="mt-6 space-y-4 animate-in fade-in-50 duration-300 slide-in-from-left-2">
-              <div className="flex items-center justify-between mb-2">
-                <h2 className="text-2xl font-bold tracking-tight">Recommended for you</h2>
-                
-                {/* View Switcher Toggle */}
-                <div className="flex items-center bg-slate-100 dark:bg-slate-800/50 p-1 rounded-xl border border-slate-200/50 dark:border-slate-700/50 scale-90 sm:scale-100 origin-right">
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button 
-                          variant="ghost" 
-                          size="icon" 
-                          onClick={() => setViewMode('grid')}
-                          className={cn(
-                            "h-8 w-8 rounded-lg transition-all duration-300",
-                            viewMode === 'grid' ? "bg-white dark:bg-slate-700 text-primary shadow-sm" : "text-muted-foreground hover:text-foreground"
-                          )}
-                        >
-                          <LayoutGrid className="h-4.5 w-4.5" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent><p>Grid View</p></TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button 
-                          variant="ghost" 
-                          size="icon" 
-                          onClick={() => setViewMode('list')}
-                          className={cn(
-                            "h-8 w-8 rounded-lg transition-all duration-300",
-                            viewMode === 'list' ? "bg-white dark:bg-slate-700 text-primary shadow-sm" : "text-muted-foreground hover:text-foreground"
-                          )}
-                        >
-                          <List className="h-4.5 w-4.5" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent><p>List View</p></TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              </div>
-              <CourseSection
-                title=""
-                viewMode={viewMode}
-                enrollments={publicCoursesData?.courses?.map((course: any) => ({
-                  courseId: course.courseId,
-                  courseVersionId: course.courseVersionId,
-                  course: {
-                    name: course.courseName,
-                    description: course.courseDescription,
-                    instructors: course.instructors
-                  },
-                  cohortId: course.cohortId,
-                  cohortName: course.cohortName,
-                })) || []}
-                isLoading={publicCoursesLoading}
-                showViewAll
-                onViewAll={() => navigate({ to: '/student/courses' })}
-                variant="dashboard"
-                cardVariant="available"
-                emptyStateConfig={{
-                  title: "Discover new courses",
-                  description: "Explore our course catalog to find your next learning adventure",
-                  actionText: "Browse All Courses",
-                  onAction: () => navigate({ to: '/student/courses' })
-                }}
-              />
-            </TabsContent>
-
-            <TabsContent value="enrolled" className="mt-6 space-y-4 animate-in fade-in-50 duration-300 slide-in-from-left-2">
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <h2 className="text-2xl font-bold tracking-tight">Your Active Courses</h2>
-                  
-                  {/* View Switcher Toggle */}
-                  <div className="flex items-center bg-slate-100 dark:bg-slate-800/50 p-1 rounded-xl border border-slate-200/50 dark:border-slate-700/50 scale-90 sm:scale-100 origin-right">
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button 
-                            variant="ghost" 
-                            size="icon" 
-                            onClick={() => setViewMode('grid')}
-                            className={cn(
-                              "h-8 w-8 rounded-lg transition-all duration-300",
-                              viewMode === 'grid' ? "bg-white dark:bg-slate-700 text-primary shadow-sm" : "text-muted-foreground hover:text-foreground"
-                            )}
-                          >
-                            <LayoutGrid className="h-4.5 w-4.5" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent><p>Grid View</p></TooltipContent>
-                      </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button 
-                            variant="ghost" 
-                            size="icon" 
-                            onClick={() => setViewMode('list')}
-                            className={cn(
-                              "h-8 w-8 rounded-lg transition-all duration-300",
-                              viewMode === 'list' ? "bg-white dark:bg-slate-700 text-primary shadow-sm" : "text-muted-foreground hover:text-foreground"
-                            )}
-                          >
-                            <List className="h-4.5 w-4.5" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent><p>List View</p></TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </div>
-                </div>
-
-                {enrollmentsLoading ? (
-                  <div className={cn(
-                    "grid gap-6",
-                    viewMode === 'grid' ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : "grid-cols-1"
-                  )}>
-                    {Array.from({ length: 3 }).map((_, i) => (
-                      <div key={i} className={cn(
-                        "w-full bg-muted animate-pulse",
-                        viewMode === 'grid' ? "h-[400px] rounded-[24px]" : "h-32 rounded-2xl"
-                      )} />
-                    ))}
-                  </div>
-                ) : activeEnrollments.length > 0 ? (
-                  <div className={cn(
-                    "grid gap-6",
-                    viewMode === 'grid' ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : "grid-cols-1"
-                  )}>
-                    {activeEnrollments.map((enrollment, index) => (
-                      viewMode === 'grid' ? (
-                        <CourseCard
-                          key={enrollment._id || index}
-                          enrollment={enrollment}
-                          index={index}
-                          isLoading={false}
-                          variant="dashboard"
-                        />
-                      ) : (
-                        <CourseListCard
-                          key={enrollment._id || index}
-                          enrollment={enrollment}
-                          index={index}
-                          isLoading={false}
-                          variant="dashboard"
-                        />
-                      )
-                    ))}
-                  </div>
-                ) : (
-                  <EmptyState
-                    title="No active courses"
-                    description="You don't have any active courses at the moment."
-                    actionText="Browse Available Courses"
-                    onAction={() => setActiveTab("available")}
-                  />
-                )}
-              </div>
-            </TabsContent>
-
-            <TabsContent value="completed" className="mt-6 space-y-4 animate-in fade-in-50 duration-300 slide-in-from-left-2">
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <h2 className="text-2xl font-bold tracking-tight">Completed Courses</h2>
-                  
-                  {/* View Switcher Toggle */}
-                  <div className="flex items-center bg-slate-100 dark:bg-slate-800/50 p-1 rounded-xl border border-slate-200/50 dark:border-slate-700/50 scale-90 sm:scale-100 origin-right">
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button 
-                            variant="ghost" 
-                            size="icon" 
-                            onClick={() => setViewMode('grid')}
-                            className={cn(
-                              "h-8 w-8 rounded-lg transition-all duration-300",
-                              viewMode === 'grid' ? "bg-white dark:bg-slate-700 text-primary shadow-sm" : "text-muted-foreground hover:text-foreground"
-                            )}
-                          >
-                            <LayoutGrid className="h-4.5 w-4.5" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent><p>Grid View</p></TooltipContent>
-                      </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button 
-                            variant="ghost" 
-                            size="icon" 
-                            onClick={() => setViewMode('list')}
-                            className={cn(
-                              "h-8 w-8 rounded-lg transition-all duration-300",
-                              viewMode === 'list' ? "bg-white dark:bg-slate-700 text-primary shadow-sm" : "text-muted-foreground hover:text-foreground"
-                            )}
-                          >
-                            <List className="h-4.5 w-4.5" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent><p>List View</p></TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </div>
-                </div>
-
-                {enrollmentsLoading ? (
-                  <div className={cn(
-                    "grid gap-6",
-                    viewMode === 'grid' ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : "grid-cols-1"
-                  )}>
-                    {Array.from({ length: 2 }).map((_, i) => (
-                      <div key={i} className={cn(
-                        "w-full bg-muted animate-pulse",
-                        viewMode === 'grid' ? "h-[400px] rounded-[24px]" : "h-32 rounded-2xl"
-                      )} />
-                    ))}
-                  </div>
-                ) : completedEnrollments.length > 0 ? (
-                  <div className={cn(
-                    "grid gap-6",
-                    viewMode === 'grid' ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" : "grid-cols-1"
-                  )}>
-                    {completedEnrollments.map((enrollment, index) => (
-                      viewMode === 'grid' ? (
-                        <CourseCard
-                          key={enrollment._id || index}
-                          enrollment={enrollment}
-                          index={index}
-                          isLoading={false}
-                          variant="dashboard"
-                        />
-                      ) : (
-                        <CourseListCard
-                          key={enrollment._id || index}
-                          enrollment={enrollment}
-                          index={index}
-                          isLoading={false}
-                          variant="dashboard"
-                        />
-                      )
-                    ))}
-                  </div>
-                ) : (
-                  <EmptyState
-                    title="No completed courses yet"
-                    description="Finish a course to see it here and claim your certificate!"
-                    actionText="Go to Enrolled Courses"
-                    onAction={() => setActiveTab("enrolled")}
-                  />
-                )}
-              </div>
-            </TabsContent>
-          </Tabs>
-
-        </main>
-        <aside className="w-full lg:w-80">
-          <div className="sticky top-6">
-            <DashboardSidebar enrollments={enrollments} />
-          </div>
-        </aside>
+          </aside>
+        </div>
       </div>
     </>
   );

--- a/frontend/src/assets/globals.css
+++ b/frontend/src/assets/globals.css
@@ -157,6 +157,12 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* Smoother in-page scrolling (respects reduced-motion preferences) */
+  @media (prefers-reduced-motion: no-preference) {
+    html {
+      scroll-behavior: smooth;
+    }
+  }
   .card, .popover, .student-course-card {
     background-color: hsl(var(--card));
     color: hsl(var(--card-foreground));

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -180,21 +180,21 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
         bannerLight: "bg-gradient-to-br from-violet-100 via-violet-50 to-white",
         bannerDark: "dark:from-violet-500/25 dark:via-violet-500/5 dark:to-transparent",
         glow: "bg-violet-500/25",
-        iconComponent: <Play className="w-10 md:w-12 h-10 md:h-12" />,
+        iconComponent: <Play className="w-8 md:w-10 h-8 md:h-10" />,
       },
       {
         bg: "bg-[#DBEAFE]", icon: "text-[#3B82F6]", iconDark: "dark:text-blue-300", progress: "bg-[#3B82F6]",
         bannerLight: "bg-gradient-to-br from-blue-100 via-blue-50 to-white",
         bannerDark: "dark:from-blue-500/25 dark:via-blue-500/5 dark:to-transparent",
         glow: "bg-blue-500/25",
-        iconComponent: <Activity className="w-10 md:w-12 h-10 md:h-12" />,
+        iconComponent: <Activity className="w-8 md:w-10 h-8 md:h-10" />,
       },
       {
         bg: "bg-[#FCE7F3]", icon: "text-[#EC4899]", iconDark: "dark:text-pink-300", progress: "bg-[#EC4899]",
         bannerLight: "bg-gradient-to-br from-pink-100 via-pink-50 to-white",
         bannerDark: "dark:from-pink-500/25 dark:via-pink-500/5 dark:to-transparent",
         glow: "bg-pink-500/25",
-        iconComponent: <Users className="w-10 md:w-12 h-10 md:h-12" />,
+        iconComponent: <Users className="w-8 md:w-10 h-8 md:h-10" />,
       },
     ];
     const theme = themes[index % themes.length];
@@ -209,13 +209,12 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
                 "group flex flex-col shadow-sm rounded-[24px] overflow-hidden transition-shadow duration-300",
                 "border bg-white border-neutral-200/80 ring-1 ring-black/[0.02]",
                 "dark:bg-white/[0.03] dark:border-white/[0.07] dark:ring-white/[0.04]",
-                variant !== 'available' ? "cursor-pointer hover:shadow-md" : "cursor-default"
+                variant !== 'available' ? "hover:shadow-md" : ""
               )}
-              onClick={() => variant !== 'available' && setIsFlipped(true)}
             >
               {/* Thumbnail/Icon Area — soft tint in light, dark gradient + accent glow in dark */}
               <div className={cn(
-                "relative flex justify-center items-center w-full aspect-[4/3] overflow-hidden transition-colors duration-300",
+                "relative flex justify-center items-center w-full aspect-[16/9] overflow-hidden transition-colors duration-300",
                 theme.bannerLight,
                 "dark:bg-[#17171a] dark:bg-gradient-to-br", theme.bannerDark
               )}>
@@ -227,13 +226,21 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
                 {enrollment.hasNewItemsAfterCompletion && (
                   <Badge className="top-4 right-4 absolute bg-yellow-400 border-0 text-yellow-900">New Content</Badge>
                 )}
-                <div className="top-4 left-4 absolute bg-white/20 opacity-0 group-hover:opacity-100 backdrop-blur-sm p-2 rounded-full transition-opacity">
-                  <Info className="w-4 h-4 text-white" />
-                </div>
+                {variant !== 'available' && (
+                  <button
+                    type="button"
+                    onClick={(e) => { e.stopPropagation(); setIsFlipped(true); }}
+                    aria-label="View course details"
+                    title="More details"
+                    className="top-3 left-3 absolute bg-black/30 hover:bg-black/50 backdrop-blur-sm p-2 rounded-full text-white transition-colors focus:outline-none focus:ring-2 focus:ring-white/40"
+                  >
+                    <Info className="w-4 h-4" />
+                  </button>
+                )}
               </div>
 
-              <CardContent className="flex flex-col p-6 pb-10">
-                <div className="flex flex-wrap items-center gap-2 mb-4">
+              <CardContent className="flex flex-col p-5 pb-6">
+                <div className="flex flex-wrap items-center gap-2 mb-3">
                   <Badge variant="secondary" className="bg-[#F1F5F9] dark:bg-slate-800 px-3 border-0 font-medium text-[#64748B] dark:text-slate-400">Course</Badge>
                   {enrollment.cohortName && (
                     <Badge variant="outline" className="dark:bg-primary/10 px-3 border-primary/30 dark:border-blue-400/30 font-medium text-primary dark:text-blue-400">
@@ -244,13 +251,13 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
                 </div>
 
                 <h3
-                  className="mb-1 min-h-[3.25rem] font-bold text-foreground text-xl break-words line-clamp-2 leading-tight"
+                  className="mb-1 min-h-[2.75rem] font-bold text-foreground text-lg break-words line-clamp-2 leading-tight"
                   title={enrollment?.course?.name || `Course ${index + 1}`}
                 >
                   {enrollment?.course?.name || `Course ${index + 1}`}
                 </h3>
                 <p
-                  className="mb-6 min-h-[1.25rem] text-muted-foreground text-sm break-words line-clamp-1"
+                  className="mb-4 min-h-[1.25rem] text-muted-foreground text-sm break-words line-clamp-1"
                   title={instructorName || enrollment?.course?.description || "Accelerate your learning journey"}
                 >
                   {instructorName || enrollment?.course?.description || "Accelerate your learning journey"}
@@ -283,7 +290,7 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
                       <Button
                         onClick={(e) => { e.stopPropagation(); handleContinue(); }}
                         className={cn(
-                          "flex flex-1 justify-center items-center gap-2 shadow-md rounded-xl h-12 font-bold text-base active:scale-95 transition-all duration-300",
+                          "flex flex-1 justify-center items-center gap-2 shadow-md rounded-xl h-10 font-bold text-sm active:scale-95 transition-all duration-300",
                           variant === 'available' ? "bg-primary text-primary-foreground" : isStart ? "bg-[#22C55E] text-white" : "bg-primary text-primary-foreground hover:bg-primary/90"
                         )}
                       >
@@ -304,8 +311,8 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
                         <div onClick={(e) => e.stopPropagation()}>
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <Button variant="outline" size="icon" className="border-2 rounded-xl w-12 h-12" aria-label="More course actions">
-                                <MoreHorizontal className="w-5 h-5" />
+                              <Button variant="outline" size="icon" className="border-2 rounded-xl w-10 h-10" aria-label="More course actions">
+                                <MoreHorizontal className="w-4 h-4" />
                               </Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end" className="w-48">

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -200,7 +200,7 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
     const theme = themes[index % themes.length];
 
     return (
-      <div className={cn("transition-all hover:-translate-y-1 duration-300 [perspective:1000px]", className)}>
+      <div className={cn("transition-all hover:-translate-y-1 duration-300 ease-out [perspective:1000px]", className)}>
         <div className={cn("relative w-full transition-all duration-700 [transform-style:preserve-3d]", isFlipped && "[transform:rotateY(180deg)]")}>
           {/* Front Side - Determines the height */}
           <div className="relative w-full [backface-visibility:hidden]">

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -175,9 +175,27 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
 
   if (variant === 'dashboard' || variant === 'available') {
     const themes = [
-      { bg: "bg-[#F3E8FF]", icon: "text-[#A855F7]", progress: "bg-[#A855F7]", iconComponent: <Play className="w-10 md:w-12 h-10 md:h-12" /> },
-      { bg: "bg-[#DBEAFE]", icon: "text-[#3B82F6]", progress: "bg-[#3B82F6]", iconComponent: <Activity className="w-10 md:w-12 h-10 md:h-12" /> },
-      { bg: "bg-[#FCE7F3]", icon: "text-[#EC4899]", progress: "bg-[#EC4899]", iconComponent: <Users className="w-10 md:w-12 h-10 md:h-12" /> },
+      {
+        bg: "bg-[#F3E8FF]", icon: "text-[#A855F7]", iconDark: "dark:text-violet-300", progress: "bg-[#A855F7]",
+        bannerLight: "bg-gradient-to-br from-violet-100 via-violet-50 to-white",
+        bannerDark: "dark:from-violet-500/25 dark:via-violet-500/5 dark:to-transparent",
+        glow: "bg-violet-500/25",
+        iconComponent: <Play className="w-10 md:w-12 h-10 md:h-12" />,
+      },
+      {
+        bg: "bg-[#DBEAFE]", icon: "text-[#3B82F6]", iconDark: "dark:text-blue-300", progress: "bg-[#3B82F6]",
+        bannerLight: "bg-gradient-to-br from-blue-100 via-blue-50 to-white",
+        bannerDark: "dark:from-blue-500/25 dark:via-blue-500/5 dark:to-transparent",
+        glow: "bg-blue-500/25",
+        iconComponent: <Activity className="w-10 md:w-12 h-10 md:h-12" />,
+      },
+      {
+        bg: "bg-[#FCE7F3]", icon: "text-[#EC4899]", iconDark: "dark:text-pink-300", progress: "bg-[#EC4899]",
+        bannerLight: "bg-gradient-to-br from-pink-100 via-pink-50 to-white",
+        bannerDark: "dark:from-pink-500/25 dark:via-pink-500/5 dark:to-transparent",
+        glow: "bg-pink-500/25",
+        iconComponent: <Users className="w-10 md:w-12 h-10 md:h-12" />,
+      },
     ];
     const theme = themes[index % themes.length];
 
@@ -195,9 +213,15 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
               )}
               onClick={() => variant !== 'available' && setIsFlipped(true)}
             >
-              {/* Thumbnail/Icon Area */}
-              <div className={cn("relative flex justify-center items-center w-full aspect-[4/3] transition-colors duration-300", theme.bg, "dark:bg-gradient-to-br dark:from-white/[0.06] dark:to-white/[0.02]")}>
-                <div className={cn("group-hover:scale-110 transition-transform duration-500", theme.icon)}>
+              {/* Thumbnail/Icon Area — soft tint in light, dark gradient + accent glow in dark */}
+              <div className={cn(
+                "relative flex justify-center items-center w-full aspect-[4/3] overflow-hidden transition-colors duration-300",
+                theme.bannerLight,
+                "dark:bg-[#17171a] dark:bg-gradient-to-br", theme.bannerDark
+              )}>
+                {/* Accent glow for a glossy, on-theme feel */}
+                <div aria-hidden className={cn("pointer-events-none absolute -top-8 -right-8 h-28 w-28 rounded-full blur-2xl opacity-60 transition-opacity duration-300 group-hover:opacity-90", theme.glow)} />
+                <div className={cn("relative group-hover:scale-110 transition-transform duration-500", theme.icon, theme.iconDark)}>
                   {theme.iconComponent}
                 </div>
                 {enrollment.hasNewItemsAfterCompletion && (

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -1,12 +1,12 @@
-import { Clock, Trophy, Medal, Crown, Info, ExternalLink, Copy, MessageCircle, Users, Check, Sparkles, Play, Activity, Award, Shield as LucideShield } from "lucide-react";
+import { Clock, Trophy, Medal, Info, ExternalLink, Copy, MessageCircle, Users, Check, Sparkles, Play, Activity, Shield as LucideShield, MoreHorizontal } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useLeaderboard, useCourseVersionById, useCheckTimeSlotAccessOnDemand } from "@/hooks/hooks";
 import { toast } from "sonner";
@@ -61,13 +61,8 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const [isTimeslotModalOpen, setIsTimeslotModalOpen] = useState(false);
   const [isLeaderboardOpen, setIsLeaderboardOpen] = useState(false);
-  const [isSupportOpen, setIsSupportOpen] = useState(false);
+  const [isForumOpen, setIsForumOpen] = useState(false);
   // const [showPolicies, setShowPolicies] = useState(false);
-  const supportEmail =
-    enrollment.courseId === "692f030a945e82ec875e9116"
-      ? "vibe-support@vicharanashala.zohodesk"
-      : "internship-support@vicharanashala.zohodesk";
-
 
   const progress = Number(Math.min(enrollment.percentCompleted ?? 0, 100).toFixed(2));
 
@@ -113,6 +108,11 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
   const completedLessons = enrollment.completedItems as number || 0;
   const isCompleted = (typeof enrollment.percentCompleted === 'number' && enrollment.percentCompleted >= 100) || false;
 
+  // Instructor name(s) for display (UI only — uses existing enrollment data).
+  const instructorName = Array.isArray(enrollment.course?.instructors)
+    ? enrollment.course.instructors.map((i: any) => i?.name).filter(Boolean).join(', ')
+    : '';
+
   const GURU_SETU_VERSION_ID = "6981df886e100cfe04f9c4ae";
   const isNotGuruSetu = versionId !== GURU_SETU_VERSION_ID;
 
@@ -134,7 +134,7 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
 
   useEffect(() => {
     if (!enrollment) return
-   
+
   })
 
   const handleContinue = async () => {
@@ -175,231 +175,147 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
 
   if (variant === 'dashboard' || variant === 'available') {
     const themes = [
-      { bg: "bg-[#F3E8FF]", icon: "text-[#A855F7]", progress: "bg-[#A855F7]", iconComponent: <Play className="h-10 w-10 md:h-12 md:w-12" /> },
-      { bg: "bg-[#DBEAFE]", icon: "text-[#3B82F6]", progress: "bg-[#3B82F6]", iconComponent: <Activity className="h-10 w-10 md:h-12 md:w-12" /> },
-      { bg: "bg-[#FCE7F3]", icon: "text-[#EC4899]", progress: "bg-[#EC4899]", iconComponent: <Users className="h-10 w-10 md:h-12 md:w-12" /> },
+      { bg: "bg-[#F3E8FF]", icon: "text-[#A855F7]", progress: "bg-[#A855F7]", iconComponent: <Play className="w-10 md:w-12 h-10 md:h-12" /> },
+      { bg: "bg-[#DBEAFE]", icon: "text-[#3B82F6]", progress: "bg-[#3B82F6]", iconComponent: <Activity className="w-10 md:w-12 h-10 md:h-12" /> },
+      { bg: "bg-[#FCE7F3]", icon: "text-[#EC4899]", progress: "bg-[#EC4899]", iconComponent: <Users className="w-10 md:w-12 h-10 md:h-12" /> },
     ];
     const theme = themes[index % themes.length];
 
     return (
-      <div className={cn("[perspective:1000px] transition-all duration-300 hover:-translate-y-1", className)}>
+      <div className={cn("transition-all hover:-translate-y-1 duration-300 [perspective:1000px]", className)}>
         <div className={cn("relative w-full transition-all duration-700 [transform-style:preserve-3d]", isFlipped && "[transform:rotateY(180deg)]")}>
           {/* Front Side - Determines the height */}
           <div className="relative w-full [backface-visibility:hidden]">
             <Card
               className={cn(
-                "border-0 bg-white dark:bg-card overflow-hidden flex flex-col rounded-[24px] shadow-sm transition-shadow duration-300 group",
+                "group flex flex-col shadow-sm rounded-[24px] overflow-hidden transition-shadow duration-300",
+                "border bg-white border-neutral-200/80 ring-1 ring-black/[0.02]",
+                "dark:bg-white/[0.03] dark:border-white/[0.07] dark:ring-white/[0.04]",
                 variant !== 'available' ? "cursor-pointer hover:shadow-md" : "cursor-default"
               )}
               onClick={() => variant !== 'available' && setIsFlipped(true)}
             >
               {/* Thumbnail/Icon Area */}
-              <div className={cn("relative w-full aspect-[4/3] flex items-center justify-center transition-colors duration-300", theme.bg)}>
-                <div className={cn("transition-transform duration-500 group-hover:scale-110", theme.icon)}>
+              <div className={cn("relative flex justify-center items-center w-full aspect-[4/3] transition-colors duration-300", theme.bg, "dark:bg-gradient-to-br dark:from-white/[0.06] dark:to-white/[0.02]")}>
+                <div className={cn("group-hover:scale-110 transition-transform duration-500", theme.icon)}>
                   {theme.iconComponent}
                 </div>
                 {enrollment.hasNewItemsAfterCompletion && (
-                  <Badge className="absolute top-4 right-4 bg-yellow-400 text-yellow-900 border-0">New Content</Badge>
+                  <Badge className="top-4 right-4 absolute bg-yellow-400 border-0 text-yellow-900">New Content</Badge>
                 )}
-                <div className="absolute top-4 left-4 p-2 rounded-full bg-white/20 backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity">
-                  <Info className="h-4 w-4 text-white" />
+                <div className="top-4 left-4 absolute bg-white/20 opacity-0 group-hover:opacity-100 backdrop-blur-sm p-2 rounded-full transition-opacity">
+                  <Info className="w-4 h-4 text-white" />
                 </div>
               </div>
 
-              <CardContent className="p-6 pb-10 flex flex-col">
+              <CardContent className="flex flex-col p-6 pb-10">
                 <div className="flex flex-wrap items-center gap-2 mb-4">
-                  <Badge variant="secondary" className="bg-[#F1F5F9] text-[#64748B] dark:bg-slate-800 dark:text-slate-400 border-0 font-medium px-3">Course</Badge>
+                  <Badge variant="secondary" className="bg-[#F1F5F9] dark:bg-slate-800 px-3 border-0 font-medium text-[#64748B] dark:text-slate-400">Course</Badge>
                   {enrollment.cohortName && (
-                    <Badge variant="outline" className="border-primary/30 text-primary dark:bg-primary/10 dark:text-blue-400 dark:border-blue-400/30 font-medium px-3">
+                    <Badge variant="outline" className="dark:bg-primary/10 px-3 border-primary/30 dark:border-blue-400/30 font-medium text-primary dark:text-blue-400">
                       {enrollment.cohortName}
                     </Badge>
                   )}
-                  {isCompleted && <Badge className="bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 border-0 font-medium">Completed</Badge>}
+                  {isCompleted && <Badge className="bg-green-100 dark:bg-green-900/30 border-0 font-medium text-green-700 dark:text-green-400">Completed</Badge>}
                 </div>
 
                 <h3
-                  className="font-bold text-xl text-foreground mb-1 line-clamp-2 leading-tight break-words min-h-[3.25rem]"
+                  className="mb-1 min-h-[3.25rem] font-bold text-foreground text-xl break-words line-clamp-2 leading-tight"
                   title={enrollment?.course?.name || `Course ${index + 1}`}
                 >
                   {enrollment?.course?.name || `Course ${index + 1}`}
                 </h3>
                 <p
-                  className="text-sm text-muted-foreground mb-6 line-clamp-1 break-words min-h-[1.25rem]"
-                  title={enrollment?.course?.description || "Accelerate your learning journey"}
+                  className="mb-6 min-h-[1.25rem] text-muted-foreground text-sm break-words line-clamp-1"
+                  title={instructorName || enrollment?.course?.description || "Accelerate your learning journey"}
                 >
-                  {enrollment?.course?.description || "Accelerate your learning journey"}
+                  {instructorName || enrollment?.course?.description || "Accelerate your learning journey"}
                 </p>
 
                 <div className="space-y-4">
                   {variant !== 'available' && (
                     <div className="space-y-2">
-                      <div className="flex justify-between items-center text-sm font-semibold">
+                      <div className="flex justify-between items-center font-semibold text-sm">
 
                         {enrollment.courseId !== "6981df886e100cfe04f9c4ad" && <> <span className="text-muted-foreground">Progress</span><span className="text-foreground">{progress.toFixed(0)}%</span></>}
                       </div>
 
-                      {enrollment.courseId !== "6981df886e100cfe04f9c4ad" ? (<div className="h-2 w-full bg-[#F1F5F9] dark:bg-slate-800 rounded-full overflow-hidden">
-                        <div className={cn("h-full rounded-full transition-all duration-700 ease-out", theme.progress)} style={{ width: `${progress}%` }} />
-                      </div>) : (<div className="flex justify-between items-center text-sm font-semibold">
+                      {enrollment.courseId !== "6981df886e100cfe04f9c4ad" ? (<div className="bg-[#F1F5F9] dark:bg-white/10 rounded-full w-full h-2 overflow-hidden">
+                        <div className={cn("rounded-full h-full transition-all duration-700 ease-out", theme.progress)} style={{ width: `${progress}%` }} />
+                      </div>) : (<div className="flex justify-between items-center font-semibold text-sm">
                         <span className="text-muted-foreground">Progress</span>
                         <span>{enrollment.completedItems}/{enrollment.contentCounts?.totalItems} (More videos soon)</span>
                       </div>)}
 
+                      {enrollment.courseId !== "6981df886e100cfe04f9c4ad" && totalLessons > 0 && (
+                        <p className="text-muted-foreground text-xs">{completedLessons} of {totalLessons} lessons</p>
+                      )}
+
                     </div>
                   )}
 
-                  <div className="grid grid-cols-1 gap-3 pt-2">
-                    <Button
-                      onClick={(e) => { e.stopPropagation(); handleContinue(); }}
-                      className={cn(
-                        "w-full h-12 rounded-xl text-lg font-bold transition-all duration-300 shadow-md active:scale-95 flex items-center justify-center gap-2",
-                        variant === 'available' ? "bg-primary text-primary-foreground" : isStart ? "bg-[#22C55E] text-white" : "bg-[#FACC15] text-black"
-                      )}
-                    >
-                      {variant === 'available' ? (
-                        <span className="flex items-center gap-2">
-                          Register Now
-                          <ExternalLink className="h-4 w-4" />
-                        </span>
-                      ) : (
-                        <>
-                          {isStart ? 'Start Course' : isCompleted ? 'View Course' : 'Continue Learning'}
-                          <Play className="h-4 w-4 fill-current" />
-                        </>
-                      )}
-                    </Button>
+                  <div className="gap-3 grid grid-cols-1 pt-2">
+                    <div className="flex items-center gap-2">
+                      <Button
+                        onClick={(e) => { e.stopPropagation(); handleContinue(); }}
+                        className={cn(
+                          "flex flex-1 justify-center items-center gap-2 shadow-md rounded-xl h-12 font-bold text-base active:scale-95 transition-all duration-300",
+                          variant === 'available' ? "bg-primary text-primary-foreground" : isStart ? "bg-[#22C55E] text-white" : "bg-primary text-primary-foreground hover:bg-primary/90"
+                        )}
+                      >
+                        {variant === 'available' ? (
+                          <span className="flex items-center gap-2">
+                            Register Now
+                            <ExternalLink className="w-4 h-4" />
+                          </span>
+                        ) : (
+                          <>
+                            {isStart ? 'Start Course' : isCompleted ? 'View Course' : 'Continue Learning'}
+                            <Play className="fill-current w-4 h-4" />
+                          </>
+                        )}
+                      </Button>
 
-                    <div className="flex gap-2">
-                      {isRankVisible && (
-                        <div onClick={(e) => e.stopPropagation()} className="flex-1">
-                          <Dialog open={isLeaderboardOpen} onOpenChange={setIsLeaderboardOpen}>
-                            <DialogTrigger asChild>
-                              <Button variant="outline" className="w-full rounded-lg border-2 h-10 text-[10px] lg:text-xs font-bold px-1" size="sm">
-                                <Trophy className="h-3 w-3 lg:h-3.5 lg:w-3.5 mr-1 text-yellow-500 flex-shrink-0" />
-                                <span className="truncate">Rank</span>
+                      {variant !== 'available' && isNotGuruSetu && (
+                        <div onClick={(e) => e.stopPropagation()}>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button variant="outline" size="icon" className="border-2 rounded-xl w-12 h-12" aria-label="More course actions">
+                                <MoreHorizontal className="w-5 h-5" />
                               </Button>
-                            </DialogTrigger>
-                            <LeaderboardDialog courseId={courseId} versionId={versionId} courseName={enrollment?.course?.name} isOpen={isLeaderboardOpen} />
-                          </Dialog>
-                        </div>
-                      )}
-                      {variant !== 'available' && isHpSystem && (
-                        <div onClick={(e) => e.stopPropagation()} className="flex-1">
-                          <Button
-                            variant="outline"
-                            className="w-full rounded-lg border-2 h-10 text-[10px] lg:text-xs font-bold px-1"
-                            size="sm"
-                            onClick={() => navigate({ to: `/student/hp-system/${versionId}/${enrollment.cohortName || 'default'}/activities` })}
-                          >
-                            <Activity className="h-3 w-3 lg:h-3.5 lg:w-3.5 mr-1 text-blue-500 flex-shrink-0" />
-                            <span className="truncate">HP</span>
-                          </Button>
-                        </div>
-                      )}
-                      {isTimeslotActive && (
-                        <div onClick={(e) => e.stopPropagation()} className="flex-1">
-                          <Button
-                            variant="outline"
-                            className="w-full rounded-lg border-2 h-10 text-[10px] lg:text-xs font-bold px-1"
-                            size="sm"
-                            onClick={() => setIsTimeslotModalOpen(true)}
-                          >
-                            <Clock className="h-3 w-3 lg:h-3.5 lg:w-3.5 mr-1 text-green-500 flex-shrink-0" />
-                            <span className="truncate">{hasAssignedTimeslot ? 'Slot' : 'Pick Slot'}</span>
-                          </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" className="w-48">
+                              {isRankVisible && (
+                                <DropdownMenuItem onClick={() => setIsLeaderboardOpen(true)}>
+                                  <Trophy className="mr-2 w-4 h-4 text-yellow-500" /> Leaderboard
+                                </DropdownMenuItem>
+                              )}
+                              {isHpSystem && (
+                                <DropdownMenuItem onClick={() => navigate({ to: `/student/hp-system/${versionId}/${enrollment.cohortName || 'default'}/activities` })}>
+                                  <Activity className="mr-2 w-4 h-4 text-blue-500" /> HP System
+                                </DropdownMenuItem>
+                              )}
+                              {isTimeslotActive && (
+                                <DropdownMenuItem onClick={() => setIsTimeslotModalOpen(true)}>
+                                  <Clock className="mr-2 w-4 h-4 text-green-500" /> {hasAssignedTimeslot ? 'Time Slot' : 'Pick Slot'}
+                                </DropdownMenuItem>
+                              )}
+                              <DropdownMenuItem onClick={() => setIsDetailsOpen(true)}>
+                                <Info className="mr-2 w-4 h-4 text-blue-500" /> Full Details
+                              </DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => setShowPolicies(true)}>
+                                <LucideShield className="mr-2 w-4 h-4 text-indigo-500" /> Policies
+                              </DropdownMenuItem>
+                              {supportLink && (
+                                <DropdownMenuItem onClick={() => setIsForumOpen(true)}>
+                                  <MessageCircle className="mr-2 w-4 h-4 text-blue-500" /> Forum
+                                </DropdownMenuItem>
+                              )}
+                            </DropdownMenuContent>
+                          </DropdownMenu>
                         </div>
                       )}
                     </div>
-
-                    {variant !== 'available' && isNotGuruSetu && (
-                      <div className="flex gap-2">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="flex-1 h-9 text-[10px] lg:text-xs font-bold rounded-lg border-2"
-                          onClick={(e) => { e.stopPropagation(); setShowPolicies(true); }}
-                        >
-                          <LucideShield className="h-3.5 w-3.5 mr-1 text-indigo-500" />
-                          Policies
-                        </Button>
-                        {supportLink && (
-                          <div onClick={(e) => e.stopPropagation()} className="flex-1">
-                            <Dialog>
-                              <DialogTrigger asChild>
-                                <Button variant="outline" size="sm" className="w-full h-9 text-[10px] lg:text-xs font-bold rounded-lg border-2">
-                                  <MessageCircle className="h-3.5 w-3.5 mr-1 text-blue-500" />
-                                  Forum
-                                </Button>
-                              </DialogTrigger>
-                              <DialogContent className="w-full max-w-lg">
-                                <DialogHeader>
-                                  <DialogTitle>Forum Details</DialogTitle>
-                                </DialogHeader>
-                                <Separator className="my-4" />
-                                <div className="space-y-4">
-                                  <div className="flex items-center gap-2">
-                                    <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
-                                      <MessageCircle className="w-4 h-4 text-primary-foreground" />
-                                    </div>
-                                    <h3 className="text-lg font-semibold">Discord Community</h3>
-                                    <Sparkles className="w-4 h-4 text-primary" />
-                                  </div>
-                                  <div className="rounded-xl border bg-primary/5 p-6 space-y-5">
-                                    <div className="flex items-start justify-between gap-4">
-                                      <div className="flex items-center gap-3">
-                                        <div className="w-14 h-14 rounded-xl bg-[#5865F2] flex items-center justify-center shadow-md">
-                                          <svg className="w-8 h-8 text-white" viewBox="0 0 24 24" fill="currentColor">
-                                            <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z" />
-                                          </svg>
-                                        </div>
-                                        <div>
-                                          <p className="font-semibold text-base">Join Our Community</p>
-                                          <p className="text-sm text-muted-foreground">Connect with fellow students</p>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <p className="text-sm text-muted-foreground leading-relaxed">
-                                      Get help, share resources, and connect with your coursemates in our exclusive Discord server.
-                                    </p>
-                                    <div className="flex items-center gap-2.5 pt-1">
-                                      <Button asChild className="flex-1">
-                                        <a href={supportLink} target="_blank" rel="noopener noreferrer" className="flex items-center justify-center gap-2">
-                                          <ExternalLink className="w-4 h-4" />
-                                          Join Discord
-                                        </a>
-                                      </Button>
-                                      <Button
-                                        variant="outline"
-                                        size="icon"
-                                        onClick={async () => {
-                                          try {
-                                            await navigator.clipboard.writeText(supportLink);
-                                            setCopied(true);
-                                            setTimeout(() => setCopied(false), 2000);
-                                          } catch {
-                                            setCopyError(true);
-                                            setTimeout(() => setCopyError(false), 2000);
-                                          }
-                                        }}
-                                        disabled={copied}
-                                      >
-                                        {copied ? <Check className="w-4 h-4 text-primary" /> : <Copy className="w-4 h-4" />}
-                                      </Button>
-                                    </div>
-                                    {(copied || copyError) && (
-                                      <div className={cn("text-xs px-3 py-2 rounded-lg border flex items-center gap-2", copied ? "text-primary bg-primary/10 border-primary/20" : "text-red-500 bg-red-50 border-red-100")}>
-                                        {copied ? <Check className="w-3 h-3" /> : <Info className="w-3 h-3" />}
-                                        {copied ? "Link copied to clipboard" : "Failed to copy link"}
-                                      </div>
-                                    )}
-                                  </div>
-                                </div>
-                              </DialogContent>
-                            </Dialog>
-                          </div>
-                        )}
-                      </div>
-                    )}
                   </div>
                 </div>
               </CardContent>
@@ -407,85 +323,85 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
           </div>
 
           {/* Back Side - Stretches to match front height */}
-          <div className="absolute inset-0 w-full h-full [backface-visibility:hidden] [transform:rotateY(180deg)] bg-white dark:bg-slate-900 rounded-[24px] p-6 border-2 border-primary/20 shadow-xl flex flex-col cursor-pointer" onClick={() => setIsFlipped(false)}>
-            <div className="flex-1 overflow-y-auto scrollbar-hide pr-1">
-              <div className="flex items-center justify-between mb-4">
-                <Badge className={cn("font-bold px-3 py-1", theme.bg, theme.icon.replace('text-', 'bg-').replace('[', '').replace(']', '/10'))}>
+          <div className="absolute inset-0 flex flex-col bg-white dark:bg-slate-900 shadow-xl p-6 border-2 border-primary/20 rounded-[24px] w-full h-full cursor-pointer [backface-visibility:hidden] [transform:rotateY(180deg)]" onClick={() => setIsFlipped(false)}>
+            <div className="flex-1 pr-1 overflow-y-auto scrollbar-hide">
+              <div className="flex justify-between items-center mb-4">
+                <Badge className={cn("px-3 py-1 font-bold", theme.bg, theme.icon.replace('text-', 'bg-').replace('[', '').replace(']', '/10'))}>
                   Course Details
                 </Badge>
-                <div className="p-2 rounded-full bg-slate-100 dark:bg-slate-800">
-                  <Play className={cn("h-5 w-5", theme.icon)} />
+                <div className="bg-slate-100 dark:bg-slate-800 p-2 rounded-full">
+                  <Play className={cn("w-5 h-5", theme.icon)} />
                 </div>
               </div>
 
-              <h3 className="font-bold text-lg text-foreground mb-4">{enrollment?.course?.name || `Course ${index + 1}`}</h3>
+              <h3 className="mb-4 font-bold text-foreground text-lg">{enrollment?.course?.name || `Course ${index + 1}`}</h3>
 
               <div className="space-y-4 mb-6">
                 <div>
-                  <h4 className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground mb-1 flex items-center gap-1.5">
-                    <Info className="h-3 w-3" /> Description
+                  <h4 className="flex items-center gap-1.5 mb-1 font-bold text-[10px] text-muted-foreground uppercase tracking-wider">
+                    <Info className="w-3 h-3" /> Description
                   </h4>
-                  <p className="text-xs text-foreground/80 leading-relaxed line-clamp-4">
+                  <p className="text-foreground/80 text-xs line-clamp-4 leading-relaxed">
                     {enrollment?.course?.description || "No description available for this course. Explore our structured curriculum designed to accelerate your learning journey."}
                   </p>
                 </div>
 
-                <div className="grid grid-cols-1 gap-3 py-3 border-y border-slate-100 dark:border-slate-800">
-                  <div className="flex items-center justify-between text-xs">
-                    <span className="text-muted-foreground font-medium">Version</span>
-                    <span className="text-foreground font-bold">{courseVersionData?.version || courseVersionData?.name || versionId.substring(0, 8)}</span>
+                <div className="gap-3 grid grid-cols-1 py-3 border-slate-100 border-y dark:border-slate-800">
+                  <div className="flex justify-between items-center text-xs">
+                    <span className="font-medium text-muted-foreground">Version</span>
+                    <span className="font-bold text-foreground">{courseVersionData?.version || courseVersionData?.name || versionId.substring(0, 8)}</span>
                   </div>
                   {enrollment.cohortName && (
-                    <div className="flex items-center justify-between text-xs">
-                      <span className="text-muted-foreground font-medium">Cohort</span>
-                      <span className="text-foreground font-bold truncate max-w-[120px]">{enrollment.cohortName}</span>
+                    <div className="flex justify-between items-center text-xs">
+                      <span className="font-medium text-muted-foreground">Cohort</span>
+                      <span className="max-w-[120px] font-bold text-foreground truncate">{enrollment.cohortName}</span>
                     </div>
                   )}
                   {/* Detailed Counts */}
-                  <div className="grid grid-cols-2 gap-x-4 gap-y-2 pt-1">
-                    <div className="flex items-center justify-between text-[11px]">
+                  <div className="gap-x-4 gap-y-2 grid grid-cols-2 pt-1">
+                    <div className="flex justify-between items-center text-[11px]">
                       <span className="text-muted-foreground">Total Items</span>
-                      <span className="text-foreground font-bold">{totalLessons}</span>
+                      <span className="font-bold text-foreground">{totalLessons}</span>
                     </div>
-                    <div className="flex items-center justify-between text-[11px]">
+                    <div className="flex justify-between items-center text-[11px]">
                       <span className="text-muted-foreground">Modules</span>
-                      <span className="text-foreground font-bold">{moduleCount}</span>
+                      <span className="font-bold text-foreground">{moduleCount}</span>
                     </div>
-                    <div className="flex items-center justify-between text-[11px]">
+                    <div className="flex justify-between items-center text-[11px]">
                       <span className="text-muted-foreground">Sections</span>
-                      <span className="text-foreground font-bold">{sectionCount}</span>
+                      <span className="font-bold text-foreground">{sectionCount}</span>
                     </div>
-                    <div className="flex items-center justify-between text-[11px]">
+                    <div className="flex justify-between items-center text-[11px]">
                       <span className="text-muted-foreground">Videos</span>
-                      <span className="text-foreground font-bold">{videoCount}</span>
+                      <span className="font-bold text-foreground">{videoCount}</span>
                     </div>
                     {quizCount > 0 && (
-                      <div className="flex items-center justify-between text-[11px]">
+                      <div className="flex justify-between items-center text-[11px]">
                         <span className="text-muted-foreground">Quizzes</span>
-                        <span className="text-foreground font-bold">{quizCount}</span>
+                        <span className="font-bold text-foreground">{quizCount}</span>
                       </div>
                     )}
                     {articleCount > 0 && (
-                      <div className="flex items-center justify-between text-[11px]">
+                      <div className="flex justify-between items-center text-[11px]">
                         <span className="text-muted-foreground">Articles</span>
-                        <span className="text-foreground font-bold">{articleCount}</span>
+                        <span className="font-bold text-foreground">{articleCount}</span>
                       </div>
                     )}
                     {projectCount > 0 && (
-                      <div className="flex items-center justify-between text-[11px]">
+                      <div className="flex justify-between items-center text-[11px]">
                         <span className="text-muted-foreground">Projects</span>
-                        <span className="text-foreground font-bold">{projectCount}</span>
+                        <span className="font-bold text-foreground">{projectCount}</span>
                       </div>
                     )}
                   </div>
 
                   {/* Timeslot Info */}
-                  <div className="flex items-center justify-between text-xs pt-2 mt-1 border-t border-slate-50 dark:border-slate-800/50">
-                    <span className="text-muted-foreground font-medium flex items-center gap-1">
-                      <Clock className="h-3 w-3" /> Timeslot
+                  <div className="flex justify-between items-center mt-1 pt-2 border-slate-50 dark:border-slate-800/50 border-t text-xs">
+                    <span className="flex items-center gap-1 font-medium text-muted-foreground">
+                      <Clock className="w-3 h-3" /> Timeslot
                     </span>
                     <span className={cn(
-                      "font-bold truncate max-w-[140px]",
+                      "max-w-[140px] font-bold truncate",
                       timeSlot ? "text-green-600 dark:text-green-400" : "text-muted-foreground"
                     )}>
                       {timeslotStr}
@@ -495,25 +411,25 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
               </div>
             </div>
 
-            <div className="mt-auto space-y-3 pt-4 border-t border-slate-100 dark:border-slate-800">
-              <div className={cn("grid gap-3", isTimeslotActive ? "grid-cols-2" : "grid-cols-1")} onClick={(e) => e.stopPropagation()}>
+            <div className="space-y-3 mt-auto pt-4 border-slate-100 dark:border-slate-800 border-t">
+              <div className={cn("gap-3 grid", isTimeslotActive ? "grid-cols-2" : "grid-cols-1")} onClick={(e) => e.stopPropagation()}>
                 {variant !== 'available' && (
                   <>
                     <Button
                       variant="outline"
-                      className="w-full rounded-lg h-9 text-[10px] font-bold border-2"
+                      className="border-2 rounded-lg w-full h-9 font-bold text-[10px]"
                       onClick={() => setIsDetailsOpen(true)}
                     >
-                      <Info className="h-3.5 w-3.5 mr-1 text-blue-500" />
+                      <Info className="mr-1 w-3.5 h-3.5 text-blue-500" />
                       Full Details
                     </Button>
                     {isTimeslotActive && (
                       <Button
                         variant="outline"
-                        className="w-full rounded-lg h-9 text-[10px] font-bold border-2"
+                        className="border-2 rounded-lg w-full h-9 font-bold text-[10px]"
                         onClick={() => setIsTimeslotModalOpen(true)}
                       >
-                        <Clock className="h-3.5 w-3.5 mr-1 text-green-500" />
+                        <Clock className="mr-1 w-3.5 h-3.5 text-green-500" />
                         {hasAssignedTimeslot ? 'Timeslot' : 'Pick Slot'}
                       </Button>
                     )}
@@ -524,12 +440,12 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
               <Button
                 onClick={(e) => { e.stopPropagation(); handleContinue(); }}
                 className={cn(
-                  "w-full h-10 rounded-xl text-xs font-bold transition-all duration-300 shadow-md active:scale-95 flex items-center justify-center gap-2",
+                  "flex justify-center items-center gap-2 shadow-md rounded-xl w-full h-10 font-bold text-xs active:scale-95 transition-all duration-300",
                   variant === 'available' ? "bg-primary text-primary-foreground" : isStart ? "bg-[#22C55E] text-white" : "bg-[#FACC15] text-black"
                 )}
               >
                 {variant === 'available' ? 'Register Now' : isStart ? 'Start Course' : isCompleted ? 'View Course' : 'Continue Learning'}
-                <ExternalLink className="h-3.5 w-3.5" />
+                <ExternalLink className="w-3.5 h-3.5" />
               </Button>
             </div>
           </div>
@@ -559,6 +475,87 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
           enrollmentDate={enrollment.enrollmentDate}
           currentProgressPercent={progress}
         />
+
+        {/* Leaderboard — opened from the overflow menu (kept fully functional) */}
+        {isRankVisible && (
+          <div onClick={(e) => e.stopPropagation()}>
+            <Dialog open={isLeaderboardOpen} onOpenChange={setIsLeaderboardOpen}>
+              <LeaderboardDialog courseId={courseId} versionId={versionId} courseName={enrollment?.course?.name} isOpen={isLeaderboardOpen} cohortId={cohortId} />
+            </Dialog>
+          </div>
+        )}
+
+        {/* Forum — opened from the overflow menu (kept fully functional) */}
+        {variant !== 'available' && isNotGuruSetu && supportLink && (
+          <div onClick={(e) => e.stopPropagation()}>
+            <Dialog open={isForumOpen} onOpenChange={setIsForumOpen}>
+              <DialogContent className="w-full max-w-lg">
+                <DialogHeader>
+                  <DialogTitle>Forum Details</DialogTitle>
+                </DialogHeader>
+                <Separator className="my-4" />
+                <div className="space-y-4">
+                  <div className="flex items-center gap-2">
+                    <div className="flex justify-center items-center bg-primary rounded-lg w-8 h-8">
+                      <MessageCircle className="w-4 h-4 text-primary-foreground" />
+                    </div>
+                    <h3 className="font-semibold text-lg">Discord Community</h3>
+                    <Sparkles className="w-4 h-4 text-primary" />
+                  </div>
+                  <div className="space-y-5 bg-primary/5 p-6 border rounded-xl">
+                    <div className="flex justify-between items-start gap-4">
+                      <div className="flex items-center gap-3">
+                        <div className="flex justify-center items-center bg-[#5865F2] shadow-md rounded-xl w-14 h-14">
+                          <svg className="w-8 h-8 text-white" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z" />
+                          </svg>
+                        </div>
+                        <div>
+                          <p className="font-semibold text-base">Join Our Community</p>
+                          <p className="text-muted-foreground text-sm">Connect with fellow students</p>
+                        </div>
+                      </div>
+                    </div>
+                    <p className="text-muted-foreground text-sm leading-relaxed">
+                      Get help, share resources, and connect with your coursemates in our exclusive Discord server.
+                    </p>
+                    <div className="flex items-center gap-2.5 pt-1">
+                      <Button asChild className="flex-1">
+                        <a href={supportLink} target="_blank" rel="noopener noreferrer" className="flex justify-center items-center gap-2">
+                          <ExternalLink className="w-4 h-4" />
+                          Join Discord
+                        </a>
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={async () => {
+                          try {
+                            await navigator.clipboard.writeText(supportLink);
+                            setCopied(true);
+                            setTimeout(() => setCopied(false), 2000);
+                          } catch {
+                            setCopyError(true);
+                            setTimeout(() => setCopyError(false), 2000);
+                          }
+                        }}
+                        disabled={copied}
+                      >
+                        {copied ? <Check className="w-4 h-4 text-primary" /> : <Copy className="w-4 h-4" />}
+                      </Button>
+                    </div>
+                    {(copied || copyError) && (
+                      <div className={cn("flex items-center gap-2 px-3 py-2 border rounded-lg text-xs", copied ? "text-primary bg-primary/10 border-primary/20" : "text-red-500 bg-red-50 border-red-100")}>
+                        {copied ? <Check className="w-3 h-3" /> : <Info className="w-3 h-3" />}
+                        {copied ? "Link copied to clipboard" : "Failed to copy link"}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </DialogContent>
+            </Dialog>
+          </div>
+        )}
       </div>
     );
   }
@@ -567,7 +564,7 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
   return (
     <Card className={className}>
       <CardHeader>
-        <div className="flex items-start justify-between">
+        <div className="flex justify-between items-start">
           <div>
             <CardTitle className="text-lg">
               {enrollment?.course?.name || `Course ${index + 1}`}
@@ -583,7 +580,7 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
           <div className="flex flex-col items-end gap-1">
             <Badge variant="outline">{progress.toFixed(2)}% complete</Badge>
             {isCompleted && (
-              <Badge className="bg-green-100 text-green-800 border-0 font-normal">
+              <Badge className="bg-green-100 border-0 font-normal text-green-800">
                 Completed
               </Badge>
             )}
@@ -600,14 +597,14 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
             <Progress value={progress} className="h-2" />
           </div>
 
-          <div className="grid grid-cols-2 gap-4 text-sm text-muted-foreground">
+          <div className="gap-4 grid grid-cols-2 text-muted-foreground text-sm">
             <div className="flex items-center gap-2">
-              <Clock className="h-4 w-4" />
+              <Clock className="w-4 h-4" />
               <span>{completedLessons} / {totalLessons} Lessons</span>
             </div>
             {enrollment.enrollmentDate && (
               <div className="flex items-center gap-2">
-                <Medal className="h-4 w-4" />
+                <Medal className="w-4 h-4" />
                 <span>Enrolled {new Date(enrollment.enrollmentDate).toLocaleDateString()}</span>
               </div>
             )}
@@ -622,7 +619,7 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
                 <Dialog open={isLeaderboardOpen} onOpenChange={setIsLeaderboardOpen}>
                   <DialogTrigger asChild>
                     <Button variant="outline" size="icon" title="Leaderboard">
-                      <Trophy className="h-4 w-4 text-yellow-500" />
+                      <Trophy className="w-4 h-4 text-yellow-500" />
                     </Button>
                   </DialogTrigger>
                   <LeaderboardDialog courseId={courseId} versionId={versionId} courseName={enrollment?.course?.name} isOpen={isLeaderboardOpen} cohortId={cohortId} />
@@ -630,12 +627,12 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
               )}
               {isHpSystem && (
                 <Button variant="outline" size="icon" title="HP System" onClick={() => navigate({ to: `/student/hp-system/${versionId}/${enrollment.cohortName || 'default'}/activities` })}>
-                  <Activity className="h-4 w-4 text-blue-500" />
+                  <Activity className="w-4 h-4 text-blue-500" />
                 </Button>
               )}
               {isTimeslotActive && (
                 <Button variant="outline" size="icon" title="Timeslot" onClick={() => setIsTimeslotModalOpen(true)}>
-                  <Clock className="h-4 w-4 text-green-500" />
+                  <Clock className="w-4 h-4 text-green-500" />
                 </Button>
               )}
             </div>
@@ -649,17 +646,17 @@ export const CourseCard = ({ enrollment, index, isLoading, variant = 'dashboard'
 export const CourseCardSkeleton = ({ variant }: { variant: string }) => {
   if (variant === 'dashboard' || variant === 'available') {
     return (
-      <Card className="border-0 bg-white dark:bg-card overflow-hidden flex flex-col rounded-[24px] shadow-sm animate-pulse">
-        <div className="w-full aspect-[4/3] bg-slate-100 dark:bg-slate-800" />
+      <Card className="flex flex-col bg-white dark:bg-card shadow-sm border-0 rounded-[24px] overflow-hidden animate-pulse">
+        <div className="bg-slate-100 dark:bg-slate-800 w-full aspect-[4/3]" />
         <CardContent className="p-6">
-          <Skeleton className="h-4 w-20 mb-4" />
-          <Skeleton className="h-6 w-full mb-2" />
-          <Skeleton className="h-4 w-3/4 mb-6" />
+          <Skeleton className="mb-4 w-20 h-4" />
+          <Skeleton className="mb-2 w-full h-6" />
+          <Skeleton className="mb-6 w-3/4 h-4" />
           <div className="space-y-2 mb-6">
-            <Skeleton className="h-2 w-full" />
-            <Skeleton className="h-2 w-full" />
+            <Skeleton className="w-full h-2" />
+            <Skeleton className="w-full h-2" />
           </div>
-          <Skeleton className="h-12 w-full rounded-xl" />
+          <Skeleton className="rounded-xl w-full h-12" />
         </CardContent>
       </Card>
     );
@@ -670,22 +667,22 @@ export const CourseCardSkeleton = ({ variant }: { variant: string }) => {
       <CardHeader>
         <div className="flex justify-between">
           <div className="space-y-2">
-            <Skeleton className="h-6 w-48" />
-            <Skeleton className="h-4 w-32" />
+            <Skeleton className="w-48 h-6" />
+            <Skeleton className="w-32 h-4" />
           </div>
-          <Skeleton className="h-6 w-24" />
+          <Skeleton className="w-24 h-6" />
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        <Skeleton className="h-2 w-full" />
+        <Skeleton className="w-full h-2" />
         <div className="flex justify-between">
-          <Skeleton className="h-4 w-32" />
-          <Skeleton className="h-4 w-32" />
+          <Skeleton className="w-32 h-4" />
+          <Skeleton className="w-32 h-4" />
         </div>
         <div className="flex gap-2">
-          <Skeleton className="h-10 flex-1" />
-          <Skeleton className="h-10 w-10" />
-          <Skeleton className="h-10 w-10" />
+          <Skeleton className="flex-1 h-10" />
+          <Skeleton className="w-10 h-10" />
+          <Skeleton className="w-10 h-10" />
         </div>
       </CardContent>
     </Card>
@@ -697,45 +694,45 @@ const LeaderboardDialog = ({ courseId, versionId, courseName, isOpen, cohortId }
   const { finishers, active, totalPages, activeTotal, isLoading, error, myStats } = useLeaderboard(courseId, versionId, page, 100, isOpen, cohortId);
 
   return (
-    <DialogContent className="max-w-4xl h-[85vh] flex flex-col overflow-hidden">
+    <DialogContent className="flex flex-col max-w-4xl h-[85vh] overflow-hidden">
       <DialogHeader className="flex-shrink-0 pb-4">
         <DialogTitle className="flex items-center gap-2">
-          <Trophy className="h-5 w-5 text-yellow-600" />
+          <Trophy className="w-5 h-5 text-yellow-600" />
           {courseName || 'Course'} Leaderboard
         </DialogTitle>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           Finishers ranked by how fast they completed; active learners by effort in the last 7 days.
         </p>
       </DialogHeader>
 
       <div className="flex-1 overflow-hidden">
-        <ScrollArea className="h-full pr-4">
+        <ScrollArea className="pr-4 h-full">
           {isLoading ? (
             <div className="space-y-3">
               {Array.from({ length: 10 }).map((_, i) => (
-                <Skeleton key={i} className="h-12 w-full" />
+                <Skeleton key={i} className="w-full h-12" />
               ))}
             </div>
           ) : error ? (
-            <p className="text-muted-foreground text-center py-8">{error}</p>
+            <p className="py-8 text-muted-foreground text-center">{error}</p>
           ) : finishers.length === 0 && active.length === 0 ? (
-            <p className="text-muted-foreground text-center py-8">No leaderboard data available.</p>
+            <p className="py-8 text-muted-foreground text-center">No leaderboard data available.</p>
           ) : (
             <LeaderboardLeagues finishers={finishers} active={active} myId={myStats?.userId} />
           )}
         </ScrollArea>
       </div>
 
-      <div className="flex-shrink-0 pt-4 border-t border-border/50 bg-background flex items-center justify-between">
+      <div className="flex flex-shrink-0 justify-between items-center bg-background pt-4 border-border/50 border-t">
         {myStats ? (
-          <div className="flex items-center gap-6 px-4 py-3 rounded-xl bg-primary/5 border border-primary/10">
+          <div className="flex items-center gap-6 bg-primary/5 px-4 py-3 border border-primary/10 rounded-xl">
             <div className="flex items-center gap-2">
-              <span className="text-[10px] text-muted-foreground uppercase font-bold tracking-wider">Your Rank</span>
-              <span className="font-bold text-xl text-yellow-500">#{myStats.rank}</span>
+              <span className="font-bold text-[10px] text-muted-foreground uppercase tracking-wider">Your Rank</span>
+              <span className="font-bold text-yellow-500 text-xl">#{myStats.rank}</span>
             </div>
-            <div className="w-px h-6 bg-border/50" />
+            <div className="bg-border/50 w-px h-6" />
             <div className="flex items-center gap-2">
-              <span className="text-[10px] text-muted-foreground uppercase font-bold tracking-wider">
+              <span className="font-bold text-[10px] text-muted-foreground uppercase tracking-wider">
                 {myStats.league === "finishers" ? "Finished in" : "This week"}
               </span>
               <Badge variant="outline" className="font-bold">

--- a/frontend/src/components/course/CourseListCard.tsx
+++ b/frontend/src/components/course/CourseListCard.tsx
@@ -105,7 +105,7 @@ export const CourseListCard = ({ enrollment, index, isLoading: _isLoading, varia
   return (
     <Card
       className={cn(
-        "group relative flex flex-col gap-3 rounded-2xl border p-4 transition-all duration-300 sm:flex-row sm:items-center sm:gap-4",
+        "group relative flex flex-col gap-3 rounded-2xl border p-4 transition-all duration-300 ease-out sm:flex-row sm:items-center sm:gap-4",
         "bg-white border-neutral-200/80 hover:border-neutral-300 hover:shadow-md",
         "dark:bg-white/[0.03] dark:border-white/[0.07] dark:hover:bg-white/[0.05]",
         "ring-1 ring-black/[0.02] dark:ring-white/[0.04]",

--- a/frontend/src/components/course/CourseListCard.tsx
+++ b/frontend/src/components/course/CourseListCard.tsx
@@ -1,22 +1,21 @@
-import { Clock, Info, Play, Trophy, Headphones, MessageCircle, ExternalLink, Users, Sparkles, Check, Copy, Crown, Medal, Award, LifeBuoy, Mail, Activity } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
+import { Clock, Info, Play, Trophy, Headphones, MessageCircle, ExternalLink, Check, Copy, Mail, Activity, MoreHorizontal, BookOpen } from "lucide-react";
+import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useCourseVersionById, useLeaderboard, useCheckTimeSlotAccessOnDemand } from "@/hooks/hooks";
 import { toast } from "sonner";
 import { useCourseStore } from "@/store/course-store";
 import { useNavigate } from "@tanstack/react-router";
-import { useState, lazy, Suspense, useEffect } from "react";
+import { useState, lazy, Suspense } from "react";
 import { bufferToHex } from "@/utils/helpers";
 import { cn } from "@/utils/utils";
 import type { CourseCardProps } from '@/types/course.types';
 import { EnrollmentDetailsDialog } from "@/components/course/EnrollmentDetailsDialog";
-import { ImageWithFallback } from "@/components/ui/ImageWithFallback";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Pagination } from "../ui/Pagination";
 import { LeaderboardLeagues } from "@/components/course/LeaderboardLeagues";
 
@@ -32,9 +31,6 @@ export const CourseListCard = ({ enrollment, index, isLoading: _isLoading, varia
   const courseId = bufferToHex(enrollment.courseId as string);
   const versionId = bufferToHex(enrollment.courseVersionId as string) || "";
   const cohortId = enrollment?.cohortId ? (typeof enrollment.cohortId === 'string' ? enrollment.cohortId : bufferToHex(enrollment.cohortId as any)) : "";
-  const module_number = enrollment.moduleNumber || "";
-  const section_number = enrollment.sectionNumber || "";
-  const item_type = enrollment.itemType || "VIDEO";
 
   const { data: courseVersionData } = useCourseVersionById(versionId, variant !== 'available', cohortId || undefined);
   const { setCurrentCourse } = useCourseStore();
@@ -64,6 +60,27 @@ export const CourseListCard = ({ enrollment, index, isLoading: _isLoading, varia
   const videoCount = Number((contentCounts as any).videos ?? itemCounts.VIDEO ?? versionItemCounts.VIDEO ?? 0);
   const quizCount = Number((contentCounts as any).quizzes ?? itemCounts.QUIZ ?? versionItemCounts.QUIZ ?? 0);
 
+  // Derived presentation data (UI only — no new data sources).
+  const instructors = enrollment.course?.instructors;
+  const instructorName = Array.isArray(instructors)
+    ? instructors.map((i: any) => i?.name).filter(Boolean).join(', ')
+    : '';
+  const completedItems = Number(enrollment.completedItems ?? 0);
+  const totalItems = Number(enrollment.contentCounts?.totalItems ?? 0);
+  const hpSystem = !!(courseVersionData as any)?.hpSystem;
+  const isMoreVideosSoon = enrollment.courseId === "6981df886e100cfe04f9c4ad";
+
+  // Subtle icon-tile accent, varied by position for visual rhythm.
+  const iconThemes = [
+    "bg-violet-500/10 text-violet-600 dark:text-violet-400",
+    "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+    "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+    "bg-pink-500/10 text-pink-600 dark:text-pink-400",
+  ];
+  const iconTheme = iconThemes[index % iconThemes.length];
+
+  const hasMenu = variant !== 'available' && isNotGuruSetu;
 
   const handleContinue = async (e?: React.MouseEvent) => {
     e?.stopPropagation();
@@ -86,167 +103,130 @@ export const CourseListCard = ({ enrollment, index, isLoading: _isLoading, varia
   };
 
   return (
-    <Card className={cn("dark:bg-[#4b341e4b] border border-border overflow-hidden flex flex-col sm:flex-row student-card-hover p-0", className)}>
-      <div className="w-full h-40 sm:h-auto sm:w-32 flex-shrink-0 flex items-center justify-center">
-        <ImageWithFallback
-          src="https://us.123rf.com/450wm/warat42/warat422108/warat42210800253/173451733-charts-graph-with-analysis-business-financial-data-white-clipboard-checklist-smartphone-wallet.jpg?ver=6"
-          alt={enrollment?.course?.name || `Course ${index + 1}`}
-          aspectRatio="aspect-square"
-          className="w-full h-full object-cover rounded-t-lg sm:rounded-l-lg sm:rounded-t-none"
-        />
+    <Card
+      className={cn(
+        "group relative flex flex-col gap-3 rounded-2xl border p-4 transition-all duration-300 sm:flex-row sm:items-center sm:gap-4",
+        "bg-white border-neutral-200/80 hover:border-neutral-300 hover:shadow-md",
+        "dark:bg-white/[0.03] dark:border-white/[0.07] dark:hover:bg-white/[0.05]",
+        "ring-1 ring-black/[0.02] dark:ring-white/[0.04]",
+        className
+      )}
+    >
+      {/* Icon tile */}
+      <div className={cn("flex h-14 w-14 shrink-0 items-center justify-center rounded-xl", iconTheme)}>
+        <BookOpen className="h-6 w-6" />
       </div>
 
-      <CardContent className="p-4 sm:pl-3 flex flex-col flex-1">
-        <div className="flex items-start justify-between xl:flex-row flex-col gap-2 mb-2">
-          <div className="flex items-center gap-2">
-            <Badge className="bg-secondary/70 text-secondary-foreground border-0 font-normal">Course</Badge>
-            {isCompleted && <Badge className="bg-green-100 text-green-800 border-0 font-normal">Completed</Badge>}
-            {enrollment.cohortName && <Badge variant="outline" className="text-[10px] border-primary/20 text-primary">{enrollment.cohortName}</Badge>}
-          </div>
-
-          <div className="text-[11px] text-muted-foreground flex flex-wrap gap-x-4 gap-y-1">
-            <div className="flex items-center gap-1.5 min-w-fit">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground hover:text-foreground transition-colors" />
-                  </TooltipTrigger>
-                  <TooltipContent side="top" sideOffset={8}>
-                    <p>This course is actively updated with new content.</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <span>Ongoing training</span>
-            </div>
-
-            {variant !== 'available' && (
-              <div className="flex items-center gap-2">
-                <span>Progress</span>
-                <div className="flex items-center gap-2">
-                  {enrollment.courseId !== "6981df886e100cfe04f9c4ad" ?  <div className="w-16 h-1.5 bg-secondary rounded-full overflow-hidden">
-                    <div className="h-full bg-primary rounded-full transition-all duration-300 ease-out" style={{ width: `${progress}%` }} />
-                  </div> : (<span>{enrollment.completedItems}/{enrollment.contentCounts?.totalItems} (More videos soon)</span>)}
-                  {enrollment.courseId !== "6981df886e100cfe04f9c4ad" && <span>{progress.toFixed(2)}%</span>}
-                </div>
-              </div>
-            )}
-
-            {variant !== 'available' && enrollment.enrollmentDate && (
-              <div className="flex items-center gap-1.5">
-                <span>Enrolled At</span>
-                <div className="flex items-center gap-1">
-                  <Clock className="h-3.5 w-3.5 text-green-500" />
-                  <span className="text-green-500">{new Date(enrollment.enrollmentDate).toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit', year: 'numeric' })}</span>
-                </div>
-              </div>
-            )}
-          </div>
+      {/* Main content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <h3
+            className="truncate text-base font-bold leading-tight text-foreground sm:text-lg"
+            title={enrollment?.course?.name || `Course ${index + 1}`}
+          >
+            {enrollment?.course?.name || `Course ${index + 1}`}
+          </h3>
+          {isCompleted && (
+            <Badge className="border-0 bg-green-100 text-green-700 dark:bg-green-500/15 dark:text-green-400">Completed</Badge>
+          )}
+          {enrollment.cohortName && (
+            <Badge variant="outline" className="border-primary/20 text-primary text-[10px]">{enrollment.cohortName}</Badge>
+          )}
         </div>
 
-        <h3 className="font-bold text-lg mb-1 leading-tight text-foreground">{enrollment?.course?.name || `Course ${index + 1}`}</h3>
+        {(instructorName || variant === 'available') && (
+          <p className="mt-0.5 truncate text-xs text-muted-foreground sm:text-sm">
+            {instructorName || 'Discover and enroll'}
+          </p>
+        )}
 
-        <p className="text-xs text-muted-foreground mb-4">
-          {variant === 'available' ? 'Discover and enroll' : isCompleted ? 'Course completed!' : progress === 0 ? 'Start your learning journey' : 'Continue Learning'}
-          {variant !== 'available' && !isCompleted && progress !== 0 && (
-            <span className="ml-2">&bull; MOD {module_number} &bull; SEC {section_number} &bull; {item_type}</span>
+        {variant !== 'available' ? (
+          <div className="mt-2.5 space-y-1.5">
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="text-muted-foreground">
+                {isMoreVideosSoon
+                  ? `${completedItems}/${totalItems} • More videos soon`
+                  : totalItems > 0
+                    ? `${completedItems} of ${totalItems} lessons`
+                    : `${videoCount} Videos • ${quizCount} Quizzes`}
+              </span>
+              {!isMoreVideosSoon && <span className="font-semibold text-foreground tabular-nums">{progress.toFixed(0)}%</span>}
+            </div>
+            {!isMoreVideosSoon && <Progress value={progress} className="h-1.5" />}
+          </div>
+        ) : (
+          <p className="mt-1.5 text-xs text-muted-foreground">
+            {videoCount} Videos • {quizCount} Quizzes
+          </p>
+        )}
+      </div>
+
+      {/* Actions: prominent primary CTA + tidy overflow menu (keeps every action) */}
+      <div className="flex shrink-0 items-center gap-2 self-stretch sm:self-center">
+        <Button
+          onClick={handleContinue}
+          className={cn(
+            "h-9 flex-1 gap-1.5 rounded-xl font-bold transition-all duration-200 sm:flex-none",
+            variant === 'available'
+              ? "bg-primary text-primary-foreground hover:bg-primary/90"
+              : progress === 0
+                ? "bg-green-600 text-white hover:bg-green-700"
+                : "bg-primary text-primary-foreground hover:bg-primary/90"
           )}
-          &nbsp;&nbsp;&bull; {videoCount} Videos &bull; {quizCount} Quizzes
-        </p>
+        >
+          {variant === 'available' ? 'Register' : progress === 0 ? 'Start' : isCompleted ? 'Review' : 'Continue'}
+          <Play className="h-3.5 w-3.5 fill-current" />
+        </Button>
 
-        <div className="mt-auto flex flex-col sm:flex-row gap-2">
-          <Button
-            className={cn("w-full sm:w-auto h-9 rounded-xl font-bold transition-all duration-200", variant === 'available' ? "bg-primary text-primary-foreground" : progress === 0 ? "bg-green-600 hover:bg-green-700 text-white shadow-md border-0" : "bg-primary text-primary-foreground hover:bg-primary/90 shadow-md")}
-            onClick={handleContinue}
-          >
-            {variant === 'available' ? 'Register' : progress === 0 ? 'Start' : isCompleted ? 'Completed' : 'Continue'}
-            <Play className="h-3.5 w-3.5 ml-2 fill-current" />
-          </Button>
-
-          {variant !== 'available' && isNotGuruSetu && (
-            <>
-              <Button variant="outline" size="sm" className="h-9 rounded-xl text-[11px] font-bold" onClick={() => setIsDetailsOpen(true)}>
-                    <Info className="h-3.5 w-3.5 mr-1.5 text-blue-500" /> Details
-                </Button>
-                {(courseVersionData as any)?.hpSystem && (
-                    <Button variant="outline" size="sm" className="h-9 rounded-xl text-[11px] font-bold" onClick={() => navigate({ to: `/student/hp-system/${versionId}/${enrollment.cohortName || 'default'}/activities` })}>
-                        <Activity className="h-3.5 w-3.5 mr-1.5 text-blue-500" /> HP
-                    </Button>
-                )}
-              <Button variant="outline" size="sm" className="h-9 rounded-xl text-[11px] font-bold" onClick={() => setIsTimeslotModalOpen(true)}>
-                <Clock className="h-3.5 w-3.5 mr-1.5 text-green-500" /> {hasAssignedTimeslot ? 'Slot' : 'Pick Slot'}
+        {hasMenu && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="icon" className="h-9 w-9 rounded-xl" aria-label="More course actions">
+                <MoreHorizontal className="h-4 w-4" />
               </Button>
-              <Dialog open={isLeaderboardOpen} onOpenChange={setIsLeaderboardOpen}>
-                <DialogTrigger asChild>
-                  <Button variant="outline" size="sm" className="h-9 rounded-xl text-[11px] font-bold">
-                    <Trophy className="h-3.5 w-3.5 mr-1.5 text-yellow-500" /> Rank
-                  </Button>
-                </DialogTrigger>
-                <LeaderboardDialog courseId={courseId} versionId={versionId} courseName={enrollment?.course?.name} isOpen={isLeaderboardOpen} cohortId={cohortId} />
-              </Dialog>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuItem onClick={() => setIsDetailsOpen(true)}>
+                <Info className="mr-2 h-4 w-4 text-blue-500" /> Details
+              </DropdownMenuItem>
+              {hpSystem && (
+                <DropdownMenuItem onClick={() => navigate({ to: `/student/hp-system/${versionId}/${enrollment.cohortName || 'default'}/activities` })}>
+                  <Activity className="mr-2 h-4 w-4 text-blue-500" /> HP System
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem onClick={() => setIsTimeslotModalOpen(true)}>
+                <Clock className="mr-2 h-4 w-4 text-green-500" /> {hasAssignedTimeslot ? 'Time Slot' : 'Pick Slot'}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setIsLeaderboardOpen(true)}>
+                <Trophy className="mr-2 h-4 w-4 text-yellow-500" /> Leaderboard
+              </DropdownMenuItem>
               {supportLink && (
-                <Button variant="outline" size="sm" className="h-9 rounded-xl text-[11px] font-bold" asChild>
-                  <a href={supportLink.startsWith('mailto:') || supportLink.includes('@') ? (supportLink.startsWith('mailto:') ? supportLink : `mailto:${supportLink}`) : supportLink} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1.5">
-                    <Headphones className="h-3.5 w-3.5 text-indigo-500" /> Support
+                <DropdownMenuItem asChild>
+                  <a
+                    href={supportLink.startsWith('mailto:') || supportLink.includes('@') ? (supportLink.startsWith('mailto:') ? supportLink : `mailto:${supportLink}`) : supportLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Headphones className="mr-2 h-4 w-4 text-indigo-500" /> Support
                   </a>
-                </Button>
+                </DropdownMenuItem>
               )}
               {enrollment.courseId === MERN_CASE_STUDY_ID && (
-                <Dialog open={isForumOpen} onOpenChange={setIsForumOpen}>
-                  <DialogTrigger asChild>
-                    <Button variant="outline" size="sm" className="h-9 rounded-xl text-[11px] font-bold">Forum</Button>
-                  </DialogTrigger>
-                  <DialogContent className="max-w-2xl h-[70vh] flex flex-col">
-                    <DialogHeader><DialogTitle>Discussion Forum</DialogTitle></DialogHeader>
-                    <ScrollArea className="flex-1 mt-4">
-                      <div className="space-y-4 p-4">
-                        <div className="flex items-center gap-2 mb-4">
-                          <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
-                            <MessageCircle className="w-4 h-4 text-primary-foreground" />
-                          </div>
-                          <h3 className="text-lg font-semibold">Discord Community</h3>
-                        </div>
-                        <div className="rounded-xl border bg-primary/5 p-6 space-y-4">
-                          <p className="text-sm text-muted-foreground">Join our exclusive Discord community to connect with peers and mentors.</p>
-                          <div className="flex gap-2">
-                            <Button className="flex-1" asChild>
-                              <a href="https://discord.gg/kKNBu3PF" target="_blank" rel="noopener noreferrer">
-                                <ExternalLink className="w-4 h-4 mr-2" /> Join Discord
-                              </a>
-                            </Button>
-                            <Button variant="outline" size="icon" onClick={() => { navigator.clipboard.writeText("https://discord.gg/kKNBu3PF"); setCopied(true); setTimeout(() => setCopied(false), 2000); }}>
-                              {copied ? <Check className="w-4 h-4 text-primary" /> : <Copy className="w-4 h-4" />}
-                            </Button>
-                          </div>
-                        </div>
-                      </div>
-                    </ScrollArea>
-                  </DialogContent>
-                </Dialog>
+                <DropdownMenuItem onClick={() => setIsForumOpen(true)}>
+                  <MessageCircle className="mr-2 h-4 w-4 text-blue-500" /> Forum
+                </DropdownMenuItem>
               )}
               {!supportLink && (enrollment.courseId === "6943b2cafa4e840eb39490b6" || enrollment.courseId === MERN_CASE_STUDY_ID) && (
-                <Dialog open={isSupportOpen} onOpenChange={setIsSupportOpen}>
-                  <DialogTrigger asChild>
-                    <Button variant="outline" size="sm" className="h-9 rounded-xl text-[11px] font-bold">Support</Button>
-                  </DialogTrigger>
-                  <DialogContent>
-                    <DialogHeader><DialogTitle>Contact Support</DialogTitle></DialogHeader>
-                    <div className="p-4 space-y-4">
-                      <div className="flex items-center gap-3">
-                        <div className="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary"><Mail className="w-6 h-6" /></div>
-                        <div>
-                          <p className="font-semibold">Email us at</p>
-                          <a href={`mailto:${supportEmail}`} className="text-primary hover:underline">{supportEmail}</a>
-                        </div>
-                      </div>
-                    </div>
-                  </DialogContent>
-                </Dialog>
+                <DropdownMenuItem onClick={() => setIsSupportOpen(true)}>
+                  <Mail className="mr-2 h-4 w-4 text-indigo-500" /> Support
+                </DropdownMenuItem>
               )}
-            </>
-          )}
-        </div>
-      </CardContent>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
 
+      {/* Controlled dialogs / modals — mounted here, opened from the menu. */}
       <EnrollmentDetailsDialog isOpen={isDetailsOpen} onOpenChange={setIsDetailsOpen} enrollment={enrollment} />
       <Suspense fallback={null}>
         <StudentTimeslotModal
@@ -258,6 +238,60 @@ export const CourseListCard = ({ enrollment, index, isLoading: _isLoading, varia
           hasAssignedTimeslot={!!hasAssignedTimeslot}
         />
       </Suspense>
+
+      {hasMenu && (
+        <Dialog open={isLeaderboardOpen} onOpenChange={setIsLeaderboardOpen}>
+          <LeaderboardDialog courseId={courseId} versionId={versionId} courseName={enrollment?.course?.name} isOpen={isLeaderboardOpen} cohortId={cohortId} />
+        </Dialog>
+      )}
+
+      {enrollment.courseId === MERN_CASE_STUDY_ID && (
+        <Dialog open={isForumOpen} onOpenChange={setIsForumOpen}>
+          <DialogContent className="max-w-2xl h-[70vh] flex flex-col">
+            <DialogHeader><DialogTitle>Discussion Forum</DialogTitle></DialogHeader>
+            <ScrollArea className="flex-1 mt-4">
+              <div className="space-y-4 p-4">
+                <div className="flex items-center gap-2 mb-4">
+                  <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
+                    <MessageCircle className="w-4 h-4 text-primary-foreground" />
+                  </div>
+                  <h3 className="text-lg font-semibold">Discord Community</h3>
+                </div>
+                <div className="rounded-xl border bg-primary/5 p-6 space-y-4">
+                  <p className="text-sm text-muted-foreground">Join our exclusive Discord community to connect with peers and mentors.</p>
+                  <div className="flex gap-2">
+                    <Button className="flex-1" asChild>
+                      <a href="https://discord.gg/kKNBu3PF" target="_blank" rel="noopener noreferrer">
+                        <ExternalLink className="w-4 h-4 mr-2" /> Join Discord
+                      </a>
+                    </Button>
+                    <Button variant="outline" size="icon" onClick={() => { navigator.clipboard.writeText("https://discord.gg/kKNBu3PF"); setCopied(true); setTimeout(() => setCopied(false), 2000); }}>
+                      {copied ? <Check className="w-4 h-4 text-primary" /> : <Copy className="w-4 h-4" />}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </ScrollArea>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {!supportLink && (enrollment.courseId === "6943b2cafa4e840eb39490b6" || enrollment.courseId === MERN_CASE_STUDY_ID) && (
+        <Dialog open={isSupportOpen} onOpenChange={setIsSupportOpen}>
+          <DialogContent>
+            <DialogHeader><DialogTitle>Contact Support</DialogTitle></DialogHeader>
+            <div className="p-4 space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary"><Mail className="w-6 h-6" /></div>
+                <div>
+                  <p className="font-semibold">Email us at</p>
+                  <a href={`mailto:${supportEmail}`} className="text-primary hover:underline">{supportEmail}</a>
+                </div>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
     </Card>
   );
 };

--- a/frontend/src/components/ui/StatCard.tsx
+++ b/frontend/src/components/ui/StatCard.tsx
@@ -35,7 +35,7 @@ export const StatCard = ({ icon, value, label, sublabel, tone = "amber", decorat
         // Light: clean white surface. Dark: soft glassy gray (not black).
         "bg-white border-neutral-200/80 dark:bg-white/[0.035] dark:border-white/[0.07]",
         "ring-1 ring-black/[0.02] dark:ring-white/[0.04] shadow-sm",
-        "transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg dark:hover:bg-white/[0.06]",
+        "transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-lg dark:hover:bg-white/[0.06]",
         className
       )}
     >

--- a/frontend/src/components/ui/StatCard.tsx
+++ b/frontend/src/components/ui/StatCard.tsx
@@ -2,67 +2,64 @@ import { Card } from "@/components/ui/card";
 import type { StatCardProps } from "@/types/ui.types";
 import { cn } from "@/utils/utils";
 
-// export const StatCard = ({ icon, value, label, className }: StatCardProps) => {
-//   return (
-//     <Card
-//       className={`
-//         bg-gradient-to-r from-[#ffecb3] to-[#ff9eb]
-//         dark:bg-gradient-to-r dark:to-[#ff940880] dark:from-[#95122c80]
-//         dark:text-white
-//         text-black
-//         shadow-lg
-//         rounded-2xl
-//         flex flex-row items-center p-4 gap-4
-//         h-[100px]
-//         w-full min-w-0 max-w-none
-//         sm:w-[180px] sm:min-w-[180px] sm:max-w-[180px]
-//         transform hover:scale-105 transition-transform duration-300
-//         ${className || ''}
-//       `}
-//     >
-//       <div className="
-//         bg-white/20
-//         p-3
-//         rounded-full
-//         text-2xl
-//         flex items-center justify-center
-//       ">
-//         {icon}
-//       </div>
-//       <div className="flex flex-col">
-//         <div className="text-xl font-bold">{value}</div>
-//         <div className="text-black dark:text-white text-sm">{label}</div>
-//       </div>
-//     </Card>
-//   );
-// };
+/**
+ * Tone presets keep the icon chip + ambient glow readable in BOTH light and
+ * dark themes (solid icon color, soft tinted chip, low-opacity glow).
+ */
+const TONES = {
+  amber: {
+    chip: "bg-amber-500/10 text-amber-600 ring-amber-500/20 dark:text-amber-400 dark:ring-amber-400/20",
+    glow: "from-amber-500/15",
+  },
+  blue: {
+    chip: "bg-blue-500/10 text-blue-600 ring-blue-500/20 dark:text-blue-400 dark:ring-blue-400/20",
+    glow: "from-blue-500/15",
+  },
+  emerald: {
+    chip: "bg-emerald-500/10 text-emerald-600 ring-emerald-500/20 dark:text-emerald-400 dark:ring-emerald-400/20",
+    glow: "from-emerald-500/15",
+  },
+  violet: {
+    chip: "bg-violet-500/10 text-violet-600 ring-violet-500/20 dark:text-violet-400 dark:ring-violet-400/20",
+    glow: "from-violet-500/15",
+  },
+} as const;
 
+export const StatCard = ({ icon, value, label, sublabel, tone = "amber", decoration, className }: StatCardProps) => {
+  const t = TONES[tone] ?? TONES.amber;
 
-export const StatCard = ({ icon, value, label, className }: StatCardProps) => {
-  const isEnrolled = label.toLowerCase().includes("enrolled");
-  
   return (
     <Card
       className={cn(
-        "border p-5 rounded-[20px] flex flex-row items-center gap-5 h-[110px] w-full transition-all duration-300 hover:shadow-lg hover:-translate-y-1",
-        isEnrolled 
-          ? "bg-[#FFF5F8] border-[#FFD6E0] dark:bg-pink-950/20 dark:border-pink-900/30" 
-          : "bg-[#F0F7FF] border-[#D1E9FF] dark:bg-blue-950/20 dark:border-blue-900/30",
+        "group relative h-full min-h-[128px] overflow-hidden rounded-2xl border p-5 gap-4",
+        // Light: clean white surface. Dark: soft glassy gray (not black).
+        "bg-white border-neutral-200/80 dark:bg-white/[0.035] dark:border-white/[0.07]",
+        "ring-1 ring-black/[0.02] dark:ring-white/[0.04] shadow-sm",
+        "transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg dark:hover:bg-white/[0.06]",
         className
       )}
     >
-      <div className={cn(
-        "p-3 rounded-xl flex items-center justify-center shrink-0 shadow-sm",
-        isEnrolled ? "bg-white text-[#D97706]" : "bg-white text-[#EF4444]"
-      )}>
-        {icon}
+      {/* Glossy ambient accent */}
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute -right-10 -top-12 h-28 w-28 rounded-full bg-gradient-to-br to-transparent opacity-70 blur-2xl transition-opacity duration-300 group-hover:opacity-100",
+          t.glow
+        )}
+      />
+
+      <div className="relative flex items-start justify-between">
+        <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-xl shadow-sm ring-1", t.chip)}>
+          {icon}
+        </div>
+        {decoration ? <div className="text-xl leading-none">{decoration}</div> : null}
       </div>
 
-      <div className="flex flex-col min-w-0">
-        <span className="text-3xl font-bold tracking-tight text-foreground">{value}</span>
-        <span className="text-sm text-muted-foreground font-medium">{label}</span>
+      <div className="relative flex min-w-0 flex-col gap-0.5">
+        <span className="text-3xl font-bold tracking-tight tabular-nums text-foreground">{value}</span>
+        <span className="text-sm font-semibold text-foreground/90">{label}</span>
+        {sublabel ? <span className="truncate text-xs text-muted-foreground">{sublabel}</span> : null}
       </div>
     </Card>
   );
 };
-

--- a/frontend/src/layouts/student-layout.tsx
+++ b/frontend/src/layouts/student-layout.tsx
@@ -170,7 +170,7 @@ percentCompleted !== 100){
   }, [showInvites, selectedInvite]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-background to-background/95 bg-gray-50/50 dark:bg-orange-950/70">
+    <div className="min-h-screen bg-gradient-to-br from-background via-background to-background/95 bg-gray-50/50 dark:from-[#1e1e22] dark:via-[#191a1d] dark:to-[#151517]">
 
       {/* <FloatingVideo isVisible={user?.role === 'student'}></FloatingVideo> */}
       <ConfirmationModal isOpen={confirmLogout}
@@ -470,7 +470,7 @@ percentCompleted !== 100){
 
       <main className="relative flex flex-1 flex-col p-6">
         {/* Content background gradient */}
-        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-background/50 to-background pointer-events-none" />
+        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-background/50 to-background dark:via-[#19191c]/40 dark:to-[#151517] pointer-events-none" />
         <div className="relative z-10 h-full">
           <Outlet />
         </div>

--- a/frontend/src/layouts/student-layout.tsx
+++ b/frontend/src/layouts/student-layout.tsx
@@ -46,6 +46,8 @@ export default function StudentLayout() {
 
   const { hasNew: hasNewAnnouncements, markSeen: markAnnouncementsSeen } = useNewAnnouncementIndicator();
   const pathname = location.pathname;
+  // Dark-gray glassy navbar only on the redesigned pages: dashboard + courses.
+  const isThemedHeaderPage = pathname === "/student" || pathname === "/student/courses";
 
   const [approvedNotificationsList, setApprovedNotificationsList] = useState<any[]>([]);
   const [localRejectedRegistrations, setLocalRejectedRegistrations] = useState<any[]>([]);
@@ -182,7 +184,7 @@ percentCompleted !== 100){
       {/* Ambient background effect */}
       <div className="fixed inset-0 bg-gradient-to-br from-primary/[0.02] via-transparent to-secondary/[0.02] pointer-events-none" />
 
-      <header className="sticky top-0 z-50 flex h-16 shrink-0 items-center gap-2 border-b border-border/20 bg-background/80 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60 transition-all duration-300 before:absolute before:inset-0 before:bg-gradient-to-r before:from-transparent before:via-primary/[0.02] before:to-transparent before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-500">
+      <header className={`sticky top-0 z-50 flex h-16 shrink-0 items-center gap-2 border-b border-border/20 bg-background/80 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60 transition-all duration-300 before:absolute before:inset-0 before:bg-gradient-to-r before:from-transparent before:via-primary/[0.02] before:to-transparent before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-500 ${isThemedHeaderPage ? "dark:border-white/[0.06] dark:bg-[#1b1b1f]/80 dark:supports-[backdrop-filter]:bg-[#1b1b1f]/70" : ""}`}>
         <div className="flex w-full items-center justify-between px-4 sm:px-8 relative z-10">
           <div className="flex items-center gap-8">
             <Link to="/student" className="relative z-20 flex items-center text-xl font-bold tracking-tight group cursor-pointer">
@@ -375,7 +377,7 @@ percentCompleted !== 100){
         </div>
 
         {isMobileMenuOpen && (
-          <div className="md:hidden absolute top-16 left-0 right-0 bg-background/95 backdrop-blur-xl border-b border-border/20 shadow-lg">
+          <div className={`md:hidden absolute top-16 left-0 right-0 bg-background/95 backdrop-blur-xl border-b border-border/20 shadow-lg ${isThemedHeaderPage ? "dark:bg-[#1b1b1f]/95 dark:border-white/[0.06]" : ""}`}>
             <div className="px-4 py-4 space-y-2">
               <Button
                 variant="ghost"

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -128,6 +128,12 @@ export interface StatCardProps {
   icon: string | ReactNode;
   value: string;
   label: string;
+  /** Optional supporting line shown beneath the label. */
+  sublabel?: string;
+  /** Accent color used for the icon chip and ambient glow. */
+  tone?: 'amber' | 'blue' | 'emerald' | 'violet';
+  /** Optional decorative node rendered in the top-right corner (e.g. an emoji/badge). */
+  decoration?: ReactNode;
   className?: string;
 }
 


### PR DESCRIPTION
**Student Dashboard Redesign (UI)**
Refreshes the student dashboard and shared course cards with a modern, glossy dark‑gray theme (full light + dark support), clearer hierarchy, and better readability. UI-only — no business logic, APIs, data flow, state, or critical systems were changed.

**What changed**

- Hero + stats — new "Your Learning Journey" header with the live greeting, plus 3 real-data stat cards: Enrolled Courses, Overall Progress, Courses Completed.
- Theme — replaced the near-black/orange dark canvas with a dark-gray glossy surface (scoped to the student layout); light mode unchanged. Near-white text preserved for contrast.
- Course cards (grid) — cleaner layout with instructor + "X of Y lessons"; bright pastel thumbnails replaced with a soft tint (light) / dark gradient + accent glow (dark). Secondary actions moved into a tidy overflow menu.
- Course cards (list) — mockup-style row (icon · title · instructor · lessons · progress bar) with the same overflow menu.
- Stat card — glossy, tone-accented component (used only on the dashboard).
- Consolidated the duplicated grid/list view switcher into one reusable control.
- Temporarily hid the right "Learning Checklist" sidebar (commented out, not removed).

**Preserved (no functionality lost)**
Time-slot access gate, leaderboard, HP system, support, forum, policies, enrollment details, special-course cases, the 3 tabs (Available/Enrolled/Completed), grid/list view persistence, greeting, announcements, and follow-up invites — all intact.

Before
<img width="1457" height="728" alt="image" src="https://github.com/user-attachments/assets/eb9f30fb-d5c2-453d-a77c-8645acbedece" />


After
<img width="1454" height="733" alt="image" src="https://github.com/user-attachments/assets/8c1eddc3-6717-463c-8a73-8bd04a0821c2" />

