### PR TITLE
feat(timeslot): alert students to hours lost on unused slots

### DIFF
--- a/backend/src/modules/setting/controllers/SlotBookingController.ts
+++ b/backend/src/modules/setting/controllers/SlotBookingController.ts
@@ -183,6 +183,33 @@ class SlotBookingController {
   }
 
   @OpenAPI({
+    summary: "The student's committed-hours summary",
+    description:
+      "Returns the calling student's hours budget, hours reserved, and hours LOST to unused (unfulfilled) slots, so the UI can warn them about wasted budget.",
+  })
+  @Authorized()
+  @Get('/my/hours/course/:courseId/version/:courseVersionId')
+  @HttpCode(200)
+  async myHoursSummary(
+    @Param('courseId') courseId: string,
+    @Param('courseVersionId') courseVersionId: string,
+    @CurrentUser() user: IUser,
+    @QueryParam('cohortId') cohortId?: string,
+  ): Promise<BookingResponse> {
+    try {
+      const data = await this.slotBookingService.getStudentHoursSummary(
+        user._id.toString(),
+        courseId,
+        courseVersionId,
+        cohortId,
+      );
+      return {success: true, data};
+    } catch (error) {
+      throw new InternalServerError(`Failed to get hours summary: ${error}`);
+    }
+  }
+
+  @OpenAPI({
     summary: 'Slot availability (for booking)',
     description:
       'Booked load and seats remaining per window for an IST day (default today), so an enrolled student can see capacity while picking a slot. Returns counts only — no learner identities.',

--- a/backend/src/modules/setting/services/SlotBookingService.ts
+++ b/backend/src/modules/setting/services/SlotBookingService.ts
@@ -430,6 +430,80 @@ export class SlotBookingService extends BaseService {
   }
 
   /**
+   * A student's committed-hours summary for the course: their budget, the hours
+   * they've reserved against it, and — the part worth surfacing — the hours
+   * LOST to unused (UNFULFILLED) slots. Lets the UI warn e.g. "you've lost 2h of
+   * your 16h budget to missed slots." `hasBudget` is false when the course sets
+   * no hours budget (everything is then unlimited).
+   */
+  async getStudentHoursSummary(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    cohortId?: string,
+  ): Promise<{
+    hasBudget: boolean;
+    budgetHours: number | null;
+    reservedHours: number;
+    lostHours: number;
+    remainingHours: number | null;
+  }> {
+    const timeslots = await this.settingsRepo.readTimeslotsSettings(
+      courseId,
+      courseVersionId,
+    );
+    let enrollment = await this.enrollmentService.findEnrollment(
+      userId,
+      courseId,
+      courseVersionId,
+      cohortId,
+    );
+    if (!enrollment && cohortId) {
+      enrollment = await this.enrollmentService.findEnrollment(
+        userId,
+        courseId,
+        courseVersionId,
+      );
+    }
+
+    const [reservedHours, lostHours] = await Promise.all([
+      this.slotBookingRepo.sumReservedHoursForStudent(
+        userId,
+        courseId,
+        courseVersionId,
+      ),
+      this.slotBookingRepo.sumUnfulfilledHoursForStudent(
+        userId,
+        courseId,
+        courseVersionId,
+      ),
+    ]);
+    const round = (n: number) => Math.round(n * 100) / 100;
+
+    const base = timeslots?.totalBudgetHours;
+    if (base == null) {
+      return {
+        hasBudget: false,
+        budgetHours: null,
+        reservedHours: round(reservedHours),
+        lostHours: round(lostHours),
+        remainingHours: null,
+      };
+    }
+    const budgetHours =
+      base +
+      ((enrollment as {commitmentExtraHours?: number} | null)
+        ?.commitmentExtraHours ?? 0);
+    return {
+      hasBudget: true,
+      budgetHours: round(budgetHours),
+      reservedHours: round(reservedHours),
+      lostHours: round(lostHours),
+      remainingHours: round(Math.max(0, budgetHours - reservedHours)),
+    };
+  }
+
+  /**
    * Booked load per window for an IST day — the "demand schedule" that lets ops
    * size capacity per window and scale down off-peak. Defaults to today.
    */

--- a/backend/src/modules/setting/tests/SlotBookingService.test.ts
+++ b/backend/src/modules/setting/tests/SlotBookingService.test.ts
@@ -35,6 +35,7 @@ function makeService(
     slotCount?: number;
     bookingById?: any;
     reservedHours?: number;
+    lostHours?: number;
   } = {},
 ) {
   const {
@@ -48,12 +49,14 @@ function makeService(
     slotCount = 0,
     bookingById = null,
     reservedHours = 0,
+    lostHours = 0,
   } = opts;
 
   const slotBookingRepo = {
     findActiveForStudent: vi.fn().mockResolvedValue(myBookings),
     countActiveInSlot: vi.fn().mockResolvedValue(slotCount),
     sumReservedHoursForStudent: vi.fn().mockResolvedValue(reservedHours),
+    sumUnfulfilledHoursForStudent: vi.fn().mockResolvedValue(lostHours),
     createBooking: vi
       .fn()
       .mockImplementation((b: any) => Promise.resolve({...b, _id: 'booking-new'})),
@@ -491,6 +494,51 @@ describe('SlotBookingService.cancelBooking', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('SlotBookingService.getStudentHoursSummary', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reports budget, reserved and hours lost to unused slots', async () => {
+    const {svc} = makeService({
+      timeslots: {isActive: true, slots: [], totalBudgetHours: 16},
+      enrollment: {_id: 'enroll-1', commitmentExtraHours: 0},
+      reservedHours: 6,
+      lostHours: 2,
+    });
+    const summary = await svc.getStudentHoursSummary(USER, COURSE, VERSION);
+    expect(summary).toEqual({
+      hasBudget: true,
+      budgetHours: 16,
+      reservedHours: 6,
+      lostHours: 2,
+      remainingHours: 10,
+    });
+  });
+
+  it('adds instructor-granted extra hours to the budget', async () => {
+    const {svc} = makeService({
+      timeslots: {isActive: true, slots: [], totalBudgetHours: 16},
+      enrollment: {_id: 'enroll-1', commitmentExtraHours: 4},
+      reservedHours: 0,
+      lostHours: 0,
+    });
+    const summary = await svc.getStudentHoursSummary(USER, COURSE, VERSION);
+    expect(summary.budgetHours).toBe(20);
+    expect(summary.remainingHours).toBe(20);
+  });
+
+  it('reports no budget (unlimited) when the course sets none', async () => {
+    const {svc} = makeService({
+      timeslots: {isActive: true, slots: []}, // no totalBudgetHours
+      lostHours: 2,
+    });
+    const summary = await svc.getStudentHoursSummary(USER, COURSE, VERSION);
+    expect(summary.hasBudget).toBe(false);
+    expect(summary.budgetHours).toBeNull();
+    expect(summary.remainingHours).toBeNull();
+    expect(summary.lostHours).toBe(2); // still reports lost hours
   });
 });
 

--- a/backend/src/shared/database/interfaces/ISlotBookingRepository.ts
+++ b/backend/src/shared/database/interfaces/ISlotBookingRepository.ts
@@ -57,6 +57,17 @@ export interface ISlotBookingRepository {
     session?: ClientSession,
   ): Promise<number>;
 
+  /**
+   * Total `hoursReserved` a student has LOST to UNFULFILLED (unused) bookings on
+   * a course version — hours spent from the budget with nothing gained.
+   */
+  sumUnfulfilledHoursForStudent(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<number>;
+
   /** Mark a booking cancelled (student re-book or instructor removal). */
   cancelBooking(
     bookingId: string,

--- a/backend/src/shared/database/providers/mongo/repositories/SlotBookingRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SlotBookingRepository.ts
@@ -164,6 +164,38 @@ export class SlotBookingRepository implements ISlotBookingRepository {
     return result.length > 0 ? (result[0] as any).total ?? 0 : 0;
   }
 
+  /**
+   * Sum the reserved hours a student has LOST to unused slots — bookings that
+   * ended UNFULFILLED (booked but not attended enough). These hours are spent
+   * from the budget with nothing to show for them.
+   */
+  async sumUnfulfilledHoursForStudent(
+    userId: string,
+    courseId: string,
+    courseVersionId: string,
+    session?: ClientSession,
+  ): Promise<number> {
+    await this.init();
+    const result = await this.slotBookingsCollection
+      .aggregate(
+        [
+          {
+            $match: {
+              userId: new ObjectId(userId),
+              courseId: new ObjectId(courseId),
+              courseVersionId: new ObjectId(courseVersionId),
+              status: SlotBookingStatus.UNFULFILLED,
+              isDeleted: {$ne: true},
+            },
+          },
+          {$group: {_id: null, total: {$sum: '$hoursReserved'}}},
+        ],
+        {session},
+      )
+      .toArray();
+    return result.length > 0 ? (result[0] as any).total ?? 0 : 0;
+  }
+
   async cancelBooking(
     bookingId: string,
     session?: ClientSession,

--- a/frontend/src/components/course/StudentTimeslotModal.tsx
+++ b/frontend/src/components/course/StudentTimeslotModal.tsx
@@ -9,6 +9,7 @@ import {
   useMyBookings,
   useSlotAvailability,
   useMyExtraBookings,
+  useMyHoursSummary,
   useBookSlot,
   useCancelBooking,
   bookableStudyDates,
@@ -93,6 +94,11 @@ export default function StudentTimeslotModal({
     courseVersionId,
     isOpen,
   );
+  const { data: hoursSummary, refetch: refetchHoursSummary } = useMyHoursSummary(
+    courseId,
+    courseVersionId,
+    isOpen,
+  );
   const { book, loading: booking } = useBookSlot();
   const { cancel, loading: cancelling } = useCancelBooking();
 
@@ -103,6 +109,7 @@ export default function StudentTimeslotModal({
     refetchBookings();
     refetchAvailability();
     refetchExtraBookings();
+    refetchHoursSummary();
   };
 
   const tsSettings = timeSlotsData as
@@ -221,12 +228,28 @@ export default function StudentTimeslotModal({
                 {extraBookings} awarded booking{extraBookings !== 1 ? 's' : ''} available
               </span>
             ) : null}
+            {hoursSummary?.hasBudget && hoursSummary.budgetHours != null ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-muted text-foreground px-2.5 py-0.5 text-xs font-medium">
+                <Clock className="h-3.5 w-3.5" />
+                {hoursSummary.remainingHours}h of {hoursSummary.budgetHours}h left
+              </span>
+            ) : null}
           </div>
           {bonusEarnedToday > 0 ? (
             <p className="mt-1 text-xs text-amber-700">
               🎉 You stayed active in {bonusEarnedToday} of your booked window
               {bonusEarnedToday !== 1 ? 's' : ''} today — that earned you{' '}
               {bonusEarnedToday} extra booking{bonusEarnedToday !== 1 ? 's' : ''}. Book another window below.
+            </p>
+          ) : null}
+          {hoursSummary && hoursSummary.lostHours > 0 ? (
+            <p className="mt-1 text-xs text-red-700">
+              ⚠️ You've lost {hoursSummary.lostHours}h
+              {hoursSummary.hasBudget && hoursSummary.budgetHours != null
+                ? ` of your ${hoursSummary.budgetHours}h budget`
+                : ''}{' '}
+              to missed slots (booked but not used). Cancel at least 1 hour before a
+              slot if you can't attend — that returns the hours.
             </p>
           ) : null}
         </DialogHeader>

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -6167,6 +6167,53 @@ export function useMyExtraBookings(
   };
 }
 
+export interface MyHoursSummary {
+  hasBudget: boolean;
+  budgetHours: number | null;
+  reservedHours: number;
+  lostHours: number;
+  remainingHours: number | null;
+}
+
+// GET /slot-bookings/my/hours/course/{courseId}/version/{courseVersionId}
+// The student's committed-hours summary: budget, reserved, and hours LOST to
+// unused (unfulfilled) slots — used to warn them about wasted budget.
+export function useMyHoursSummary(
+  courseId: string | undefined,
+  courseVersionId: string | undefined,
+  enabled: boolean = true,
+): { data: MyHoursSummary | undefined; isLoading: boolean; refetch: () => void } {
+  const valid =
+    !!courseId &&
+    courseId.length === 24 &&
+    !!courseVersionId &&
+    courseVersionId.length === 24;
+  const result = useQuery({
+    queryKey: ['my-hours-summary', courseId, courseVersionId],
+    enabled: enabled && valid,
+    queryFn: async (): Promise<MyHoursSummary> => {
+      const url = `${import.meta.env.VITE_BASE_URL}/slot-bookings/my/hours/course/${courseId}/version/${courseVersionId}`;
+      const res = await fetch(url, {
+        headers: {
+          authorization: `Bearer ${localStorage.getItem('firebase-auth-token')}`,
+        },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.message || `Failed to load hours summary: ${res.status}`);
+      }
+      return data?.data as MyHoursSummary;
+    },
+  });
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+    refetch: () => {
+      void result.refetch();
+    },
+  };
+}
+
 // POST /slot-bookings/book — book a time slot for today (raw fetch). The backend
 // returns { success:false, message } for capacity/allowance/budget rejections
 // (HTTP 200), so callers must check `success`, not just the HTTP status.


### PR DESCRIPTION
Surface the cost of missed slots. New GET /slot-bookings/my/hours endpoint returns a committed-hours summary — budget (incl. instructor-granted extra hours), hours reserved, and hours LOST to UNFULFILLED (booked-but-unused) slots. The student booking modal now shows a budget chip ("Xh of Yh left") and a red warning when hours have been lost: "You've lost 2h of your 16h budget to missed slots — cancel at least 1 hour before next time."
