### PR TITLE
chore: gitignore one-off script dumps and local reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,16 @@ e2e/*.txt
 
 # Local Claude agents
 .github/agents/debugger.agent.md
+
+# One-off script run-output dumps & local reports (backend root)
+backend/*.json
+backend/*.csv
+backend/*.html
+backend/*.pdf
+backend/html/
+
+# Local PR draft notes
+.pr-*.md
+
+# Firebase hosting cache
+.firebase/


### PR DESCRIPTION
Stop tracking the backend run-output artifacts (timestamped *.json, *.csv, *.html, *.pdf reports from one-off scripts), local .pr-*.md draft notes, and the .firebase hosting cache so git status stays readable.
