### PR TITLE
Fix/timeslot wasted hours repair

### DIFF
--- a/backend/src/modules/setting/services/FulfillmentService.ts
+++ b/backend/src/modules/setting/services/FulfillmentService.ts
@@ -11,9 +11,19 @@ import {
 } from '#shared/interfaces/models.js';
 import {IWatchSession} from '#shared/database/index.js';
 import {GLOBAL_TYPES} from '#root/types.js';
+import {EnrollmentService} from '#users/services/EnrollmentService.js';
+import {USERS_TYPES} from '#users/types.js';
 
 /** Default share of a window a student must be active to FULFILL it. */
 const DEFAULT_THRESHOLD_PCT = 90;
+/**
+ * Floor for the "finished early" credit: a student who engaged DENSELY (active
+ * >= threshold of the time they were present) but left before the booked window
+ * ended still fulfills, provided they put in at least this many minutes — or the
+ * whole window if it is shorter. Stops a token 5-minute appearance from passing
+ * while not punishing someone who did their work and left.
+ */
+const EARLY_FINISH_MIN_MINUTES = 45;
 const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000;
 
 export interface FulfillmentRunSummary {
@@ -40,6 +50,9 @@ export class FulfillmentService extends BaseService {
 
     @inject(GLOBAL_TYPES.SettingRepo)
     private readonly settingsRepo: ISettingRepository,
+
+    @inject(USERS_TYPES.EnrollmentService)
+    private readonly enrollmentService: EnrollmentService,
 
     @inject(GLOBAL_TYPES.Database)
     private readonly mongoDatabase: MongoDatabase,
@@ -103,6 +116,27 @@ export class FulfillmentService extends BaseService {
   }
 
   /**
+   * The latest instant (ms) the student was active within [startUTC, endUTC), or
+   * null if never active. Used to measure engagement DENSITY up to when they
+   * stopped, so finishing early isn't read as idleness.
+   */
+  private lastActiveWithin(
+    sessions: IWatchSession[],
+    startUTC: Date,
+    endUTC: Date,
+  ): number | null {
+    const winStart = startUTC.getTime();
+    const winEnd = endUTC.getTime();
+    let last: number | null = null;
+    for (const s of sessions) {
+      const endSource = s.endTime ?? s.lastSeenAt ?? s.startTime;
+      const end = Math.min(endSource.getTime(), winEnd);
+      if (end > winStart) last = last === null ? end : Math.max(last, end);
+    }
+    return last;
+  }
+
+  /**
    * Evaluate every still-BOOKED booking whose window has ended as of `now`.
    * Settings are read once per course version. Returns a run summary.
    */
@@ -118,6 +152,9 @@ export class FulfillmentService extends BaseService {
       skipped: 0,
     };
     const thresholdCache = new Map<string, number | null>();
+    // "Has the student finished the course?" cached per student+version — a
+    // completed student has no remaining work, so an unused slot isn't wasted.
+    const noRemainingWorkCache = new Map<string, boolean>();
 
     for (const booking of due) {
       const {startUTC, endUTC, minutes} = this.windowBoundsUTC(booking);
@@ -156,10 +193,57 @@ export class FulfillmentService extends BaseService {
       const active = this.activeMinutes(sessions, startUTC, endUTC);
       const activePct =
         minutes > 0 ? Math.min(100, Math.round((active / minutes) * 100)) : 0;
-      const status =
-        activePct >= threshold
-          ? SlotBookingStatus.FULFILLED
-          : SlotBookingStatus.UNFULFILLED;
+
+      // (1) Engaged across the full booked window — the original rule.
+      let fulfilled = activePct >= threshold;
+
+      // (2) Finished early: engaged DENSELY (>= threshold of the time present)
+      // and put in a real session, then left before the window closed. A booked
+      // window longer than the work shouldn't read as wasted.
+      if (!fulfilled && active > 0) {
+        const lastActive = this.lastActiveWithin(sessions, startUTC, endUTC);
+        const engagedMin = lastActive
+          ? (lastActive - startUTC.getTime()) / 60000
+          : 0;
+        const densityPct =
+          engagedMin > 0
+            ? Math.min(100, Math.round((active / engagedMin) * 100))
+            : 0;
+        const minActive = Math.min(minutes, EARLY_FINISH_MIN_MINUTES);
+        if (active >= minActive && densityPct >= threshold) fulfilled = true;
+      }
+
+      // (3) No remaining work: a student who has completed the course has
+      // nothing left to do in the slot, so don't mark it unfulfilled.
+      if (!fulfilled) {
+        const userId = String(booking.userId);
+        const cohortId = booking.cohortId ? String(booking.cohortId) : '';
+        const workKey = `${userId}:${versionId}:${cohortId}`;
+        let noWork = noRemainingWorkCache.get(workKey);
+        if (noWork === undefined) {
+          try {
+            const enrollment = await this.enrollmentService.findEnrollment(
+              userId,
+              courseId,
+              versionId,
+              cohortId || undefined,
+            );
+            noWork =
+              ((enrollment as {percentCompleted?: number} | null)
+                ?.percentCompleted ?? 0) >= 100;
+          } catch {
+            // Lookup failed (e.g. archived version) — assume work remains rather
+            // than crash the run; the slot stays evaluated on engagement alone.
+            noWork = false;
+          }
+          noRemainingWorkCache.set(workKey, noWork);
+        }
+        if (noWork) fulfilled = true;
+      }
+
+      const status = fulfilled
+        ? SlotBookingStatus.FULFILLED
+        : SlotBookingStatus.UNFULFILLED;
 
       await this.slotBookingRepo.setFulfillment(
         String((booking as ISlotBooking)._id),

--- a/backend/src/modules/setting/services/SlotBookingService.ts
+++ b/backend/src/modules/setting/services/SlotBookingService.ts
@@ -46,6 +46,13 @@ export class SlotBookingService extends BaseService {
     super(mongoDatabase);
   }
 
+  /**
+   * Rolling window (days) over which UNFULFILLED slots count as "wasted hours"
+   * in the student-facing warning. Keeps the warning a recent-accountability
+   * signal that decays once the student gets back on track, not an all-time tally.
+   */
+  private static readonly LOST_HOURS_WINDOW_DAYS = 7;
+
   /** How many days before the study day booking opens. */
   private static readonly BOOKING_OPEN_LEAD_DAYS = 2;
   /** Hour (IST) at which booking opens on D-2. */
@@ -466,6 +473,12 @@ export class SlotBookingService extends BaseService {
       );
     }
 
+    // Only recent misses count toward the warning, so it decays as the student
+    // recovers rather than lingering for the life of the course.
+    const lostSince = this.formatISTDate(
+      this.getISTNowMs() -
+        SlotBookingService.LOST_HOURS_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+    );
     const [reservedHours, lostHours] = await Promise.all([
       this.slotBookingRepo.sumReservedHoursForStudent(
         userId,
@@ -476,6 +489,7 @@ export class SlotBookingService extends BaseService {
         userId,
         courseId,
         courseVersionId,
+        lostSince,
       ),
     ]);
     const round = (n: number) => Math.round(n * 100) / 100;

--- a/backend/src/modules/setting/tests/FulfillmentService.test.ts
+++ b/backend/src/modules/setting/tests/FulfillmentService.test.ts
@@ -29,11 +29,13 @@ function makeService(opts: {
   bookings?: any[];
   sessions?: any[];
   timeslots?: any;
+  percentCompleted?: number;
 }) {
   const {
     bookings = [DAY_BOOKING],
     sessions = [],
     timeslots = {isActive: true, slots: [], fulfillmentThresholdPct: 90},
+    percentCompleted = 0,
   } = opts;
 
   const slotBookingRepo = {
@@ -44,12 +46,16 @@ function makeService(opts: {
   const settingsRepo = {
     readTimeslotsSettings: vi.fn().mockResolvedValue(timeslots),
   };
+  const enrollmentService = {
+    findEnrollment: vi.fn().mockResolvedValue({percentCompleted}),
+  };
   const svc = new FulfillmentService(
     slotBookingRepo as any,
     settingsRepo as any,
+    enrollmentService as any,
     {} as any,
   );
-  return {svc, slotBookingRepo, settingsRepo};
+  return {svc, slotBookingRepo, settingsRepo, enrollmentService};
 }
 
 // A watch session as Date objects.
@@ -126,14 +132,56 @@ describe('FulfillmentService.evaluateDueBookings', () => {
   });
 
   it('defaults the threshold to 90% when unset', async () => {
-    // 89% should fail the default, 90% should pass it.
+    // Sparse 89%: 30min + 76.8min with a gap, so engagement density is also 89%
+    // → fails both the full-window rule and the finished-early rule under the
+    // default 90% threshold.
     const eightyNine = makeService({
       timeslots: {isActive: true, slots: []}, // no fulfillmentThresholdPct
-      sessions: [session('2026-06-20T07:30:00Z', '2026-06-20T09:16:48Z')], // ~106.8min → 89%
+      sessions: [
+        session('2026-06-20T07:30:00Z', '2026-06-20T08:00:00Z'), // 30 min
+        session('2026-06-20T08:13:12Z', '2026-06-20T09:30:00Z'), // 76.8 min
+      ],
     });
     await eightyNine.svc.evaluateDueBookings(AFTER);
     expect(eightyNine.slotBookingRepo.setFulfillment.mock.calls[0][1]).toBe(
       SlotBookingStatus.UNFULFILLED,
+    );
+  });
+
+  it('credits finishing early: dense engagement that leaves before the window ends', async () => {
+    // Active 13:00–14:46.8 IST (07:30–09:16.8 UTC) = 106.8 min of a 120-min
+    // window → 89% of the window (fails rule 1), but the student was active
+    // 100% of the time until they left → FULFILLED via the finished-early rule.
+    const {svc, slotBookingRepo} = makeService({
+      sessions: [session('2026-06-20T07:30:00Z', '2026-06-20T09:16:48Z')],
+    });
+    await svc.evaluateDueBookings(AFTER);
+    const [, status, activePct] = slotBookingRepo.setFulfillment.mock.calls[0];
+    expect(status).toBe(SlotBookingStatus.FULFILLED);
+    expect(activePct).toBe(89); // honest measured pct still recorded
+  });
+
+  it('does not credit a token appearance below the minimum active floor', async () => {
+    // 13:00–13:30 IST = 30 min dense, but under the 45-min floor → UNFULFILLED.
+    const {svc, slotBookingRepo} = makeService({
+      sessions: [session('2026-06-20T07:30:00Z', '2026-06-20T08:00:00Z')],
+    });
+    await svc.evaluateDueBookings(AFTER);
+    expect(slotBookingRepo.setFulfillment.mock.calls[0][1]).toBe(
+      SlotBookingStatus.UNFULFILLED,
+    );
+  });
+
+  it('credits a slot when the student has no remaining work (course complete)', async () => {
+    // Barely active, but the course is 100% complete → nothing left to do, so
+    // the booked slot is not counted as wasted.
+    const {svc, slotBookingRepo} = makeService({
+      sessions: [session('2026-06-20T07:30:00Z', '2026-06-20T07:35:00Z')],
+      percentCompleted: 100,
+    });
+    await svc.evaluateDueBookings(AFTER);
+    expect(slotBookingRepo.setFulfillment.mock.calls[0][1]).toBe(
+      SlotBookingStatus.FULFILLED,
     );
   });
 

--- a/backend/src/modules/users/scripts/clearLegacyAssignedTimeSlots.ts
+++ b/backend/src/modules/users/scripts/clearLegacyAssignedTimeSlots.ts
@@ -1,0 +1,83 @@
+/**
+ * Clear legacy enrollment.assignedTimeSlots so the booking system is the sole
+ * source of truth for time-slot access. The access gate honors legacy assigned
+ * slots as a transition fallback — leftover ones let a student in without a
+ * fresh booking (e.g. the Jatish case). This retires them.
+ *
+ * READ-ONLY by default (dry run). Pass --apply to write.
+ * Scope: by default only courses where time-slot booking is ACTIVE (where the
+ * legacy slots actually grant access). Pass --all to clear on every course.
+ *
+ *   npx ts-node src/modules/users/scripts/clearLegacyAssignedTimeSlots.ts          # dry run, active courses
+ *   npx ts-node src/modules/users/scripts/clearLegacyAssignedTimeSlots.ts --apply  # apply, active courses
+ *   npx ts-node src/modules/users/scripts/clearLegacyAssignedTimeSlots.ts --all --apply
+ */
+import 'dotenv/config';
+import {MongoClient, ObjectId} from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const ALL = process.argv.includes('--all');
+const idIn = (id: any) => ({$in: [String(id), new ObjectId(String(id))]});
+
+(async () => {
+  const c = new MongoClient(process.env.DB_URL!);
+  await c.connect();
+  const db = c.db(process.env.DB_NAME || 'vibe');
+  console.log(`MODE: ${APPLY ? 'APPLY (writes)' : 'DRY RUN (read-only)'} · SCOPE: ${ALL ? 'ALL courses' : 'time-slot ACTIVE courses only'}\n`);
+
+  // Which course versions have time-slot booking active?
+  const activeVersions = new Set<string>();
+  const settings = await db.collection('courseSettings').find({}).toArray();
+  for (const s of settings as any[]) {
+    if (s?.settings?.timeslots?.isActive) {
+      activeVersions.add(String(s.courseVersionId));
+    }
+  }
+
+  // Enrollments still carrying legacy assignedTimeSlots.
+  const enrs = await db
+    .collection('enrollment')
+    .find({assignedTimeSlots: {$exists: true, $ne: []}})
+    .toArray();
+
+  const targets: any[] = [];
+  for (const e of enrs as any[]) {
+    const vId = String(e.courseVersionId);
+    const isActive = activeVersions.has(vId);
+    if (!ALL && !isActive) continue; // out of scope
+    const u = await db
+      .collection('users')
+      .findOne({_id: new ObjectId(String(e.userId))}, {projection: {email: 1, firstName: 1, lastName: 1}});
+    targets.push({enrollmentId: e._id, vId, isActive, slots: e.assignedTimeSlots, email: u?.email});
+  }
+
+  console.log(`Enrollments with legacy assignedTimeSlots: ${enrs.length}`);
+  console.log(`In scope to clear: ${targets.length}\n`);
+  targets.forEach(t =>
+    console.log(
+      `  ${t.email ?? t.enrollmentId}  version=${t.vId}  active=${t.isActive}  slots=${JSON.stringify(t.slots)}`,
+    ),
+  );
+
+  if (!APPLY) {
+    console.log(`\nDRY RUN — nothing written. Re-run with --apply to clear these.`);
+    await c.close();
+    return;
+  }
+
+  let cleared = 0;
+  for (const t of targets) {
+    const res = await db
+      .collection('enrollment')
+      .updateOne(
+        {_id: t.enrollmentId},
+        {$set: {assignedTimeSlots: [], updatedAt: new Date()}},
+      );
+    cleared += res.modifiedCount;
+  }
+  console.log(`\nAPPLIED — cleared assignedTimeSlots on ${cleared} enrollment(s).`);
+  await c.close();
+})().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/backend/src/modules/users/scripts/resetMisreservedSlotBookings.ts
+++ b/backend/src/modules/users/scripts/resetMisreservedSlotBookings.ts
@@ -1,0 +1,130 @@
+/**
+ * Repair slot bookings whose stored `hoursReserved` no longer matches their
+ * window length — the fallout of a misconfigured slot (e.g. a window saved as
+ * 08:00–22:00 = 14h that students booked thinking it was 20:00–22:00 = 2h).
+ *
+ * Once the instructor corrects the slot's from/to, existing bookings keep the
+ * stale `hoursReserved` frozen at booking time, so the student's budget is still
+ * over-charged AND the booking sits UNFULFILLED (nobody is active 90% of 14h),
+ * which keeps the red "x hours wasted" warning up. This script re-derives
+ * `hoursReserved` from the booking's CURRENT window and, for bookings that were
+ * wrongly marked UNFULFILLED, restores credit (FULFILLED) since the misconfig
+ * was not the student's fault.
+ *
+ * Detection is self-identifying: any non-cancelled booking where
+ * round(windowHours(from,to)) !== round(hoursReserved) is a mismatch. Legit
+ * bookings always match, so they are never touched.
+ *
+ * READ-ONLY by default (dry run). Pass --apply to write.
+ * Optional scoping:
+ *   --course=<courseId>          limit to one course
+ *   --version=<courseVersionId>  limit to one course version
+ *   --keep-status                only fix hoursReserved, leave status as-is
+ *
+ *   npx ts-node src/modules/users/scripts/resetMisreservedSlotBookings.ts
+ *   npx ts-node src/modules/users/scripts/resetMisreservedSlotBookings.ts --apply
+ *   npx ts-node src/modules/users/scripts/resetMisreservedSlotBookings.ts --course=<id> --apply
+ */
+import 'dotenv/config';
+import {MongoClient, ObjectId} from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const KEEP_STATUS = process.argv.includes('--keep-status');
+const arg = (k: string) =>
+  process.argv.find(a => a.startsWith(`--${k}=`))?.split('=')[1];
+const COURSE = arg('course');
+const VERSION = arg('version');
+const idIn = (id: string) => ({$in: [id, new ObjectId(id)]});
+
+const toMinutes = (t: string) => {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+};
+/** Window length in hours, mirroring SlotBookingService.slotHours (overnight wraps). */
+const windowHours = (from: string, to: string) => {
+  let minutes = toMinutes(to) - toMinutes(from);
+  if (minutes <= 0) minutes += 24 * 60;
+  return Math.round((minutes / 60) * 100) / 100;
+};
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+(async () => {
+  const c = new MongoClient(process.env.DB_URL!);
+  await c.connect();
+  const db = c.db(process.env.DB_NAME || 'vibe');
+  console.log(
+    `MODE: ${APPLY ? 'APPLY (writes)' : 'DRY RUN (read-only)'} · STATUS: ${
+      KEEP_STATUS ? 'leave as-is' : 'UNFULFILLED→FULFILLED on repaired bookings'
+    }${COURSE ? ` · course=${COURSE}` : ''}${VERSION ? ` · version=${VERSION}` : ''}\n`,
+  );
+
+  const q: any = {status: {$ne: 'CANCELLED'}, isDeleted: {$ne: true}};
+  if (COURSE) q.courseId = idIn(COURSE);
+  if (VERSION) q.courseVersionId = idIn(VERSION);
+
+  const bookings = await db.collection('slotBookings').find(q).toArray();
+
+  const targets: any[] = [];
+  for (const b of bookings as any[]) {
+    if (typeof b.from !== 'string' || typeof b.to !== 'string') continue;
+    const expected = windowHours(b.from, b.to);
+    const stored = round2(Number(b.hoursReserved));
+    if (expected === stored) continue; // legit booking — untouched
+    const u = await db
+      .collection('users')
+      .findOne(
+        {_id: new ObjectId(String(b.userId))},
+        {projection: {email: 1}},
+      );
+    targets.push({
+      _id: b._id,
+      email: u?.email,
+      date: b.date,
+      window: `${b.from}-${b.to}`,
+      status: b.status,
+      from: b.from,
+      to: b.to,
+      storedHours: stored,
+      correctHours: expected,
+      refund: round2(stored - expected),
+    });
+  }
+
+  console.log(`Non-cancelled bookings scanned: ${bookings.length}`);
+  console.log(`Mismatched (over/under-reserved): ${targets.length}\n`);
+  let totalRefund = 0;
+  for (const t of targets) {
+    totalRefund += t.refund;
+    console.log(
+      `  ${t.email ?? t._id}  ${t.date} ${t.window}  ` +
+        `hoursReserved ${t.storedHours}→${t.correctHours} (refund ${t.refund}h)  ` +
+        `status=${t.status}${
+          !KEEP_STATUS && t.status === 'UNFULFILLED' ? '→FULFILLED' : ''
+        }`,
+    );
+  }
+  console.log(`\nTotal hours to refund across bookings: ${round2(totalRefund)}h`);
+
+  if (!APPLY) {
+    console.log(`\nDRY RUN — nothing written. Re-run with --apply to repair these.`);
+    await c.close();
+    return;
+  }
+
+  let fixed = 0;
+  for (const t of targets) {
+    const set: any = {hoursReserved: t.correctHours, updatedAt: new Date()};
+    if (!KEEP_STATUS && t.status === 'UNFULFILLED') {
+      set.status = 'FULFILLED';
+    }
+    const res = await db
+      .collection('slotBookings')
+      .updateOne({_id: t._id}, {$set: set});
+    fixed += res.modifiedCount;
+  }
+  console.log(`\nAPPLIED — repaired ${fixed} booking(s).`);
+  await c.close();
+})().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/backend/src/shared/database/interfaces/ISlotBookingRepository.ts
+++ b/backend/src/shared/database/interfaces/ISlotBookingRepository.ts
@@ -59,12 +59,15 @@ export interface ISlotBookingRepository {
 
   /**
    * Total `hoursReserved` a student has LOST to UNFULFILLED (unused) bookings on
-   * a course version — hours spent from the budget with nothing gained.
+   * a course version — hours spent from the budget with nothing gained. Pass
+   * `sinceDate` (YYYY-MM-DD IST) to only count recent misses, so the warning
+   * decays as the student gets back on track rather than being an all-time tally.
    */
   sumUnfulfilledHoursForStudent(
     userId: string,
     courseId: string,
     courseVersionId: string,
+    sinceDate?: string,
     session?: ClientSession,
   ): Promise<number>;
 

--- a/backend/src/shared/database/providers/mongo/repositories/SlotBookingRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SlotBookingRepository.ts
@@ -173,20 +173,24 @@ export class SlotBookingRepository implements ISlotBookingRepository {
     userId: string,
     courseId: string,
     courseVersionId: string,
+    sinceDate?: string,
     session?: ClientSession,
   ): Promise<number> {
     await this.init();
+    const match: Record<string, unknown> = {
+      userId: new ObjectId(userId),
+      courseId: new ObjectId(courseId),
+      courseVersionId: new ObjectId(courseVersionId),
+      status: SlotBookingStatus.UNFULFILLED,
+      isDeleted: {$ne: true},
+    };
+    // `date` is YYYY-MM-DD IST, so a lexical >= is a correct date comparison.
+    if (sinceDate) match.date = {$gte: sinceDate};
     const result = await this.slotBookingsCollection
       .aggregate(
         [
           {
-            $match: {
-              userId: new ObjectId(userId),
-              courseId: new ObjectId(courseId),
-              courseVersionId: new ObjectId(courseVersionId),
-              status: SlotBookingStatus.UNFULFILLED,
-              isDeleted: {$ne: true},
-            },
+            $match: match,
           },
           {$group: {_id: null, total: {$sum: '$hoursReserved'}}},
         ],


### PR DESCRIPTION
Fixes two reported bugs with the "x of y hours wasted" warning.

Misconfigured slot drained budgets — an 08:00–22:00 (14h) slot was booked as if 2h. hoursReserved is frozen at booking time, so correcting the slot didn't refund and the 14h windows stayed permanently UNFULFILLED. Adds a dry-run repair script (resetMisreservedSlotBookings.ts) that recomputes hoursReserved and flips UNFULFILLED → FULFILLED.

Warning stuck after completing properly — fulfillment now also credits finishing early (dense ≥45m) and no-remaining-work (course 100%), and lostHours decays over a rolling 7-day window instead of being all-time.

Testing
10 FulfillmentService (4 new) + 39 SlotBookingService tests pass; tsc clean.

Note
EARLY_FINISH_MIN_MINUTES=45 and the 7-day window change accountability semantics — flagged for @Sudarshan. Repair script writes nothing without --apply.