### PR TITLE
fix(timeslot): correct allowance meter + add 1h cancellation cutoff

### DIFF
--- a/backend/src/modules/setting/services/SlotBookingService.ts
+++ b/backend/src/modules/setting/services/SlotBookingService.ts
@@ -50,6 +50,8 @@ export class SlotBookingService extends BaseService {
   private static readonly BOOKING_OPEN_LEAD_DAYS = 2;
   /** Hour (IST) at which booking opens on D-2. */
   private static readonly BOOKING_OPEN_HOUR = 9;
+  /** Hours before a slot's start after which it can no longer be cancelled. */
+  private static readonly CANCEL_CUTOFF_HOURS = 1;
 
   /** IST "now" as epoch ms whose UTC fields read as the IST wall clock. */
   private getISTNowMs(): number {
@@ -350,7 +352,12 @@ export class SlotBookingService extends BaseService {
     });
   }
 
-  /** Cancel one of the student's own bookings (used for re-booking / changes). */
+  /**
+   * Cancel one of the student's own bookings (used for re-booking / changes).
+   * Only allowed up to CANCEL_CUTOFF_HOURS before the slot starts — once inside
+   * that window (or after the slot has started) it can no longer be cancelled
+   * and counts as an unused slot, which the fulfilment job marks UNFULFILLED.
+   */
   async cancelBooking(userId: string, bookingId: string): Promise<boolean> {
     return this._withTransaction(async (session) => {
       const booking = await this.slotBookingRepo.findById(bookingId, session);
@@ -359,6 +366,19 @@ export class SlotBookingService extends BaseService {
       }
       if (String(booking.userId) !== String(userId)) {
         throw new ForbiddenError('You can only cancel your own bookings.');
+      }
+      // Lock cancellation within the cutoff window before the slot starts.
+      if (booking.date && booking.from) {
+        const startMs = this.slotCloseMs(booking.date, booking.from);
+        const cancelDeadlineMs =
+          startMs -
+          SlotBookingService.CANCEL_CUTOFF_HOURS * 60 * 60 * 1000;
+        if (this.getISTNowMs() >= cancelDeadlineMs) {
+          throw new BadRequestError(
+            `Bookings can only be cancelled up to ${SlotBookingService.CANCEL_CUTOFF_HOURS} hour before the slot starts. ` +
+              'It will count as an unused slot if you do not attend.',
+          );
+        }
       }
       return this.slotBookingRepo.cancelBooking(bookingId, session);
     });

--- a/backend/src/modules/setting/tests/SlotBookingService.test.ts
+++ b/backend/src/modules/setting/tests/SlotBookingService.test.ts
@@ -461,6 +461,37 @@ describe('SlotBookingService.cancelBooking', () => {
     expect(ok).toBe(true);
     expect(slotBookingRepo.cancelBooking).toHaveBeenCalledWith('b1', {});
   });
+
+  it('allows cancelling more than 1 hour before the slot starts', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-06-20T05:30:00.000Z')); // 11:00 IST
+      const {svc, slotBookingRepo} = makeService({
+        bookingById: {userId: USER, date: '2026-06-20', from: '13:00', to: '15:00'},
+      });
+      const ok = await svc.cancelBooking(USER, 'b1'); // deadline 12:00 IST
+      expect(ok).toBe(true);
+      expect(slotBookingRepo.cancelBooking).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects cancelling within 1 hour of the slot start', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-06-20T07:00:00.000Z')); // 12:30 IST
+      const {svc, slotBookingRepo} = makeService({
+        bookingById: {userId: USER, date: '2026-06-20', from: '13:00', to: '15:00'},
+      });
+      await expect(svc.cancelBooking(USER, 'b1')).rejects.toThrowError(
+        /1 hour before the slot starts/i,
+      );
+      expect(slotBookingRepo.cancelBooking).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('SlotBookingService.getStudentBookings', () => {

--- a/frontend/src/components/course/StudentTimeslotModal.tsx
+++ b/frontend/src/components/course/StudentTimeslotModal.tsx
@@ -14,6 +14,7 @@ import {
   bookableStudyDates,
   istToday,
   slotBookingClosed,
+  slotCancelClosed,
   type MyBooking,
 } from "@/hooks/hooks";
 import { cn } from "@/utils/utils";
@@ -80,7 +81,7 @@ export default function StudentTimeslotModal({
     data: myBookings,
     isLoading: bookingsLoading,
     refetch: refetchBookings,
-  } = useMyBookings(courseId, courseVersionId, undefined, isOpen);
+  } = useMyBookings(courseId, courseVersionId, null, isOpen);
   const { data: availability, refetch: refetchAvailability } = useSlotAvailability(
     courseId,
     courseVersionId,
@@ -248,6 +249,9 @@ export default function StudentTimeslotModal({
                 const booked = bookingFor(slot);
                 // A slot closes for booking at its own start time on the study day.
                 const hasStarted = !booked && slotBookingClosed(activeDate, slot.from);
+                // Cancellation locks 1 hour before the slot starts; after that the
+                // booking counts as an unused slot.
+                const cancelLocked = !!booked && slotCancelClosed(booked.date, booked.from);
                 // Past the daily allowance a student may still book by drawing
                 // from an instructor-awarded pool — mirrors the backend rule.
                 const atLimit =
@@ -292,10 +296,15 @@ export default function StudentTimeslotModal({
                             <Button
                               size="sm"
                               variant="outline"
-                              disabled={busy}
+                              disabled={busy || cancelLocked}
+                              title={
+                                cancelLocked
+                                  ? "Cancellation closes 1 hour before the slot starts"
+                                  : undefined
+                              }
                               onClick={() => handleCancel(booked._id)}
                             >
-                              Cancel
+                              {cancelLocked ? "Locked" : "Cancel"}
                             </Button>
                           </div>
                         ) : (
@@ -364,7 +373,7 @@ export default function StudentTimeslotModal({
             {bonusEnabled ? (
               <p>• Stay active for most of a booked window and you'll earn a bonus booking to use the same day.</p>
             ) : null}
-            <p>• Need a different window? Cancel a booking to free up your allowance, then book another.</p>
+            <p>• Need a different window? Cancel up to 1 hour before the slot starts to free up your allowance, then book another. After that it locks and counts as an unused slot.</p>
             <p>• Access to the course is allowed during a window you've booked.</p>
             <p>• Time slots are in IST (Indian Standard Time, UTC+5:30).</p>
           </div>

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -6061,12 +6061,31 @@ export function slotBookingClosed(date: string, from: string): boolean {
   return h * 60 + m <= istNowMinutes();
 }
 
+// How many minutes before a slot's start a booking can no longer be cancelled.
+// Mirrors the backend CANCEL_CUTOFF_HOURS (1h).
+export const CANCEL_CUTOFF_MINUTES = 60;
+
+// A booking can be cancelled only up to CANCEL_CUTOFF_MINUTES before its slot
+// starts; after that (or once the slot has started/passed) it locks and counts
+// as an unused slot. Future study days are always cancellable; past days locked.
+export function slotCancelClosed(date: string, from: string): boolean {
+  const today = istToday();
+  if (date < today) return true; // a past study day — already locked
+  if (date > today) return false; // a future study day — well outside the cutoff
+  const [h, m] = from.split(':').map(Number);
+  return h * 60 + m - CANCEL_CUTOFF_MINUTES <= istNowMinutes();
+}
+
 // GET /slot-bookings/my/course/{courseId}/version/{courseVersionId}?date=
-// The calling student's active bookings for an IST day (default today).
+// The calling student's active bookings. Pass a YYYY-MM-DD `date` to restrict to
+// one IST study day; pass `null` to fetch ALL active bookings across every study
+// day (needed for the per-calendar-day allowance meter, which counts bookings by
+// the day they were MADE, not the day they're for). Omitting `date` defaults to
+// today for backward compatibility.
 export function useMyBookings(
   courseId: string | undefined,
   courseVersionId: string | undefined,
-  date?: string,
+  date?: string | null,
   enabled: boolean = true,
 ): {
   data: MyBooking[] | undefined;
@@ -6074,17 +6093,19 @@ export function useMyBookings(
   error: string | null;
   refetch: () => void;
 } {
-  const day = date ?? istToday();
+  const allDates = date === null;
+  const day = allDates ? undefined : date ?? istToday();
   const valid =
     !!courseId &&
     courseId.length === 24 &&
     !!courseVersionId &&
     courseVersionId.length === 24;
   const result = useQuery({
-    queryKey: ['my-bookings', courseId, courseVersionId, day],
+    queryKey: ['my-bookings', courseId, courseVersionId, allDates ? 'all' : day],
     enabled: enabled && valid,
     queryFn: async (): Promise<MyBooking[]> => {
-      const url = `${import.meta.env.VITE_BASE_URL}/slot-bookings/my/course/${courseId}/version/${courseVersionId}?date=${encodeURIComponent(day)}`;
+      const base = `${import.meta.env.VITE_BASE_URL}/slot-bookings/my/course/${courseId}/version/${courseVersionId}`;
+      const url = allDates ? base : `${base}?date=${encodeURIComponent(day as string)}`;
       const res = await fetch(url, {
         headers: {
           authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,


### PR DESCRIPTION
Meter bug: the booking modal fetched only today's study-day bookings, so a slot booked for a future day never counted — the meter stayed "0 of 1" even though the backend had consumed the daily allowance. useMyBookings now supports fetching ALL active bookings (date=null); the modal uses it so the per-calendar-day allowance meter and per-slot "Booked" state are correct across days.

Cancellation cutoff: a booking can now be cancelled only up to 1 hour before its slot starts; after that it locks (button shows "Locked") and counts as an unused slot (the fulfilment job marks it UNFULFILLED — no refund). Enforced server-side in cancelBooking and reflected in the modal + help text.

<!-- Description -->

<!-- 
Mention any related issues here. 
Use the following sytax:

Closes #ISSUE-NUMBER 
-->
