### PR TITLE
Fix/timeslot booking window and extra bookings

### DIFF
--- a/backend/src/modules/setting/controllers/SlotBookingController.ts
+++ b/backend/src/modules/setting/controllers/SlotBookingController.ts
@@ -31,7 +31,8 @@ class BookSlotRequestBody {
   timeSlot: {from: string; to: string};
   cohortId?: string;
   // Study day to book (YYYY-MM-DD IST). Defaults to today. Must fall inside the
-  // booking window: opens 9 AM IST on D-2, closes 9 AM IST on D.
+  // booking window: opens 9 AM IST on D-2, and each slot stays bookable until
+  // its own start time on D.
   date?: string;
 }
 
@@ -57,7 +58,7 @@ class SlotBookingController {
   @OpenAPI({
     summary: 'Book a time slot',
     description:
-      'A student books a time slot for a study day (default today). Booking for day D is open from 9 AM IST on D-2 until 9 AM IST on D, subject to the slot capacity cap and their per-day allowance.',
+      'A student books a time slot for a study day (default today). Booking for day D opens at 9 AM IST on D-2, and each slot stays bookable until its own start time on D, subject to the slot capacity cap and their per-day allowance.',
   })
   @Authorized()
   @Post('/book')
@@ -148,6 +149,36 @@ class SlotBookingController {
       return {success: true, data};
     } catch (error) {
       throw new InternalServerError(`Failed to get bookings: ${error}`);
+    }
+  }
+
+  @OpenAPI({
+    summary: "The student's awarded extra-bookings pool",
+    description:
+      "Returns how many extra bookings the calling student may still make beyond their daily allowance (instructor-awarded, consumable). Used to keep the booking action enabled.",
+  })
+  @Authorized()
+  @Get('/my/extra-bookings/course/:courseId/version/:courseVersionId')
+  @HttpCode(200)
+  async myExtraBookings(
+    @Param('courseId') courseId: string,
+    @Param('courseVersionId') courseVersionId: string,
+    @CurrentUser() user: IUser,
+    @QueryParam('cohortId') cohortId?: string,
+  ): Promise<BookingResponse> {
+    try {
+      const extraBookings =
+        await this.slotBookingService.getStudentExtraBookings(
+          user._id.toString(),
+          courseId,
+          courseVersionId,
+          cohortId,
+        );
+      return {success: true, data: {extraBookings}};
+    } catch (error) {
+      throw new InternalServerError(
+        `Failed to get extra bookings: ${error}`,
+      );
     }
   }
 

--- a/backend/src/modules/setting/controllers/TimeSlotController.ts
+++ b/backend/src/modules/setting/controllers/TimeSlotController.ts
@@ -116,6 +116,14 @@ class ExtendStudentHoursRequestBody {
   extraHours: number;
 }
 
+// Request body for awarding a student extra bookings (consumable pool).
+class GrantExtraBookingsRequestBody {
+  courseId: string;
+  courseVersionId: string;
+  studentId: string;
+  extraBookings: number;
+}
+
 // Response for time slot operations
 class TimeSlotResponse {
   success: boolean;
@@ -605,6 +613,54 @@ class TimeSlotController {
         throw error;
       }
       throw new InternalServerError(`Failed to grant extra hours: ${error}`);
+    }
+  }
+
+  @OpenAPI({
+    summary: 'Award a student extra bookings',
+    description:
+      "Adds extra bookings to a student's consumable pool so they can book beyond their daily allowance (instructor action). These grant bookings bypass the slot capacity cap and hours budget.",
+  })
+  @Authorized()
+  @Put('/grant-bookings')
+  @HttpCode(200)
+  @ResponseSchema(TimeSlotResponse, {
+    description: 'Extra bookings awarded successfully',
+  })
+  async grantExtraBookings(
+    @Body() body: GrantExtraBookingsRequestBody,
+    @CurrentUser() user: IUser,
+    @Ability(getItemAbility) { ability },
+  ): Promise<TimeSlotResponse> {
+    const itemResource = subject('Item', { versionId: body.courseVersionId });
+    if (!ability.can(ItemActions.Modify, itemResource)) {
+      throw new ForbiddenError(
+        'You do not have permission to modify this item',
+      );
+    }
+
+    try {
+      const data = await this.timeSlotService.grantExtraBookings(
+        body.courseId,
+        body.courseVersionId,
+        body.studentId,
+        body.extraBookings,
+        user._id.toString(),
+      );
+      return {
+        success: true,
+        message: 'Extra bookings awarded successfully',
+        data,
+      };
+    } catch (error) {
+      if (
+        error instanceof BadRequestError ||
+        error instanceof NotFoundError ||
+        error instanceof ForbiddenError
+      ) {
+        throw error;
+      }
+      throw new InternalServerError(`Failed to award extra bookings: ${error}`);
     }
   }
 

--- a/backend/src/modules/setting/services/SlotBookingService.ts
+++ b/backend/src/modules/setting/services/SlotBookingService.ts
@@ -48,8 +48,8 @@ export class SlotBookingService extends BaseService {
 
   /** How many days before the study day booking opens. */
   private static readonly BOOKING_OPEN_LEAD_DAYS = 2;
-  /** Hour (IST) at which booking opens on D-2 and closes on D. */
-  private static readonly BOOKING_CUTOFF_HOUR = 9;
+  /** Hour (IST) at which booking opens on D-2. */
+  private static readonly BOOKING_OPEN_HOUR = 9;
 
   /** IST "now" as epoch ms whose UTC fields read as the IST wall clock. */
   private getISTNowMs(): number {
@@ -76,26 +76,35 @@ export class SlotBookingService extends BaseService {
   }
 
   /**
-   * Booking window for study day D: opens at 09:00 IST on D-2 and closes at
-   * 09:00 IST on D. So at any moment a student may book today (only before
-   * 9 AM), tomorrow (all day), and the day after tomorrow (only from 9 AM).
-   * Returns the open/close instants as IST-space epoch ms.
+   * When booking opens for study day D: 09:00 IST on D-2. Returned as an
+   * IST-space epoch ms. A student may book today, tomorrow, and the day after
+   * tomorrow (the latter only once its 09:00 IST D-2 open time is reached).
    */
-  private bookingWindowForDate(date: string): {openMs: number; closeMs: number} {
+  private bookingOpenMs(date: string): number {
     const [y, m, d] = date.split('-').map(Number);
-    const closeMs = Date.UTC(
+    const nineAm = Date.UTC(
       y,
       m - 1,
       d,
-      SlotBookingService.BOOKING_CUTOFF_HOUR,
+      SlotBookingService.BOOKING_OPEN_HOUR,
       0,
       0,
       0,
     );
-    const openMs =
-      closeMs -
-      SlotBookingService.BOOKING_OPEN_LEAD_DAYS * 24 * 60 * 60 * 1000;
-    return {openMs, closeMs};
+    return (
+      nineAm - SlotBookingService.BOOKING_OPEN_LEAD_DAYS * 24 * 60 * 60 * 1000
+    );
+  }
+
+  /**
+   * When a specific slot closes for booking: its own start time on study day D.
+   * A slot can be booked right up until it starts; once it has begun it can no
+   * longer be booked. Returned as an IST-space epoch ms.
+   */
+  private slotCloseMs(date: string, from: string): number {
+    const [y, m, d] = date.split('-').map(Number);
+    const [h, min] = from.split(':').map(Number);
+    return Date.UTC(y, m - 1, d, h, min, 0, 0);
   }
 
   private toMinutes(time: string): number {
@@ -177,8 +186,10 @@ export class SlotBookingService extends BaseService {
         throw new BadRequestError('Invalid booking date.');
       }
 
-      // The booking window: opens 09:00 IST on D-2, closes 09:00 IST on D.
-      const {openMs, closeMs} = this.bookingWindowForDate(date);
+      // The booking window: opens 09:00 IST on D-2, and a slot stays bookable
+      // right up until it starts (it closes at its own start time on D).
+      const openMs = this.bookingOpenMs(date);
+      const closeMs = this.slotCloseMs(date, slot.from);
       const nowMs = this.getISTNowMs();
       if (nowMs < openMs) {
         throw new BadRequestError(
@@ -188,8 +199,8 @@ export class SlotBookingService extends BaseService {
       }
       if (nowMs >= closeMs) {
         throw new BadRequestError(
-          `Booking for ${date} has closed. ` +
-            'Bookings close at 9:00 AM IST on the study day.',
+          `Booking for the ${slot.from}–${slot.to} slot on ${date} has closed. ` +
+            'A slot can be booked up until it starts.',
         );
       }
 
@@ -232,59 +243,72 @@ export class SlotBookingService extends BaseService {
           ).length
         : 0;
       const effectiveAllowance = baseAllowance + bonusesToday;
-      if (madeToday.length >= effectiveAllowance) {
+      // A booking beyond the normal daily allowance (base + earned bonus) is
+      // only permitted by drawing from the instructor-awarded extra-bookings
+      // pool. Such grant bookings bypass the capacity cap and the hours budget.
+      const extraBookingsPool =
+        (enrollment as {commitmentExtraBookings?: number})
+          .commitmentExtraBookings ?? 0;
+      const usingGrant = madeToday.length >= effectiveAllowance;
+      if (usingGrant && extraBookingsPool <= 0) {
         const earned = bonusesToday > 0 ? ` (+${bonusesToday} bonus)` : '';
         throw new BadRequestError(
           `You have used your ${effectiveAllowance} booking(s) for today${earned}.`,
         );
       }
-      // A booking beyond the base allowance is a bonus booking.
+      // A booking beyond the base allowance is an extra (bonus) booking.
       const kind =
         madeToday.length >= baseAllowance
           ? SlotBookingKind.BONUS
           : SlotBookingKind.BASE;
 
-      // Hard capacity cap — the per-window concurrency ceiling.
-      if (configured.maxStudents) {
-        const taken = await this.slotBookingRepo.countActiveInSlot(
-          courseId,
-          courseVersionId,
-          date,
-          slot,
-          session,
-        );
-        if (taken >= configured.maxStudents) {
-          throw new BadRequestError(
-            'This time slot is full. Please choose another.',
-          );
-        }
-      }
-
       const hoursReserved = this.slotHours(slot.from, slot.to);
 
-      // Per-course hours budget — the "committed hours" ceiling, plus any extra
-      // hours an instructor has granted this student. A booking reserves its
-      // hours; the student can't exceed their budget. Undefined = unlimited.
-      if (timeslots.totalBudgetHours != null) {
-        const budget =
-          timeslots.totalBudgetHours +
-          ((enrollment as {commitmentExtraHours?: number})
-            .commitmentExtraHours ?? 0);
-        const consumed = await this.slotBookingRepo.sumReservedHoursForStudent(
-          userId,
-          courseId,
-          courseVersionId,
-          session,
-        );
-        if (consumed + hoursReserved > budget) {
-          const remaining = Math.max(
-            0,
-            Math.round((budget - consumed) * 100) / 100,
+      // Capacity cap and hours budget apply to normal bookings only; an awarded
+      // grant booking bypasses both by design.
+      if (!usingGrant) {
+        // Hard capacity cap — the per-window concurrency ceiling.
+        if (configured.maxStudents) {
+          const taken = await this.slotBookingRepo.countActiveInSlot(
+            courseId,
+            courseVersionId,
+            date,
+            slot,
+            session,
           );
-          throw new BadRequestError(
-            `This booking (${hoursReserved}h) exceeds your committed hours for this course. ` +
-              `You have ${remaining}h of ${budget}h remaining.`,
-          );
+          if (taken >= configured.maxStudents) {
+            throw new BadRequestError(
+              'This time slot is full. Please choose another.',
+            );
+          }
+        }
+
+        // Per-course hours budget — the "committed hours" ceiling, plus any
+        // extra hours an instructor has granted this student. A booking reserves
+        // its hours; the student can't exceed their budget. Undefined =
+        // unlimited.
+        if (timeslots.totalBudgetHours != null) {
+          const budget =
+            timeslots.totalBudgetHours +
+            ((enrollment as {commitmentExtraHours?: number})
+              .commitmentExtraHours ?? 0);
+          const consumed =
+            await this.slotBookingRepo.sumReservedHoursForStudent(
+              userId,
+              courseId,
+              courseVersionId,
+              session,
+            );
+          if (consumed + hoursReserved > budget) {
+            const remaining = Math.max(
+              0,
+              Math.round((budget - consumed) * 100) / 100,
+            );
+            throw new BadRequestError(
+              `This booking (${hoursReserved}h) exceeds your committed hours for this course. ` +
+                `You have ${remaining}h of ${budget}h remaining.`,
+            );
+          }
         }
       }
 
@@ -313,6 +337,14 @@ export class SlotBookingService extends BaseService {
       );
       if (!created) {
         throw new InternalServerError('Failed to create the booking.');
+      }
+      // Draw one from the awarded pool when this booking exceeded the normal
+      // daily allowance, so each grant is single-use.
+      if (usingGrant) {
+        await this.enrollmentService.consumeCommitmentExtraBooking(
+          String(enrollment._id),
+          session,
+        );
       }
       return created;
     });
@@ -344,6 +376,36 @@ export class SlotBookingService extends BaseService {
       courseId,
       courseVersionId,
       date,
+    );
+  }
+
+  /**
+   * The size of a student's awarded extra-bookings pool — how many bookings
+   * they may still make beyond their normal daily allowance. Lets the client
+   * keep the "Book" action enabled when an instructor has granted extras.
+   */
+  async getStudentExtraBookings(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    cohortId?: string,
+  ): Promise<number> {
+    let enrollment = await this.enrollmentService.findEnrollment(
+      userId,
+      courseId,
+      courseVersionId,
+      cohortId,
+    );
+    if (!enrollment && cohortId) {
+      enrollment = await this.enrollmentService.findEnrollment(
+        userId,
+        courseId,
+        courseVersionId,
+      );
+    }
+    return (
+      (enrollment as {commitmentExtraBookings?: number} | null)
+        ?.commitmentExtraBookings ?? 0
     );
   }
 

--- a/backend/src/modules/setting/services/TimeSlotService.ts
+++ b/backend/src/modules/setting/services/TimeSlotService.ts
@@ -767,6 +767,31 @@ export class TimeSlotService extends BaseService {
   }
 
   /**
+   * Award a student extra bookings (instructor action) by adding to their
+   * consumable pool, letting them book beyond their daily allowance. Returns
+   * the new pool total.
+   */
+  async grantExtraBookings(
+    courseId: string,
+    courseVersionId: string,
+    studentId: string,
+    extraBookings: number,
+    _userId: string,
+  ): Promise<{ commitmentExtraBookings: number }> {
+    if (!extraBookings || extraBookings <= 0) {
+      throw new BadRequestError('extraBookings must be greater than 0.');
+    }
+    const commitmentExtraBookings =
+      await this.enrollmentService.grantCommitmentExtraBookings(
+        studentId,
+        courseId,
+        courseVersionId,
+        extraBookings,
+      );
+    return { commitmentExtraBookings };
+  }
+
+  /**
    * Update existing time slot
    */
   async updateTimeSlot(

--- a/backend/src/modules/setting/tests/SlotBookingService.test.ts
+++ b/backend/src/modules/setting/tests/SlotBookingService.test.ts
@@ -65,6 +65,7 @@ function makeService(
   };
   const enrollmentService = {
     findEnrollment: vi.fn().mockResolvedValue(enrollment),
+    consumeCommitmentExtraBooking: vi.fn().mockResolvedValue(0),
   };
   const db = {} as any;
 
@@ -208,6 +209,63 @@ describe('SlotBookingService.bookSlot', () => {
     expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
   });
 
+  // --- Awarded extra-bookings pool (instructor grant) ---
+
+  it('allows booking past the daily allowance by drawing from the awarded pool', async () => {
+    const {svc, slotBookingRepo, enrollmentService} = makeService({
+      enrollment: {_id: 'enroll-1', commitmentExtraBookings: 2},
+      // already used the 1/day base allowance
+      myBookings: [{bookedOnDate: TODAY, from: '09:00', to: '10:00'}],
+    });
+
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT);
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+    // one drawn from the pool
+    expect(enrollmentService.consumeCommitmentExtraBooking).toHaveBeenCalledWith(
+      'enroll-1',
+      {},
+    );
+  });
+
+  it('still rejects past the allowance when the awarded pool is empty', async () => {
+    const {svc, enrollmentService} = makeService({
+      enrollment: {_id: 'enroll-1', commitmentExtraBookings: 0},
+      myBookings: [{bookedOnDate: TODAY, from: '09:00', to: '10:00'}],
+    });
+    await expect(svc.bookSlot(USER, COURSE, VERSION, SLOT)).rejects.toThrowError(
+      /booking\(s\) for today/i,
+    );
+    expect(
+      enrollmentService.consumeCommitmentExtraBooking,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('a pool (grant) booking bypasses the hard capacity cap', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      enrollment: {_id: 'enroll-1', commitmentExtraBookings: 1},
+      slotCount: 2, // slot is full (maxStudents = 2)
+      myBookings: [{bookedOnDate: TODAY, from: '09:00', to: '10:00'}],
+    });
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT);
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+  });
+
+  it('a pool (grant) booking bypasses the hours budget', async () => {
+    const {svc, slotBookingRepo} = makeService({
+      timeslots: {
+        isActive: true,
+        slots: [{from: '13:00', to: '15:00', studentIds: [], maxStudents: 2}],
+        dailyBaseAllowance: 1,
+        totalBudgetHours: 1, // a 2h slot would normally exceed this
+      },
+      enrollment: {_id: 'enroll-1', commitmentExtraBookings: 1},
+      reservedHours: 1,
+      myBookings: [{bookedOnDate: TODAY, from: '09:00', to: '10:00'}],
+    });
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT);
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+  });
+
   // --- Phase 3 bonus allowance (bonusOnFulfillment) ---
 
   // A booking made today that consumes the base allowance, plus a window the
@@ -332,16 +390,23 @@ describe('SlotBookingService.bookSlot — booking window (D-2 9AM → D 9AM IST)
     expect(saved.bookedOnDate).toBe('2026-06-20'); // calendar day booked
   });
 
-  it('rejects booking for today once past the 9 AM cutoff', async () => {
-    at('2026-06-20T04:30:00.000Z'); // 10:00 IST on 06-20
+  it("allows booking today's slot any time before it starts (after 9 AM)", async () => {
+    at('2026-06-20T04:30:00.000Z'); // 10:00 IST on 06-20 — slot starts 13:00
+    const {svc, slotBookingRepo} = makeService();
+    await svc.bookSlot(USER, COURSE, VERSION, SLOT, undefined, '2026-06-20');
+    expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();
+  });
+
+  it('rejects booking for today once the slot has started', async () => {
+    at('2026-06-20T08:30:00.000Z'); // 14:00 IST on 06-20 — slot (13:00) started
     const {svc} = makeService();
     await expect(
       svc.bookSlot(USER, COURSE, VERSION, SLOT, undefined, '2026-06-20'),
     ).rejects.toThrowError(/has closed/i);
   });
 
-  it('allows booking for today before the 9 AM cutoff', async () => {
-    at('2026-06-20T02:30:00.000Z'); // 08:00 IST on 06-20
+  it("allows booking today's slot well before it starts", async () => {
+    at('2026-06-20T02:30:00.000Z'); // 08:00 IST on 06-20 — slot starts 13:00
     const {svc, slotBookingRepo} = makeService();
     await svc.bookSlot(USER, COURSE, VERSION, SLOT, undefined, '2026-06-20');
     expect(slotBookingRepo.createBooking).toHaveBeenCalledOnce();

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -2126,6 +2126,55 @@ export class EnrollmentService extends BaseService {
   }
 
   /**
+   * Award a student extra bookings (instructor action). Adds to the consumable
+   * pool so the student can book beyond their normal daily allowance. Returns
+   * the enrollment's new total commitmentExtraBookings.
+   */
+  async grantCommitmentExtraBookings(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    extraBookings: number,
+    session?: ClientSession,
+  ): Promise<number> {
+    const execute = async (session: ClientSession) => {
+      const enrollment = await this.enrollmentRepo.findActiveEnrollment(
+        userId,
+        courseId,
+        courseVersionId,
+        null,
+        session,
+      );
+      if (!enrollment) {
+        throw new NotFoundError('Enrollment not found for this student.');
+      }
+      return this.enrollmentRepo.addCommitmentExtraBookings(
+        enrollment._id?.toString(),
+        extraBookings,
+        session,
+      );
+    };
+
+    return session ? execute(session) : this._withTransaction(execute);
+  }
+
+  /**
+   * Consume one booking from a student's awarded extra-bookings pool. Called
+   * within the booking transaction when a student books beyond their normal
+   * daily allowance. Returns the new pool total.
+   */
+  async consumeCommitmentExtraBooking(
+    enrollmentId: string,
+    session?: ClientSession,
+  ): Promise<number> {
+    return this.enrollmentRepo.addCommitmentExtraBookings(
+      enrollmentId,
+      -1,
+      session,
+    );
+  }
+
+  /**
    * Remove assigned time slot from student enrollment
    */
   async removeStudentTimeSlot(

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -4470,6 +4470,41 @@ export class EnrollmentRepository {
   }
 
   /**
+   * Add (increment) the consumable extra-bookings pool on an enrollment and
+   * return the new total. Pass a negative delta to consume one when a student
+   * books beyond their normal daily allowance. The pool is clamped at 0 so it
+   * never goes negative.
+   */
+  async addCommitmentExtraBookings(
+    enrollmentId: string,
+    delta: number,
+    session?: ClientSession,
+  ): Promise<number> {
+    await this.init();
+
+    const updated = await this.enrollmentCollection.findOneAndUpdate(
+      { _id: new ObjectId(enrollmentId) },
+      {
+        $inc: { commitmentExtraBookings: delta },
+        $set: { updatedAt: new Date() },
+      },
+      { session, returnDocument: 'after' },
+    );
+
+    const total = (updated as any)?.commitmentExtraBookings ?? 0;
+    if (total < 0) {
+      // Clamp back to 0 if a concurrent consume drove it negative.
+      await this.enrollmentCollection.updateOne(
+        { _id: new ObjectId(enrollmentId) },
+        { $set: { commitmentExtraBookings: 0, updatedAt: new Date() } },
+        { session },
+      );
+      return 0;
+    }
+    return total;
+  }
+
+  /**
    * Remove a specific time slot from enrollment's assigned time slots
    */
   async removeEnrollmentTimeSlot(

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -413,6 +413,10 @@ export interface IEnrollment {
   // Extra committed hours granted to this student by an instructor, added on
   // top of the course's totalBudgetHours when enforcing the hours budget.
   commitmentExtraHours?: number;
+  // A consumable pool of extra bookings an instructor has awarded this student.
+  // Each booking made beyond the student's normal daily allowance draws one from
+  // this pool; such bookings bypass the slot capacity cap and the hours budget.
+  commitmentExtraBookings?: number;
   isDeleted?: boolean;
   deletedAt?: Date;
   unenrolledAt?: Date;

--- a/frontend/src/app/pages/teacher/components/TimeSlotsModal.tsx
+++ b/frontend/src/app/pages/teacher/components/TimeSlotsModal.tsx
@@ -18,6 +18,7 @@ import {
   useRemoveStudentFromTimeSlot,
   useSetHoursBudget,
   useGrantExtraHours,
+  useGrantExtraBookings,
   useSetFulfillmentConfig,
   useSetCapacityConfig,
   useSlotDemand,
@@ -156,6 +157,9 @@ function TimeSlotsModal({ isOpen, onClose, courseId, courseVersionId }: TimeSlot
   // Grant extra committed hours to a specific student.
   const [extendStudentId, setExtendStudentId] = useState<string>("");
   const [extendHours, setExtendHours] = useState<number>(1);
+  // Award extra bookings (consumable pool) to a specific student.
+  const [grantBookingsStudentId, setGrantBookingsStudentId] = useState<string>("");
+  const [grantBookingsCount, setGrantBookingsCount] = useState<number>(1);
   // Phase 3: fulfillment threshold (active share of a window) + bonus toggle.
   const [fulfillmentThresholdPct, setFulfillmentThresholdPct] = useState<number>(90);
   const [bonusOnFulfillment, setBonusOnFulfillment] = useState<boolean>(false);
@@ -186,6 +190,7 @@ function TimeSlotsModal({ isOpen, onClose, courseId, courseVersionId }: TimeSlot
   const removeStudentFromTimeSlotMutation = useRemoveStudentFromTimeSlot();
   const { setHoursBudget, loading: budgetLoading } = useSetHoursBudget();
   const { grantExtraHours, loading: extendLoading } = useGrantExtraHours();
+  const { grantExtraBookings, loading: grantBookingsLoading } = useGrantExtraBookings();
   const { setFulfillmentConfig, loading: fulfillmentLoading } = useSetFulfillmentConfig();
   const { setCapacityConfig, loading: capacityLoading } = useSetCapacityConfig();
 
@@ -291,6 +296,31 @@ function TimeSlotsModal({ isOpen, onClose, courseId, courseVersionId }: TimeSlot
       setExtendHours(1);
     } catch (error: any) {
       toast.error(error?.message || 'Failed to grant extra hours');
+    }
+  };
+
+  const handleGrantBookings = async () => {
+    if (!grantBookingsStudentId) {
+      toast.error('Select a student first');
+      return;
+    }
+    if (!grantBookingsCount || grantBookingsCount <= 0) {
+      toast.error('Enter a positive number of bookings');
+      return;
+    }
+    try {
+      const result = await grantExtraBookings(
+        courseId,
+        courseVersionId,
+        grantBookingsStudentId,
+        grantBookingsCount,
+      );
+      toast.success(
+        `Awarded ${grantBookingsCount} booking(s) — student can now book ${result.commitmentExtraBookings} extra time(s)`,
+      );
+      setGrantBookingsCount(1);
+    } catch (error: any) {
+      toast.error(error?.message || 'Failed to award extra bookings');
     }
   };
 
@@ -908,6 +938,7 @@ function TimeSlotsModal({ isOpen, onClose, courseId, courseVersionId }: TimeSlot
                               enr.user ? (
                                 <option key={enr.user._id} value={enr.user._id}>
                                   {enr.user.firstName} {enr.user.lastName}
+                                  {enr.user.email ? ` — ${enr.user.email}` : ""}
                                 </option>
                               ) : null,
                             )}
@@ -932,6 +963,61 @@ function TimeSlotsModal({ isOpen, onClose, courseId, courseVersionId }: TimeSlot
                             <Plus className="h-4 w-4 mr-2" />
                           )}
                           Grant
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  {/* Award extra bookings to a student (consumable pool) */}
+                  <Card className="border shadow-sm">
+                    <CardContent className="p-4 space-y-3">
+                      <div>
+                        <h3 className="text-lg font-semibold flex items-center gap-2">
+                          <Plus className="h-5 w-5" />
+                          Award extra bookings
+                        </h3>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Let a specific student book again beyond their daily limit. Each award is a one-time pool — every extra booking they make uses one up. These bookings ignore the slot capacity cap and hours budget.
+                        </p>
+                      </div>
+                      <div className="flex items-end gap-2">
+                        <div className="flex-1">
+                          <Label className="text-xs">Student</Label>
+                          <select
+                            value={grantBookingsStudentId}
+                            onChange={(e) => setGrantBookingsStudentId(e.target.value)}
+                            className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                          >
+                            <option value="">Select a student…</option>
+                            {enrolledStudents.map((enr: any) =>
+                              enr.user ? (
+                                <option key={enr.user._id} value={enr.user._id}>
+                                  {enr.user.firstName} {enr.user.lastName}
+                                  {enr.user.email ? ` — ${enr.user.email}` : ""}
+                                </option>
+                              ) : null,
+                            )}
+                          </select>
+                        </div>
+                        <div className="w-24">
+                          <Label className="text-xs">Bookings</Label>
+                          <Input
+                            type="number"
+                            min="1"
+                            value={grantBookingsCount}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                              setGrantBookingsCount(e.target.value === "" ? 0 : parseInt(e.target.value))
+                            }
+                            className="mt-1"
+                          />
+                        </div>
+                        <Button size="sm" onClick={handleGrantBookings} disabled={grantBookingsLoading}>
+                          {grantBookingsLoading ? (
+                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          ) : (
+                            <Plus className="h-4 w-4 mr-2" />
+                          )}
+                          Award
                         </Button>
                       </div>
                     </CardContent>

--- a/frontend/src/components/course/StudentTimeslotModal.tsx
+++ b/frontend/src/components/course/StudentTimeslotModal.tsx
@@ -8,10 +8,12 @@ import {
   useGetTimeSlots,
   useMyBookings,
   useSlotAvailability,
+  useMyExtraBookings,
   useBookSlot,
   useCancelBooking,
   bookableStudyDates,
   istToday,
+  slotBookingClosed,
   type MyBooking,
 } from "@/hooks/hooks";
 import { cn } from "@/utils/utils";
@@ -65,8 +67,9 @@ export default function StudentTimeslotModal({
 }: StudentTimeslotModalProps) {
   const { data: timeSlotsData, isLoading } = useGetTimeSlots(courseId, courseVersionId, isOpen);
 
-  // Study days a student may book right now (today before 9 AM / tomorrow /
-  // day-after from 9 AM IST). The first open day is selected by default.
+  // Study days a student may book right now (today / tomorrow / day-after from
+  // 9 AM IST). Per slot, a slot stays bookable until it starts. The first open
+  // day is selected by default.
   const studyDates = bookableStudyDates();
   const [selectedDate, setSelectedDate] = useState<string>(studyDates[0]);
   const activeDate = studyDates.includes(selectedDate) ? selectedDate : studyDates[0];
@@ -84,6 +87,11 @@ export default function StudentTimeslotModal({
     activeDate,
     isOpen,
   );
+  const { data: extraBookings, refetch: refetchExtraBookings } = useMyExtraBookings(
+    courseId,
+    courseVersionId,
+    isOpen,
+  );
   const { book, loading: booking } = useBookSlot();
   const { cancel, loading: cancelling } = useCancelBooking();
 
@@ -93,6 +101,7 @@ export default function StudentTimeslotModal({
   const refresh = () => {
     refetchBookings();
     refetchAvailability();
+    refetchExtraBookings();
   };
 
   const tsSettings = timeSlotsData as
@@ -205,6 +214,12 @@ export default function StudentTimeslotModal({
                 +{bonusEarnedToday} bonus earned
               </span>
             ) : null}
+            {(extraBookings ?? 0) > 0 ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 text-emerald-800 px-2.5 py-0.5 text-xs font-medium">
+                <Gift className="h-3.5 w-3.5" />
+                {extraBookings} awarded booking{extraBookings !== 1 ? 's' : ''} available
+              </span>
+            ) : null}
           </div>
           {bonusEarnedToday > 0 ? (
             <p className="mt-1 text-xs text-amber-700">
@@ -231,7 +246,15 @@ export default function StudentTimeslotModal({
                 const remaining = avail?.remaining ?? null;
                 const isFull = remaining !== null && remaining <= 0;
                 const booked = bookingFor(slot);
-                const atLimit = !booked && bookedCount >= allowance;
+                // A slot closes for booking at its own start time on the study day.
+                const hasStarted = !booked && slotBookingClosed(activeDate, slot.from);
+                // Past the daily allowance a student may still book by drawing
+                // from an instructor-awarded pool — mirrors the backend rule.
+                const atLimit =
+                  !booked &&
+                  !hasStarted &&
+                  bookedCount >= allowance &&
+                  (extraBookings ?? 0) <= 0;
                 const pct = cap && cap > 0 ? Math.min(100, (bookedSeats / cap) * 100) : 0;
                 const nearFull = cap !== null && !isFull && pct >= 80;
 
@@ -242,7 +265,7 @@ export default function StudentTimeslotModal({
                       "border transition-all",
                       booked
                         ? "border-green-300 bg-green-50/40"
-                        : isFull || atLimit
+                        : isFull || atLimit || hasStarted
                           ? "opacity-70 border-muted"
                           : "hover:border-primary hover:shadow-sm"
                     )}
@@ -278,11 +301,13 @@ export default function StudentTimeslotModal({
                         ) : (
                           <Button
                             size="sm"
-                            disabled={busy || atLimit || isFull}
+                            disabled={busy || atLimit || isFull || hasStarted}
                             onClick={() => handleBook(slot)}
                           >
                             {busy ? (
                               <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : hasStarted ? (
+                              'Started'
                             ) : isFull ? (
                               'Full'
                             ) : atLimit ? (
@@ -334,7 +359,7 @@ export default function StudentTimeslotModal({
 
         <div className="mt-4 pt-4 border-t">
           <div className="text-xs text-muted-foreground space-y-0.5">
-            <p>• Booking for a day opens at 9:00 AM IST two days before, and closes at 9:00 AM IST on the day itself.</p>
+            <p>• Booking for a day opens at 9:00 AM IST two days before. Each slot stays open to book right up until it starts.</p>
             <p>• Your booking allowance resets each calendar day — it counts every booking you make today, for any day.</p>
             {bonusEnabled ? (
               <p>• Stay active for most of a booked window and you'll earn a bonus booking to use the same day.</p>

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -5837,6 +5837,46 @@ export function useGrantExtraHours() {
   return { grantExtraHours, loading, error };
 }
 
+// PUT /timeslots/grant-bookings — award a student extra bookings (a consumable
+// pool that lets them book beyond their daily allowance).
+export function useGrantExtraBookings() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const grantExtraBookings = async (
+    courseId: string,
+    courseVersionId: string,
+    studentId: string,
+    extraBookings: number,
+  ): Promise<{ commitmentExtraBookings: number }> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/timeslots/grant-bookings`;
+      const res = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+        body: JSON.stringify({ courseId, courseVersionId, studentId, extraBookings }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.message || `Failed to award extra bookings: ${res.status}`);
+      }
+      return data?.data;
+    } catch (err: any) {
+      setError(err.message || 'Unknown error');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { grantExtraBookings, loading, error };
+}
+
 export interface SlotDemandData {
   date: string;
   isActive: boolean;
@@ -5984,19 +6024,41 @@ export function addDays(date: string, days: number): string {
   return `${yy}-${mm}-${dd}`;
 }
 
-// The study days a student may book *right now*, given the rule that booking for
-// day D opens 9 AM IST on D-2 and closes 9 AM IST on D:
-//   • today        — only before 9 AM IST
+// The study days a student may book *right now*. Booking for day D opens 9 AM
+// IST on D-2, and each individual slot stays bookable until its own start time
+// on D (see slotBookingClosed):
+//   • today        — all day (per-slot: only slots that haven't started yet)
 //   • tomorrow     — all day
-//   • day-after    — only from 9 AM IST
+//   • day-after    — only from 9 AM IST (its D-2 open time)
 export function bookableStudyDates(): string[] {
   const today = istToday();
   const hour = istHour();
-  const dates: string[] = [];
-  if (hour < 9) dates.push(today); // today, before the 9 AM cutoff
+  const dates: string[] = [today]; // today — slots bookable until they start
   dates.push(addDays(today, 1)); // tomorrow, always open
   if (hour >= 9) dates.push(addDays(today, 2)); // day-after, opens at 9 AM
   return dates;
+}
+
+// Minutes since midnight in IST (0–1439). Used to tell whether a slot on the
+// current IST day has already started (and so is no longer bookable).
+export function istNowMinutes(): number {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Asia/Kolkata',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(new Date());
+  const h = Number(parts.find(p => p.type === 'hour')?.value ?? '0') % 24;
+  const m = Number(parts.find(p => p.type === 'minute')?.value ?? '0');
+  return h * 60 + m;
+}
+
+// A slot closes for booking at its own start time on the study day. Only the
+// current IST day can have already-started slots; future days are always open.
+export function slotBookingClosed(date: string, from: string): boolean {
+  if (date !== istToday()) return false;
+  const [h, m] = from.split(':').map(Number);
+  return h * 60 + m <= istNowMinutes();
 }
 
 // GET /slot-bookings/my/course/{courseId}/version/{courseVersionId}?date=
@@ -6039,6 +6101,45 @@ export function useMyBookings(
     data: result.data,
     isLoading: result.isLoading,
     error: result.error ? (result.error as Error).message : null,
+    refetch: () => {
+      void result.refetch();
+    },
+  };
+}
+
+// GET /slot-bookings/my/extra-bookings/course/{courseId}/version/{courseVersionId}
+// How many instructor-awarded extra bookings the student may still make beyond
+// their daily allowance (a consumable pool). 0 when none granted.
+export function useMyExtraBookings(
+  courseId: string | undefined,
+  courseVersionId: string | undefined,
+  enabled: boolean = true,
+): { data: number; isLoading: boolean; refetch: () => void } {
+  const valid =
+    !!courseId &&
+    courseId.length === 24 &&
+    !!courseVersionId &&
+    courseVersionId.length === 24;
+  const result = useQuery({
+    queryKey: ['my-extra-bookings', courseId, courseVersionId],
+    enabled: enabled && valid,
+    queryFn: async (): Promise<number> => {
+      const url = `${import.meta.env.VITE_BASE_URL}/slot-bookings/my/extra-bookings/course/${courseId}/version/${courseVersionId}`;
+      const res = await fetch(url, {
+        headers: {
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.message || `Failed to load extra bookings: ${res.status}`);
+      }
+      return Number(data?.data?.extraBookings ?? 0);
+    },
+  });
+  return {
+    data: result.data ?? 0,
+    isLoading: result.isLoading,
     refetch: () => {
       void result.refetch();
     },


### PR DESCRIPTION
Summary
Two changes to the time-slot commitment scheme:

Book a slot until it starts — removes the flat 9 AM IST booking cutoff. A slot now stays bookable right up until its own start time on the study day. Advance booking is unchanged (opens 09:00 IST on D‑2).
Instructor-awarded extra bookings — instructors can award a specific student a one-time, consumable pool of extra bookings so they can book again beyond their daily allowance. Also surfaces student emails in the grant pickers.
Motivation
The 9 AM cutoff was confusing and over-restrictive — learners couldn't book a same-day evening slot after 9 AM even though the slot hadn't started. Closing at the slot's start time is the intuitive rule.
Daily allowance is fixed at 1/day with no admin lever. Instructors needed a way to let an individual learner book again (e.g. to make up a missed session) without changing the global setting.
Changes
Booking window

SlotBookingService: replaced the per-day window with bookingOpenMs (09:00 IST D‑2) + slotCloseMs (the slot's start time); updated the close error message.
Frontend: bookableStudyDates() shows Today all day; new slotBookingClosed()/istNowMinutes() helpers disable already-started slots with a "Started" label; updated help text and controller OpenAPI docs.
Extra bookings (consumable pool)

New commitmentExtraBookings field on the enrollment (IEnrollment).
bookSlot: a booking past the normal daily allowance (base + earned bonus) draws one from the pool; grant bookings bypass the per-slot capacity cap and the hours budget, and the pool is decremented in the same transaction (clamped at 0).
New endpoint PUT /timeslots/grant-bookings (instructor/admin, ItemActions.Modify) → TimeSlotService.grantExtraBookings → EnrollmentService.grantCommitmentExtraBookings → repository $inc.
New endpoint GET /slot-bookings/my/extra-bookings/... so the student UI keeps the Book button enabled and shows an "N awarded bookings available" badge.
Instructor UI: new "Award extra bookings" card; both student pickers now show Name — email.
Behavior notes / risks
Awarded bookings intentionally ignore slot capacity — a grant can push a slot past its maxStudents. This was an explicit product decision.
Granted bookings still respect the booking window (you can't book a slot after it has started, even with a grant).
No data migration needed — commitmentExtraBookings defaults to 0/absent.
Testing
34 SlotBookingService tests (added: books from pool, rejects when pool empty, bypasses capacity, bypasses hours; reworked window tests) + 37 TimeSlotService tests passing.
tsc --noEmit clean for backend and frontend.
Out of scope
No instructor dashboard for no-shows/activePct.
The global flat dailyBaseAllowance still has no UI (per-student grant covers the immediate need).
Want me to push the branch and open the PR with gh (targeting main)? I can also pull the exact added/removed line stats into the description if useful.

