### PR TITLE
fix(submissions): memoize student-question list fns to stop infinite …

### DIFF
--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -2416,7 +2416,11 @@ export function useListStudentQuestions(): {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const request = async (url: string) => {
+  // Memoized so their identity is stable across renders. Callers put these in
+  // useEffect/useCallback deps; unstable references caused an infinite fetch
+  // loop on the teacher review + segment panel. (Setters are stable; all inputs
+  // arrive as arguments.)
+  const request = useCallback(async (url: string) => {
     setLoading(true);
     setError(null);
     try {
@@ -2445,9 +2449,9 @@ export function useListStudentQuestions(): {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const listForCourseVersion = async (
+  const listForCourseVersion = useCallback(async (
     courseId: string,
     courseVersionId: string,
     status: import('@/types/student-question.types').StudentQuestionStatusFilter = 'ALL',
@@ -2458,9 +2462,9 @@ export function useListStudentQuestions(): {
     params.set('limit', String(limit));
     const url = `${import.meta.env.VITE_BASE_URL}/student-questions/courses/${courseId}/versions/${courseVersionId}?${params.toString()}`;
     return await request(url);
-  };
+  }, [request]);
 
-  const listForSegment = async (
+  const listForSegment = useCallback(async (
     courseId: string,
     courseVersionId: string,
     segmentId: string,
@@ -2470,7 +2474,7 @@ export function useListStudentQuestions(): {
     params.set('limit', String(limit));
     const url = `${import.meta.env.VITE_BASE_URL}/student-questions/courses/${courseId}/versions/${courseVersionId}/segments/${segmentId}?${params.toString()}`;
     return await request(url);
-  };
+  }, [request]);
 
   return { listForCourseVersion, listForSegment, loading, error };
 }


### PR DESCRIPTION
# fix: stop infinite fetch loop on teacher student-question views

## What was wrong
The teacher-side student-question pages were fetching data **over and over in an endless loop**, hammering the backend with the same request non-stop.
before:
<img width="1157" height="256" alt="image" src="https://github.com/user-attachments/assets/44b727ed-b6fe-43c6-a449-d05c5b7c4746" />


Affected pages:
- **Teacher review queue** (`StudentQuestionReview`)
- **Segment question panel** (`StudentQuestionPanel`)

## Why it happened
The `useListStudentQuestions` hook returned its fetch functions (`listForCourseVersion`, `listForSegment`) **without memoizing them**. So on every render they were brand-new function references.

Those functions are used inside the components' `useEffect` dependencies. Because their reference changed every render, React thought "the dependency changed" each time → re-ran the effect → fetched again → state updated → re-rendered → new function reference → fetched again… an infinite loop.

## The fix
Wrapped `request`, `listForCourseVersion`, and `listForSegment` in `useCallback` so their references stay **stable across renders**. Now the effect runs once (and only re-runs when a filter actually changes) instead of looping.

Only one file changed: `frontend/src/hooks/hooks.ts`.

## Note
Same root cause as the student-side "My Submissions" loop fixed in #1136 — this PR handles the **teacher side** separately.

## How to verify
1. Open the teacher **Student Question Review** page (and the segment panel).
2. Watch the network tab — the list request should fire **once**, not repeat continuously.
