### PR TITLE
feat(crowd-q): peer-validation gate before instructor approval (V3)

### DIFF
--- a/backend/src/modules/quizzes/classes/validators/QuizValidator.ts
+++ b/backend/src/modules/quizzes/classes/validators/QuizValidator.ts
@@ -387,6 +387,18 @@ class QuestionAnswer implements IQuestionAnswer {
   })
   @IsNotEmpty()
   answer: Answer;
+
+  @IsOptional()
+  @IsIn(['UP', 'DOWN'])
+  @JSONSchema({
+    description:
+      "Stage-2 crowd questions only: the student's thumbs up/down on the " +
+      'ungraded peer question. Ignored for graded questions.',
+    type: 'string',
+    enum: ['UP', 'DOWN'],
+    example: 'UP',
+  })
+  thumb?: 'UP' | 'DOWN';
 }
 
 class QuestionDetails implements IQuestionDetails {

--- a/backend/src/modules/quizzes/interfaces/grading.ts
+++ b/backend/src/modules/quizzes/interfaces/grading.ts
@@ -38,6 +38,11 @@ interface IQuestionAnswer {
   questionId: string | ObjectId;
   questionType: string;
   answer: Answer;
+  /**
+   * Stage-2 crowd questions only: the student's 👍/👎 on the ungraded peer
+   * question. Ignored for graded questions.
+   */
+  thumb?: 'UP' | 'DOWN';
 }
 
 interface IAttempt {
@@ -108,6 +113,13 @@ interface IQuestionDetails {
    * STUDENT_GENERATED entries are rendered ungraded; grading skips them.
    */
   source?: 'STUDENT_GENERATED';
+  /**
+   * Stage-2 crowd questions only: the lot-item id (from the shuffled render
+   * view) that is the correct answer. Persisted at serve time because the peer
+   * render view's lot-item ids are generated fresh per attempt and aren't
+   * otherwise recoverable. Used to score the ungraded response at capture.
+   */
+  peerCorrectLotItemId?: ObjectId;
 }
 
 interface IQuestionAnswerFeedback {

--- a/backend/src/modules/quizzes/repositories/providers/mongodb/QuestionBankRepository.ts
+++ b/backend/src/modules/quizzes/repositories/providers/mongodb/QuestionBankRepository.ts
@@ -46,6 +46,25 @@ class QuestionBankRepository {
     throw new Error('Failed to create question bank');
   }
 
+  /**
+   * Find the crowd "Submitted – Pending Validation" bank for a given graded
+   * bank (keyed by sourceGradedBankId). Returns null if none exists yet.
+   */
+  async findCrowdSubmittedBankByGradedBankId(
+    gradedBankId: string,
+    session?: ClientSession,
+  ): Promise<IQuestionBank | null> {
+    await this.init();
+    return this.questionBankCollection.findOne(
+      {
+        crowdSubmitted: true,
+        sourceGradedBankId: new ObjectId(gradedBankId),
+        isDeleted: {$ne: true},
+      },
+      {session},
+    );
+  }
+
   async getById(
     questionBankId: string,
     session?: ClientSession,

--- a/backend/src/modules/quizzes/services/QuestionBankService.ts
+++ b/backend/src/modules/quizzes/services/QuestionBankService.ts
@@ -182,6 +182,81 @@ class QuestionBankService extends BaseService {
       );
     });
   }
+
+  /**
+   * Find (or lazily create) the crowd "Submitted – Pending Validation" bank
+   * for a quiz's graded bank. Crowd-sourced student questions are parked here
+   * instead of the graded bank until peer-validated + instructor-approved, so
+   * they never enter graded quiz draws. The bank is NOT added to the quiz's
+   * questionBankRefs. See studentQuestions/CROWD_QUESTION_BANK.md.
+   */
+  async findOrCreateCrowdSubmittedBank(
+    gradedBankId: string,
+    sourceQuizId?: string | ObjectId,
+  ): Promise<string> {
+    const existing =
+      await this.questionBankRepository.findCrowdSubmittedBankByGradedBankId(
+        gradedBankId,
+      );
+    if (existing?._id) {
+      return existing._id.toString();
+    }
+
+    const gradedBank = await this.questionBankRepository.getById(gradedBankId);
+    if (!gradedBank) {
+      throw new NotFoundError(
+        `Graded question bank with ID ${gradedBankId} not found`,
+      );
+    }
+
+    const now = new Date();
+    const doc: IQuestionBank = {
+      courseId: gradedBank.courseId
+        ? new ObjectId(gradedBank.courseId.toString())
+        : undefined,
+      courseVersionId: gradedBank.courseVersionId
+        ? new ObjectId(gradedBank.courseVersionId.toString())
+        : undefined,
+      title: 'Submitted – Pending Validation: ' + (gradedBank.title || 'Quiz'),
+      description:
+        'Crowd-sourced student questions awaiting peer validation + instructor approval. Not part of the graded quiz.',
+      questions: [],
+      tags: ['CROWD_SUBMITTED'],
+      crowdSubmitted: true,
+      sourceGradedBankId: new ObjectId(gradedBankId),
+      sourceQuizId: sourceQuizId ? new ObjectId(sourceQuizId.toString()) : undefined,
+      createdAt: now,
+      updatedAt: now,
+    };
+    return this.questionBankRepository.create(doc);
+  }
+
+  /**
+   * Instructor-approval step of the crowd pipeline: move a peer-validated,
+   * instructor-approved crowd question OUT of its "Submitted – Pending
+   * Validation" bank and INTO the quiz's graded bank, so it counts toward
+   * grading. Idempotent and best-effort. Adds to graded BEFORE removing from
+   * submitted, so an interruption leaves the question in both (recoverable),
+   * never neither. Returns the graded bank id it was moved into, or null if
+   * the question is not in any crowd-submitted bank (e.g. already moved).
+   */
+  async promoteSubmittedQuestionToGraded(
+    questionId: string,
+  ): Promise<string | null> {
+    const banks =
+      (await this.questionBankRepository.getQuestionBanksByQuestionId(
+        questionId,
+      )) ?? [];
+    const submitted = banks.find(b => (b as IQuestionBank).crowdSubmitted);
+    if (!submitted || !submitted._id || !submitted.sourceGradedBankId) {
+      return null;
+    }
+    const gradedBankId = submitted.sourceGradedBankId.toString();
+    await this.addQuestion(gradedBankId, questionId);
+    await this.removeQuestion(submitted._id.toString(), questionId);
+    return gradedBankId;
+  }
+
   async removeQuestion(
     questionBankId: string,
     questionId: string,

--- a/backend/src/modules/studentQuestions/classes/transformers/StudentSegmentQuestion.ts
+++ b/backend/src/modules/studentQuestions/classes/transformers/StudentSegmentQuestion.ts
@@ -2,6 +2,15 @@ import {ObjectId} from 'mongodb';
 
 export type StudentQuestionStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
 
+/**
+ * Peer-validation lifecycle of a PENDING question (see CROWD_QUESTION_BANK.md).
+ * COLLECTING = served ungraded to students, gathering answers + 👍/👎.
+ * ELIGIBLE  = passed the gate (responseCount ≥ 200, correctRate ∈ [0.30,0.70],
+ *             thumbsDownRate < 0.10) and now awaits instructor approval.
+ * Only meaningful while `status === 'PENDING'`.
+ */
+export type StudentQuestionGateState = 'COLLECTING' | 'ELIGIBLE';
+
 export type StudentQuestionSource = 'STUDENT_GENERATED';
 
 export type StudentQuestionType = 'SELECT_ONE_IN_LOT';
@@ -31,6 +40,13 @@ export interface IStudentSegmentQuestion {
   isDeleted?: boolean;
   deletedAt?: Date;
   promotedQuestionId?: ObjectId;
+  // Peer-validation (stage 2) — only used while status === 'PENDING'.
+  gateState?: StudentQuestionGateState;
+  responseCount?: number;
+  correctCount?: number;
+  thumbsUpCount?: number;
+  thumbsDownCount?: number;
+  eligibleAt?: Date;
 }
 
 export class StudentSegmentQuestion implements IStudentSegmentQuestion {
@@ -54,6 +70,12 @@ export class StudentSegmentQuestion implements IStudentSegmentQuestion {
   isDeleted?: boolean;
   deletedAt?: Date;
   promotedQuestionId?: ObjectId;
+  gateState?: StudentQuestionGateState;
+  responseCount?: number;
+  correctCount?: number;
+  thumbsUpCount?: number;
+  thumbsDownCount?: number;
+  eligibleAt?: Date;
 
   constructor(input: {
     courseId: string;
@@ -80,5 +102,11 @@ export class StudentSegmentQuestion implements IStudentSegmentQuestion {
     this.createdAt = new Date();
     this.updatedAt = new Date();
     this.isDeleted = false;
+    // Peer-validation starts collecting with zeroed counters.
+    this.gateState = 'COLLECTING';
+    this.responseCount = 0;
+    this.correctCount = 0;
+    this.thumbsUpCount = 0;
+    this.thumbsDownCount = 0;
   }
 }

--- a/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
+++ b/backend/src/modules/studentQuestions/repositories/providers/mongodb/StudentQuestionRepository.ts
@@ -9,9 +9,20 @@ import {
   StudentSegmentQuestion,
 } from '../../../classes/transformers/StudentSegmentQuestion.js';
 
+/** One student's ungraded response to a peer (crowd) question. */
+export interface IStudentCrowdResponse {
+  _id?: ObjectId;
+  studentQuestionId: ObjectId;
+  userId: ObjectId;
+  isCorrect: boolean;
+  thumb?: 'UP' | 'DOWN';
+  createdAt: Date;
+}
+
 @injectable()
 export class StudentQuestionRepository {
   private collection!: Collection<IStudentSegmentQuestion>;
+  private responsesCollection!: Collection<IStudentCrowdResponse>;
   private initialized = false;
 
   constructor(@inject(GLOBAL_TYPES.Database) private db: MongoDatabase) {}
@@ -21,6 +32,10 @@ export class StudentQuestionRepository {
     this.collection = await this.db.getCollection<IStudentSegmentQuestion>(
       'studentSegmentQuestions',
     );
+    this.responsesCollection =
+      await this.db.getCollection<IStudentCrowdResponse>(
+        'studentCrowdResponses',
+      );
     this.initialized = true;
 
     try {
@@ -31,6 +46,11 @@ export class StudentQuestionRepository {
       await this.collection.createIndex(
         {courseVersionId: 1, segmentId: 1, normalizedSignature: 1, isDeleted: 1},
         {background: true},
+      );
+      // One response per (question, student) — enforces idempotent capture.
+      await this.responsesCollection.createIndex(
+        {studentQuestionId: 1, userId: 1},
+        {unique: true, background: true},
       );
     } catch {
       // index already exists
@@ -253,5 +273,122 @@ export class StudentQuestionRepository {
       },
     );
     return result.matchedCount > 0;
+  }
+
+  /**
+   * Stage-2 serving pool: COLLECTING (PENDING, not-yet-eligible) crowd questions
+   * for the given video segments, excluding a given author and a set of already
+   * answered question ids. Sorted by fewest responses first so the pool
+   * advances toward the gate threshold evenly. `limit` caps the result.
+   */
+  async findCollectingForSegments(input: {
+    segmentIds: string[];
+    excludeUserId: string;
+    excludeQuestionIds?: string[];
+    limit?: number;
+  }): Promise<IStudentSegmentQuestion[]> {
+    await this.init();
+    if (input.segmentIds.length === 0) return [];
+    return this.collection
+      .find({
+        segmentId: {$in: input.segmentIds.map(id => new ObjectId(id))},
+        status: 'PENDING',
+        gateState: {$ne: 'ELIGIBLE'},
+        isDeleted: {$ne: true},
+        createdBy: {$ne: new ObjectId(input.excludeUserId)},
+        ...(input.excludeQuestionIds && input.excludeQuestionIds.length > 0
+          ? {_id: {$nin: input.excludeQuestionIds.map(id => new ObjectId(id))}}
+          : {}),
+      })
+      .sort({responseCount: 1, createdAt: 1})
+      .limit(input.limit ?? 1)
+      .toArray();
+  }
+
+  /** Question ids (from a candidate set) this user has already responded to. */
+  async listAnsweredQuestionIds(
+    userId: string,
+    questionIds: string[],
+  ): Promise<string[]> {
+    await this.init();
+    if (questionIds.length === 0) return [];
+    const docs = await this.responsesCollection
+      .find({
+        userId: new ObjectId(userId),
+        studentQuestionId: {$in: questionIds.map(id => new ObjectId(id))},
+      })
+      .toArray();
+    return docs.map(d => d.studentQuestionId.toString());
+  }
+
+  /**
+   * Idempotently record one student's ungraded response (answer correctness +
+   * optional thumb) to a crowd question, and atomically bump the question's
+   * counters on first write only. Returns the updated counters, or null if this
+   * (question, student) already responded (no double counting). The caller uses
+   * the returned counters to evaluate the promotion gate.
+   */
+  async recordCrowdResponse(input: {
+    studentQuestionId: string;
+    userId: string;
+    isCorrect: boolean;
+    thumb?: 'UP' | 'DOWN';
+  }): Promise<{
+    responseCount: number;
+    correctCount: number;
+    thumbsUpCount: number;
+    thumbsDownCount: number;
+  } | null> {
+    await this.init();
+    const qId = new ObjectId(input.studentQuestionId);
+    try {
+      await this.responsesCollection.insertOne({
+        studentQuestionId: qId,
+        userId: new ObjectId(input.userId),
+        isCorrect: input.isCorrect,
+        thumb: input.thumb,
+        createdAt: new Date(),
+      });
+    } catch (e: any) {
+      // Duplicate key → already responded; do not double-count.
+      if (e?.code === 11000) return null;
+      throw e;
+    }
+
+    const inc: Record<string, number> = {responseCount: 1};
+    if (input.isCorrect) inc.correctCount = 1;
+    if (input.thumb === 'UP') inc.thumbsUpCount = 1;
+    if (input.thumb === 'DOWN') inc.thumbsDownCount = 1;
+
+    const updated = await this.collection.findOneAndUpdate(
+      {_id: qId},
+      {$inc: inc, $set: {updatedAt: new Date()}},
+      {returnDocument: 'after'},
+    );
+    if (!updated) return null;
+    return {
+      responseCount: updated.responseCount ?? 0,
+      correctCount: updated.correctCount ?? 0,
+      thumbsUpCount: updated.thumbsUpCount ?? 0,
+      thumbsDownCount: updated.thumbsDownCount ?? 0,
+    };
+  }
+
+  /** Flip a question to ELIGIBLE (gate passed). Idempotent. */
+  async markEligible(studentQuestionId: string): Promise<void> {
+    await this.init();
+    await this.collection.updateOne(
+      {_id: new ObjectId(studentQuestionId), gateState: {$ne: 'ELIGIBLE'}},
+      {$set: {gateState: 'ELIGIBLE', eligibleAt: new Date(), updatedAt: new Date()}},
+    );
+  }
+
+  /** Fetch several questions by id (for serving/capture lookups). */
+  async findByIds(ids: string[]): Promise<IStudentSegmentQuestion[]> {
+    await this.init();
+    if (ids.length === 0) return [];
+    return this.collection
+      .find({_id: {$in: ids.map(id => new ObjectId(id))}, isDeleted: {$ne: true}})
+      .toArray();
   }
 }

--- a/backend/src/modules/studentQuestions/services/StudentQuestionService.ts
+++ b/backend/src/modules/studentQuestions/services/StudentQuestionService.ts
@@ -22,6 +22,7 @@ import {COURSES_TYPES} from '../../courses/types.js';
 import {SOLQuestion} from '../../quizzes/classes/transformers/Question.js';
 import {IQuizDetails, ItemType} from '#root/shared/interfaces/models.js';
 import {ISOLSolution} from '#root/shared/interfaces/quiz.js';
+import {isEligibleForReview} from './crowdGate.js';
 
 const REPEATED_CHAR_PATTERN = /(.)\1{7,}/;
 const REPEATED_WORD_PATTERN = /(\b\w+\b)(\s+\1){4,}/;
@@ -45,7 +46,7 @@ export class StudentQuestionService {
     private readonly itemRepo: ItemRepository,
   ) {}
 
-  private async _promoteToQuestionBank(
+  private async _stageToSubmittedBank(
     studentQuestionId: string,
     input: {
       segmentId: string;
@@ -57,14 +58,17 @@ export class StudentQuestionService {
   ): Promise<void> {
     try {
       // `segmentId` is the VIDEO item the student just finished. The question
-      // belongs in the quiz that immediately follows that video in the same
-      // section, so resolve that quiz's question bank.
+      // belongs to the quiz immediately following that video. We do NOT add it
+      // to that quiz's GRADED bank — under the V3 crowd-question design
+      // (CROWD_QUESTION_BANK.md) crowd questions are parked in a separate
+      // "Submitted – Pending Validation" bank until peer-validated + instructor
+      // approved, so they never enter graded quiz draws.
       const quizItem = await this._resolveTargetQuiz(input.segmentId);
       if (!quizItem) return;
 
-      const bankId = ((quizItem as any).details as IQuizDetails | undefined)
+      const gradedBankId = ((quizItem as any).details as IQuizDetails | undefined)
         ?.questionBankRefs?.[0]?.bankId?.toString();
-      if (!bankId) return;
+      if (!gradedBankId) return;
 
       const solution: ISOLSolution = {
         correctLotItem: {
@@ -88,12 +92,17 @@ export class StudentQuestionService {
       }, solution);
 
       const promotedId = await this.questionService.create(solQuestion);
-      await this.questionBankService.addQuestion(bankId, promotedId).catch(e =>
-        console.warn('crowd-q: failed to add to bank', e),
-      );
+      const submittedBankId =
+        await this.questionBankService.findOrCreateCrowdSubmittedBank(
+          gradedBankId,
+          (quizItem as any)._id,
+        );
+      await this.questionBankService
+        .addQuestion(submittedBankId, promotedId)
+        .catch(e => console.warn('crowd-q: failed to add to submitted bank', e));
       await this.repository.setPromotedQuestionId(studentQuestionId, promotedId).catch(() => {});
     } catch (err) {
-      console.warn('crowd-q: promotion failed (non-fatal)', err);
+      console.warn('crowd-q: staging to submitted bank failed (non-fatal)', err);
     }
   }
 
@@ -325,7 +334,7 @@ export class StudentQuestionService {
 
     const createdId = await this.repository.create(question);
 
-    await this._promoteToQuestionBank(createdId, {
+    await this._stageToSubmittedBank(createdId, {
       segmentId: input.segmentId,
       questionText,
       options,
@@ -334,6 +343,30 @@ export class StudentQuestionService {
     });
 
     return createdId;
+  }
+
+  /**
+   * Stage-2 capture: record one student's ungraded response (answer correctness
+   * + optional 👍/👎) to a served crowd question, then evaluate the promotion
+   * gate. Idempotent per (question, student). When the gate passes, flips the
+   * question to ELIGIBLE so it surfaces in the instructor review queue.
+   * Best-effort: never throws into the quiz-submission path.
+   */
+  async recordPeerResponse(input: {
+    studentQuestionId: string;
+    userId: string;
+    isCorrect: boolean;
+    thumb?: 'UP' | 'DOWN';
+  }): Promise<void> {
+    try {
+      const counters = await this.repository.recordCrowdResponse(input);
+      if (!counters) return; // already responded — no double count
+      if (isEligibleForReview(counters)) {
+        await this.repository.markEligible(input.studentQuestionId);
+      }
+    } catch (err) {
+      console.warn('crowd-q: failed to record peer response', err);
+    }
   }
 
   async listSegmentQuestions(input: {
@@ -530,13 +563,21 @@ export class StudentQuestionService {
           input.status,
           input.reason?.trim(),
         );
-        // Sync the promoted quiz Question's reviewStatus.
+        // Sync the linked quiz Question.
         if (question.promotedQuestionId) {
           const promotedId = question.promotedQuestionId.toString();
           if (input.status === 'APPROVED') {
+            // Mark approved AND move it from the "Submitted – Pending
+            // Validation" bank into the quiz's graded bank so it counts toward
+            // grading. Both are best-effort and must not fail the status update.
             await this.questionService.setReviewStatus(promotedId, 'APPROVED').catch(e =>
               console.warn('crowd-q: failed to approve quiz question', e),
             );
+            await this.questionBankService
+              .promoteSubmittedQuestionToGraded(promotedId)
+              .catch(e =>
+                console.warn('crowd-q: failed to move approved question to graded bank', e),
+              );
           } else {
             await this.questionService.delete(promotedId).catch(e =>
               console.warn('crowd-q: failed to delete quiz question', e),

--- a/backend/src/modules/studentQuestions/services/crowdGate.ts
+++ b/backend/src/modules/studentQuestions/services/crowdGate.ts
@@ -1,0 +1,66 @@
+/*
+ * Crowd-question peer-validation gate.
+ *
+ * A COLLECTING crowd question (in its "Submitted – Pending Validation" bank)
+ * becomes ELIGIBLE — i.e. surfaces to the instructor for approval — only when
+ * ALL of the gate criteria below hold. See CROWD_QUESTION_BANK.md.
+ *
+ * This module is the single source of truth for the thresholds; stage-2
+ * response/vote handling calls isEligibleForReview() after each new signal.
+ */
+
+/** Minimum number of (ungraded) student answers before the gate can fire. */
+export const MIN_RESPONSES_FOR_GATE = 200;
+
+/** Difficulty band on the proportion answering correctly. */
+export const MIN_CORRECT_RATE = 0.3;
+export const MAX_CORRECT_RATE = 0.7;
+
+/** Quality ceiling: thumbs-down as a share of all votes must stay below this. */
+export const MAX_THUMBS_DOWN_RATE = 0.1;
+
+export interface CrowdGateCounters {
+  responseCount: number;
+  correctCount: number;
+  thumbsUpCount: number;
+  thumbsDownCount: number;
+}
+
+export interface CrowdGateEvaluation {
+  eligible: boolean;
+  correctRate: number;
+  thumbsDownRate: number;
+  /** Which criteria currently pass — useful for instructor/debug surfaces. */
+  reasons: {
+    hasMinResponses: boolean;
+    inDifficultyBand: boolean;
+    underThumbsDownCeiling: boolean;
+  };
+}
+
+/**
+ * Evaluate the gate. Returns the computed rates and per-criterion pass flags.
+ * `eligible` is true only when every criterion passes.
+ */
+export function evaluateCrowdGate(c: CrowdGateCounters): CrowdGateEvaluation {
+  const correctRate = c.responseCount > 0 ? c.correctCount / c.responseCount : 0;
+  const totalVotes = c.thumbsUpCount + c.thumbsDownCount;
+  const thumbsDownRate = totalVotes > 0 ? c.thumbsDownCount / totalVotes : 0;
+
+  const hasMinResponses = c.responseCount >= MIN_RESPONSES_FOR_GATE;
+  const inDifficultyBand =
+    correctRate >= MIN_CORRECT_RATE && correctRate <= MAX_CORRECT_RATE;
+  const underThumbsDownCeiling = thumbsDownRate < MAX_THUMBS_DOWN_RATE;
+
+  return {
+    eligible: hasMinResponses && inDifficultyBand && underThumbsDownCeiling,
+    correctRate,
+    thumbsDownRate,
+    reasons: {hasMinResponses, inDifficultyBand, underThumbsDownCeiling},
+  };
+}
+
+/** Convenience boolean form of {@link evaluateCrowdGate}. */
+export function isEligibleForReview(c: CrowdGateCounters): boolean {
+  return evaluateCrowdGate(c).eligible;
+}

--- a/backend/src/shared/interfaces/quiz.ts
+++ b/backend/src/shared/interfaces/quiz.ts
@@ -92,6 +92,17 @@ interface IQuestionBank {
   points?: number;
   createdAt: Date;
   updatedAt: Date;
+  // Crowd-sourced "Submitted – Pending Validation" staging bank (see
+  // studentQuestions/CROWD_QUESTION_BANK.md). When true, this bank holds
+  // student-submitted questions awaiting peer validation + instructor approval
+  // and is NOT referenced by the live quiz's questionBankRefs, so it never
+  // affects graded quiz draws. Keyed to the quiz it belongs to via
+  // sourceGradedBankId (the quiz's graded questionBankRefs[0].bankId).
+  crowdSubmitted?: boolean;
+  sourceGradedBankId?: ID;
+  sourceQuizId?: ID;
+  isDeleted?: boolean;
+  deletedAt?: Date;
 }
 
 type QuestionQuizView = Omit<IQuestion, 'hint'>;


### PR DESCRIPTION
Restore and extend the crowd-question pipeline as the V3 peer-validation design (see studentQuestions/CROWD_QUESTION_BANK.md): student-submitted questions are parked in a per-quiz "Submitted – Pending Validation" bank, served to peers for thumbs up/down, and only promoted into the graded bank once peer-validated (eligible) and instructor-approved.

- crowdGate.ts: evaluateCrowdGate / isEligibleForReview thresholds as the single source of truth for the COLLECTING -> ELIGIBLE transition.
- QuestionBankService: findOrCreateCrowdSubmittedBank, findCrowdSubmittedBankByGradedBankId, promoteSubmittedQuestionToGraded.
- StudentQuestionRepository: studentCrowdResponses collection + findCollectingForSegments stage-2 serving pool.
- Peer thumbs up/down + peerCorrectLotItemId plumbing through the validators, transformer, grading and quiz interfaces.


