### PR TITLE
ci: use repo pnpm 10 (fixes lockfile-ignore + postman-code-generators…

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -36,9 +36,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
           run_install: false
 
       - name: Install dependencies
@@ -66,9 +65,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
           run_install: false
 
       - name: Install dependencies and fix TypeScript errors

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,9 +21,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8 # or your pnpm version
+        uses: pnpm/action-setup@v4
+        # No version pin: use the repo's `packageManager` (pnpm 10).
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/nightly-staging-e2e.yml
+++ b/.github/workflows/nightly-staging-e2e.yml
@@ -22,9 +22,10 @@ jobs:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
+        # No version pin: action-setup reads the repo's `packageManager`
+        # (pnpm 10), which keeps the lockfile compatible and gates dependency
+        # postinstall scripts (avoids the broken postman-code-generators script).
 
       - name: Install Dependencies
         run: pnpm install


### PR DESCRIPTION
# ci: align workflows to repo pnpm 10 (fix e2e install failure)

## What
Switch the `nightly-staging-e2e`, `linter`, and `deploy-frontend` workflows from a hard-pinned **pnpm 8** to the repo's declared **pnpm 10** (`pnpm/action-setup@v4` with no version pin, so it reads the root `packageManager`). This mirrors the already-passing `jest-test.yml`.

## Why
The e2e pipeline was failing at the **Install Dependencies** step. Running CI on pnpm 8 while the repo is on pnpm 10 (`packageManager: pnpm@10.12.1`) caused two problems:

1. **Lockfile ignored** — `WARN Ignoring not compatible lockfile … pnpm-lock.yaml` → non-deterministic, full re-resolve.
2. **Fatal postinstall crash** — pnpm 8 runs *every* dependency's lifecycle script, including the broken `postman-code-generators` one:

   ```
   error This project's package.json defines "packageManager": "yarn@pnpm@10.12.1" …
   Error: Callback was already called.
   ELIFECYCLE  Command failed with exit code 1.
   ```

**pnpm 10 gates dependency build/postinstall scripts by default**, so that script never runs — which is exactly why local installs (pnpm 10) already succeed. Aligning CI to pnpm 10 fixes both the lockfile warning and the crash.

## Scope / safety
- **Only 3 workflow YAML files** changed (8 insertions, 10 deletions). No application, runtime, or dependency code touched.
- `jest-test.yml`, `docs-check.yml`, `deploy-docs.yml` already used pnpm 10 (unchanged).

## Testing
- Verified the failure reproduces only under pnpm 8; local `pnpm install` on pnpm 10 completes successfully (the broken script is gated).
- Full green confirmation will come from the e2e run after this lands (it needs the scheduled/dispatch trigger + staging secrets on the merged branch).
