### PR TITLE
fix: handle MM:SS duration format in GuruSetu feedback export pipeline

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/queries/guruSetuFeedbackExportPipeline.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/queries/guruSetuFeedbackExportPipeline.ts
@@ -6,42 +6,63 @@ const HHMMSS_TO_SECONDS = (path: string) => ({
       parts: { $split: [{ $ifNull: [path, '00:00:00'] }, ':'] },
     },
     in: {
-      $add: [
-        {
-          $multiply: [
-            {
-              $convert: {
-                input: { $arrayElemAt: ['$$parts', 0] },
-                to: 'int',
-                onError: 0,
-                onNull: 0,
-              },
+      $let: {
+        vars: {
+          numParts: { $size: '$$parts' },
+          p0: {
+            $convert: {
+              input: { $arrayElemAt: ['$$parts', 0] },
+              to: 'int',
+              onError: 0,
+              onNull: 0,
             },
-            3600,
-          ],
-        },
-        {
-          $multiply: [
-            {
-              $convert: {
-                input: { $arrayElemAt: ['$$parts', 1] },
-                to: 'int',
-                onError: 0,
-                onNull: 0,
-              },
+          },
+          p1: {
+            $convert: {
+              input: { $arrayElemAt: ['$$parts', 1] },
+              to: 'int',
+              onError: 0,
+              onNull: 0,
             },
-            60,
-          ],
-        },
-        {
-          $convert: {
-            input: { $arrayElemAt: ['$$parts', 2] },
-            to: 'int',
-            onError: 0,
-            onNull: 0,
+          },
+          p2: {
+            $convert: {
+              input: { $arrayElemAt: ['$$parts', 2] },
+              to: 'int',
+              onError: 0,
+              onNull: 0,
+            },
           },
         },
-      ],
+        in: {
+          $switch: {
+            branches: [
+              {
+                // HH:MM:SS
+                case: { $eq: ['$$numParts', 3] },
+                then: {
+                  $add: [
+                    { $multiply: ['$$p0', 3600] },
+                    { $multiply: ['$$p1', 60] },
+                    '$$p2',
+                  ],
+                },
+              },
+              {
+                // MM:SS
+                case: { $eq: ['$$numParts', 2] },
+                then: { $add: [{ $multiply: ['$$p0', 60] }, '$$p1'] },
+              },
+              {
+                // SS only
+                case: { $eq: ['$$numParts', 1] },
+                then: '$$p0',
+              },
+            ],
+            default: 0,
+          },
+        },
+      },
     },
   },
 });


### PR DESCRIPTION
Problem
The HHMMSS_TO_SECONDS function in guruSetuFeedbackExportPipeline.ts assumed all video durations were stored in HH:MM:SS format. However, 13 out of 26 videos in the GuruSetu course are stored in MM:SS format. The old logic always applied the 3-part formula (p0 * 3600 + p1 * 60 + p2), which treated MM:SS values as HH:MM, causing a 60x overestimate of video duration.
As a result, a faculty member who watched a video completely appeared as having watched only ~1.67% in the export instead of ~100%.
Fix
Added a $switch branch inside the aggregation expression that detects the number of parts in the duration string and applies the correct formula:

3 parts → HH:MM:SS (unchanged behavior)
2 parts → MM:SS (new, previously broken)
1 part → seconds only (fallback)

This matches the same format-aware logic already used in parseDurationToSeconds in CourseVersionService.ts.
Testing

Verified against real production data — all 26 GuruSetu videos now compute correct videoDurationSeconds
npx tsc --noEmit passes cleanly
Compared before/after CSV exports — MM:SS videos now show realistic watchPercentage values (e.g. Abirami's "Developing World Class Professionals" went from 1.38% to 82.71%)
HH:MM:SS videos are unaffected

Files changed
backend/src/shared/database/providers/mongo/repositories/queries/guruSetuFeedbackExportPipeline.ts