### PR TITLE
fix(sidebar): use Sun icon for light-mode theme toggle

### DIFF
--- a/frontend/src/components/student-sidebar/StudentSidebar.tsx
+++ b/frontend/src/components/student-sidebar/StudentSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { Link, useLocation, useNavigate } from "@tanstack/react-router"
-import { LogOut, Settings, Circle, Moon } from "lucide-react"
+import { LogOut, Settings, Sun, Moon } from "lucide-react"
 import { useTheme } from "next-themes"
 import { useAuthStore } from "@/store/auth-store"
 import { useUserEnrollments } from "@/hooks/hooks"
@@ -170,7 +170,7 @@ export function StudentSidebar() {
                     title="Toggle theme"
                     className={`flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground ${yellowItem}`}
                   >
-                    <Circle className="size-4 dark:hidden" />
+                    <Sun className="size-4 dark:hidden" />
                     <Moon className="hidden size-4 dark:block" />
                   </button>
                 </div>


### PR DESCRIPTION
# fix(sidebar): sun icon for light-mode theme toggle

## What
Replaced the plain `Circle` icon in the sidebar theme toggle with a `Sun` icon for light mode. Dark mode keeps the `Moon` icon.

## Why
A circle didn't communicate "light mode" — a sun reads instantly and matches the moon it pairs with.

## Scope
- `frontend/src/components/student-sidebar/StudentSidebar.tsx` — icon swap only. Toggle logic, `dark:hidden` behaviour, and layout unchanged.
