### PR TITLE
fix: resolve enrollment dropdown aggregation crash on missing/invalid…

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -1611,7 +1611,14 @@ export class EnrollmentRepository {
       { $match: matchStage },
       {
         $addFields: {
-          userIdObj: { $toObjectId: '$userId' },
+          userIdObj: {
+            $convert: {
+              input: '$userId',
+              to: 'objectId',
+              onError: null,
+              onNull: null,
+            },
+          },
         },
       },
       {
@@ -1689,7 +1696,13 @@ export class EnrollmentRepository {
     // 4. Enrich only with basic user data and assigned time slots (no heavy watchTime/itemsGroup lookups)
     paginatedPipeline.push({
       $addFields: {
-        userId: { $toString: '$userInfo._id' },
+        userId: {
+          $cond: [
+            { $ifNull: ['$userInfo._id', false] },
+            { $toString: '$userInfo._id' },
+            '$userId',
+          ],
+        },
         _id: { $toString: '$_id' },
         courseId: { $toString: '$courseId' },
         courseVersionId: { $toString: '$courseVersionId' },
@@ -1787,7 +1800,13 @@ export class EnrollmentRepository {
       {
         $project: {
           _id: { $toString: '$_id' },
-          userId: { $toString: '$userInfo._id' },
+          userId: {
+            $cond: [
+              { $ifNull: ['$userInfo._id', false] },
+              { $toString: '$userInfo._id' },
+              '$userId',
+            ],
+          },
           firstName: '$userInfo.firstName',
           lastName: '$userInfo.lastName',
           email: '$userInfo.email',


### PR DESCRIPTION
# Description

Resolves a `500 Internal Server Error` (often reported by the browser as a `CORS error`) when attempting to open the student selection dropdown in the instructor's **Time Slots Modal** or when exporting student data.

## Root Cause

1. **Vulnerability in Aggregation Pipeline (`userIdObj` parsing)**:
   The pipeline previously used `{ $toObjectId: '$userId' }` to parse the student's `userId`. If any matched enrollment contains a malformed or non-hexadecimal ID string (like an empty string or Firebase UID format), MongoDB throws a parsing error and crashes the aggregation.
2. **Vulnerability in Missing User References (`userInfo._id` parsing)**:
   In production, student user records may be deleted or missing from the `users` collection, resulting in a `null` value for the joined `userInfo` object (due to `$unwind` using `preserveNullAndEmptyArrays: true`). Calling `{ $toString: '$userInfo._id' }` on a null/missing operand causes MongoDB to crash.
3. **Why List View Worked but Dropdown Failed**:
   - The main enrollment page list view queries with a `limit: 10`. Since the string conversion step happens after the pagination limit, it only ran on the first page of active users (which were valid).
   - The modal dropdown queries with `limit: 1000` (or `limit: 841` on production) to retrieve all student options. This processes almost the entire matched set, including any legacy/deleted users, triggering the crash.

## Changes

### `backend`

#### [EnrollmentRepository.ts](file:///d:/programm3d/vibe/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts)

- Replaced `$toObjectId` in `getCourseVersionEnrollments` with a safe `$convert` operator:
  ```json
  userIdObj: {
    $convert: {
      input: '$userId',
      to: 'objectId',
      onError: null,
      onNull: null
    }
  }
- Wrapped the `$toString` call for `$userInfo._id` inside a conditional `$cond` expression in both `getCourseVersionEnrollments` and getStudentProgressDetail methods. If userInfo._id is missing/null, it safely falls back to the original userId string:
```json
userId: {
  $cond: [
    { $ifNull: ['$userInfo._id', false] },
    { $toString: '$userInfo._id' },
    '$userId'
  ]
}