### PR TITLE
fix: exclude PROJECT items from bulk auto-completion

### DIFF
--- a/backend/src/modules/users/services/ProgressService.ts
+++ b/backend/src/modules/users/services/ProgressService.ts
@@ -9,6 +9,7 @@ import {
   ICourseVersion,
   IWatchTime,
   IProgress,
+  ItemType,
   IVideoDetails,
   ICurrentProgressPath,
   IEnrollment,
@@ -4346,6 +4347,36 @@ class ProgressService extends BaseService {
 
     return allItemIds;
   }
+
+  /**
+   * Item types whose "completion" cannot be inferred from watch-time alone —
+   * they require a real learner-submitted artifact as the source of truth.
+   * PROJECT items are only complete when a project_submissions doc exists;
+   * a synthetic watchTime record must never stand in for that.
+   */
+  private static readonly SUBMISSION_GATED_TYPES: Set<string> = new Set([ItemType.PROJECT]);
+
+  async getSubmissionGatedItemIds(courseVersionId: string): Promise<Set<string>> {
+    const courseVersion = await this.courseRepo.readVersion(courseVersionId);
+    if (!courseVersion) return new Set();
+
+    const gated = new Set<string>();
+    for (const module of courseVersion.modules) {
+      for (const section of module.sections) {
+        const itemGroupId = section.itemsGroupId;
+        if (!itemGroupId) continue;
+        const itemGroup = await this.itemRepo.readItemsGroup(itemGroupId.toString());
+        if (!itemGroup || !itemGroup.items) continue;
+        for (const item of itemGroup.items) {
+          if (item._id && ProgressService.SUBMISSION_GATED_TYPES.has(item.type)) {
+            gated.add(item._id.toString());
+          }
+        }
+      }
+    }
+    return gated;
+  }
+
   async getModuleWiseProgress(
     userId: string,
     courseId: string,
@@ -4634,6 +4665,11 @@ class ProgressService extends BaseService {
       throw new NotFoundError('No items found for this course version');
     }
 
+    // Computed once per course version, not once per user — this only
+    // depends on versionId, so hoisting it out of the user loop avoids
+    // re-walking the course structure for every enrolled student.
+    const gatedItemIds = await this.getSubmissionGatedItemIds(versionId);
+
     for (const userId of enrolledUsersId) {
       let isProceed = true;
       if (lastItem.type == 'QUIZ') {
@@ -4673,19 +4709,24 @@ class ProgressService extends BaseService {
       const missedItemIds = allItemIds.filter(
         itemId => !completedItemIds.includes(itemId),
       );
+
+      const eligibleMissedItemIds = missedItemIds.filter(
+        itemId => !gatedItemIds.has(itemId),
+      );
+
       console.log(`UserId: ${userId}`);
-      console.log(`Missed Items:`, missedItemIds);
-      console.log(`Missed Items Count: ${missedItemIds.length}`);
+      console.log(`Missed Items:`, eligibleMissedItemIds);
+      console.log(`Missed Items Count: ${eligibleMissedItemIds.length}`);
       console.log(`Completed Items length:`, completedItemIds.length);
       console.log(`Total Items length:`, allItemIds.length);
 
-      if (!missedItemIds.length) continue;
+      if (!eligibleMissedItemIds.length) continue;
 
       await this.progressRepository.addBulkWatchTime(
         userId,
         courseId,
         versionId,
-        missedItemIds,
+        eligibleMissedItemIds,
       );
     }
   }


### PR DESCRIPTION
POST /progress/watch-time/bulk was marking PROJECT items as complete once a student passed the final quiz, without checking for an actual submission. This let students show 100% completion with no real project on file.
Fix: added a filter to exclude PROJECT-type items from the auto-completion backfill in createBulkWatchiTimeDocs().