### PR TITLE
Fix null _id in user creation — generate ObjectId before findOneAndUp…

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
@@ -58,6 +58,9 @@ export class UserRepository implements IUserRepository {
    */
   async create(user: IUser, session?: ClientSession): Promise<string> {
     await this.init();
+    if (!user._id) {
+      user._id = new ObjectId();
+    }
     const result = await this.usersCollection.findOneAndUpdate(
       { firebaseUID: user.firebaseUID },
       { $setOnInsert: user },


### PR DESCRIPTION
Title: Fix null _id in user creation — generate ObjectId before upsert
Description:
"Fix 1  replaced insertOne with findOneAndUpdate + $setOnInsert to prevent duplicate user creation. However, new User(user) explicitly sets _id: null when no _id is provided, and unlike insertOne, findOneAndUpdate does not auto-generate an ObjectId for null _id fields — the null is sent to MongoDB as-is, causing the insert to fail.
Root cause: User.ts constructor sets this._id = data?._id ? new ObjectId(data?._id) : null — so _id is explicitly null, not absent. insertOne would have auto-generated an ObjectId via maybeAddIdToDocuments in the driver. findOneAndUpdate skips this step.
Fix: Generate a new ObjectId before the upsert if _id is not set.