### PR TITLE
Fix Face Registration Saving and Instructor Reset DB Persistence

### DIFF
--- a/backend/src/modules/users/controllers/EnrollmentController.ts
+++ b/backend/src/modules/users/controllers/EnrollmentController.ts
@@ -457,10 +457,7 @@ export class EnrollmentController {
       );
     }
 
-    await this.userService.editUser(userId, {
-      profileImage: null as any,
-      faceEmbedding: null as any,
-    });
+    await this.userService.updateFaceReference(userId, null, null);
 
     setAuditTrail(req, {
       category: AuditCategory.ENROLLMENT,

--- a/backend/src/modules/users/controllers/UserController.ts
+++ b/backend/src/modules/users/controllers/UserController.ts
@@ -162,10 +162,11 @@ export class UserController {
   ): Promise<void> {
     const token = req.headers.authorization?.split(' ')[1];
     const user = await this.authService.getCurrentUserFromToken(token);
-    await this.userService.editUser(user._id!.toString(), {
-      profileImage: body.profileImage,
-      faceEmbedding: body.faceEmbedding,
-    });
+    await this.userService.updateFaceReference(
+      user._id!.toString(),
+      body.profileImage,
+      body.faceEmbedding,
+    );
   }
 
   @OpenAPI({

--- a/backend/src/modules/users/services/UserService.ts
+++ b/backend/src/modules/users/services/UserService.ts
@@ -51,6 +51,21 @@ export class UserService extends BaseService {
   });
   }
 
+  async updateFaceReference(
+    userId: string,
+    profileImage: string | null,
+    faceEmbedding: number[] | null,
+  ): Promise<void> {
+    return this._withTransaction(async (session) => {
+      const user = await this.userRepo.findById(userId);
+      if (!user) {
+        throw new NotFoundError(`User with ID ${userId} not found`);
+      }
+      await this.userRepo.edit(userId, { profileImage, faceEmbedding }, session);
+    });
+  }
+
+
   async makeAdmin(userId: string, currentUser: IUser): Promise<void> {
     // Privilege escalation guard: only an existing admin may promote another
     // user. The runtime authorizationChecker only verifies token validity (not


### PR DESCRIPTION
## Description
This PR resolves two major proctoring-related bugs introduced after merging the face reset feature:
1. **Face Registration Failure**: When students register their face, the API returns success but the photo and embedding are not saved to MongoDB.
2. **Reset Face Failure**: When instructors reset a student's face reference from the course enrollment panel, the UI shows a success notification but the credentials remain in the database.

### Root Cause
Both actions were routed to `UserService.editUser`. To prevent admin privilege-escalation vectors, a recent security change added a strict whitelist `EDITABLE_FIELDS` in `UserService.editUser` containing only basic fields like `firstName`, `lastName`, etc. Because `profileImage` and `faceEmbedding` were not on this whitelist, they were silently filtered out, resulting in no changes persisting to MongoDB.

### Solution
1. Added a dedicated `updateFaceReference(userId, profileImage, faceEmbedding)` method in `UserService` that interacts directly with the database repository and bypasses the generic self-edit sanitize whitelist.
2. Updated the student registration route in `UserController.ts` to call this new method.
3. Updated the instructor reset route in `EnrollmentController.ts` to call this new method with `null` values.

---

## 🛠️ Changes

### Backend
* **`UserService.ts`**: Added `updateFaceReference` method to update face data.
* **`UserController.ts`**: Called `updateFaceReference` in `updateCurrentUserFaceReference`.
* **`EnrollmentController.ts`**: Called `updateFaceReference(userId, null, null)` in `resetFaceReference`.

---

## 🧪 Verification & Testing
* **Compilation**: Built backend codebase successfully:
  ```bash
  pnpm run build
* **Face Registration (Manual)**:  Verified face enrollment succeeds and values persist in the database.
* **Face Reset (Manual)**: Verified that triggering the reset sets both profileImage and faceEmbedding to null in MongoDB.