### PR TITLE
feat(discussion): add cohort-scoped peer discussion forum

### DIFF
--- a/backend/src/modules/discussions/controllers/DiscussionController.ts
+++ b/backend/src/modules/discussions/controllers/DiscussionController.ts
@@ -1,0 +1,272 @@
+import 'reflect-metadata';
+import {
+    JsonController,
+    Post,
+    Delete,
+    Get,
+    HttpCode,
+    Param,
+    Body,
+    Authorized,
+    CurrentUser,
+    QueryParams,
+    NotFoundError,
+    BadRequestError
+} from 'routing-controllers';
+import { injectable, inject } from 'inversify';
+import { OpenAPI } from 'routing-controllers-openapi';
+import { ObjectId } from 'mongodb';
+import { IsString, IsOptional, MaxLength } from 'class-validator';
+import { MongoDatabase } from '#shared/index.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { IUser } from '#root/shared/interfaces/models.js';
+
+export class CreateThreadDto {
+    @IsString()
+    courseId!: string;
+
+    @IsString()
+    @IsOptional()
+    cohortId?: string;
+
+    @IsString()
+    @MaxLength(120)
+    title!: string;
+
+    @IsString()
+    body!: string;
+}
+
+export class CreateReplyDto {
+    @IsString()
+    body!: string;
+}
+
+export class GetThreadsQueryParams {
+    @IsString()
+    courseId!: string;
+
+    @IsString()
+    @IsOptional()
+    cohortId?: string;
+}
+
+@OpenAPI({
+    tags: ['Discussions'],
+})
+@JsonController('/discussions')
+@injectable()
+@Authorized()
+export class DiscussionController {
+    constructor(
+        @inject(GLOBAL_TYPES.Database)
+        private readonly mongoDb: MongoDatabase
+    ) {}
+
+    private async getThreadsCollection() {
+        return await this.mongoDb.getCollection('discussion_threads');
+    }
+
+    private async getRepliesCollection() {
+        return await this.mongoDb.getCollection('discussion_replies');
+    }
+
+    // 1. POST /discussions/threads
+    @Post('/threads')
+    @HttpCode(201)
+    async createThread(
+        @Body() body: CreateThreadDto,
+        @CurrentUser() user: IUser
+    ) {
+        const threadsColl = await this.getThreadsCollection();
+        const newThread = {
+            courseId: body.courseId,
+            cohortId: body.cohortId || '',
+            title: body.title,
+            body: body.body,
+            author: {
+                uid: user._id.toString(),
+                name: `${user.firstName}${user.lastName ? ' ' + user.lastName : ''}`,
+                avatar: (user as any).avatar || ''
+            },
+            replyCount: 0,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            lastActivityAt: new Date().toISOString()
+        };
+
+        const result = await threadsColl.insertOne(newThread);
+        return {
+            ...newThread,
+            _id: result.insertedId.toString()
+        };
+    }
+
+    // 2. GET /discussions/threads?courseId=&cohortId=
+    @Get('/threads')
+    async getThreads(
+        @QueryParams() query: GetThreadsQueryParams
+    ) {
+        const threadsColl = await this.getThreadsCollection();
+        const filter: any = { courseId: query.courseId };
+        if (query.cohortId) {
+            filter.cohortId = query.cohortId;
+        }
+
+        const threadsList = await threadsColl
+            .find(filter)
+            .sort({ lastActivityAt: -1, createdAt: -1 })
+            .toArray();
+
+        return threadsList.map(t => ({
+            ...t,
+            _id: t._id.toString()
+        }));
+    }
+
+    // 3. GET /discussions/threads/:threadId
+    @Get('/threads/:threadId')
+    async getThread(@Param('threadId') threadId: string) {
+        if (!ObjectId.isValid(threadId)) {
+            throw new BadRequestError('Invalid thread ID');
+        }
+
+        const threadsColl = await this.getThreadsCollection();
+        const repliesColl = await this.getRepliesCollection();
+
+        const thread = await threadsColl.findOne({ _id: new ObjectId(threadId) });
+        if (!thread) {
+            throw new NotFoundError('Thread not found');
+        }
+
+        const threadReplies = await repliesColl
+            .find({ threadId })
+            .sort({ createdAt: 1 })
+            .toArray();
+
+        return {
+            ...thread,
+            _id: thread._id.toString(),
+            replies: threadReplies.map(r => ({
+                ...r,
+                _id: r._id.toString()
+            }))
+        };
+    }
+
+    // 4. POST /discussions/threads/:threadId/replies
+    @Post('/threads/:threadId/replies')
+    @HttpCode(201)
+    async createReply(
+        @Param('threadId') threadId: string,
+        @Body() body: CreateReplyDto,
+        @CurrentUser() user: IUser
+    ) {
+        if (!ObjectId.isValid(threadId)) {
+            throw new BadRequestError('Invalid thread ID');
+        }
+
+        const threadsColl = await this.getThreadsCollection();
+        const repliesColl = await this.getRepliesCollection();
+
+        const thread = await threadsColl.findOne({ _id: new ObjectId(threadId) });
+        if (!thread) {
+            throw new NotFoundError('Thread not found');
+        }
+
+        const newReply = {
+            threadId,
+            body: body.body,
+            author: {
+                uid: user._id.toString(),
+                name: `${user.firstName}${user.lastName ? ' ' + user.lastName : ''}`,
+                avatar: (user as any).avatar || ''
+            },
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+        };
+
+        const result = await repliesColl.insertOne(newReply);
+
+        // Update reply count and last activity timestamp on the thread
+        await threadsColl.updateOne(
+            { _id: new ObjectId(threadId) },
+            {
+                $inc: { replyCount: 1 },
+                $set: { lastActivityAt: new Date().toISOString(), updatedAt: new Date().toISOString() }
+            }
+        );
+
+        return {
+            ...newReply,
+            _id: result.insertedId.toString()
+        };
+    }
+
+    // 5. DELETE /discussions/threads/:threadId
+    @Delete('/threads/:threadId')
+    @HttpCode(204)
+    async deleteThread(
+        @Param('threadId') threadId: string,
+        @CurrentUser() user: IUser
+    ) {
+        if (!ObjectId.isValid(threadId)) {
+            throw new BadRequestError('Invalid thread ID');
+        }
+
+        const threadsColl = await this.getThreadsCollection();
+        const repliesColl = await this.getRepliesCollection();
+
+        const thread = await threadsColl.findOne({ _id: new ObjectId(threadId) });
+        if (!thread) {
+            throw new NotFoundError('Thread not found');
+        }
+
+        // Only author (or admin) can delete
+        if (thread.author.uid !== user._id.toString() && user.roles !== 'admin') {
+            throw new BadRequestError('You do not have permission to delete this thread');
+        }
+
+        await threadsColl.deleteOne({ _id: new ObjectId(threadId) });
+        await repliesColl.deleteMany({ threadId });
+
+        return null;
+    }
+
+    // 6. DELETE /discussions/replies/:replyId
+    @Delete('/replies/:replyId')
+    @HttpCode(204)
+    async deleteReply(
+        @Param('replyId') replyId: string,
+        @CurrentUser() user: IUser
+    ) {
+        if (!ObjectId.isValid(replyId)) {
+            throw new BadRequestError('Invalid reply ID');
+        }
+
+        const threadsColl = await this.getThreadsCollection();
+        const repliesColl = await this.getRepliesCollection();
+
+        const reply = await repliesColl.findOne({ _id: new ObjectId(replyId) });
+        if (!reply) {
+            throw new NotFoundError('Reply not found');
+        }
+
+        // Only author (or admin) can delete
+        if (reply.author.uid !== user._id.toString() && user.roles !== 'admin') {
+            throw new BadRequestError('You do not have permission to delete this reply');
+        }
+
+        await repliesColl.deleteOne({ _id: new ObjectId(replyId) });
+
+        // Decrement reply count on the thread
+        if (ObjectId.isValid(reply.threadId)) {
+            await threadsColl.updateOne(
+                { _id: new ObjectId(reply.threadId) },
+                { $inc: { replyCount: -1 } }
+            );
+        }
+
+        return null;
+    }
+}

--- a/backend/src/modules/discussions/index.ts
+++ b/backend/src/modules/discussions/index.ts
@@ -1,0 +1,38 @@
+import { Container, ContainerModule } from 'inversify';
+import { sharedContainerModule } from '#root/container.js';
+import { InversifyAdapter } from '#root/inversify-adapter.js';
+import {
+    RoutingControllersOptions,
+    useContainer,
+} from 'routing-controllers';
+import { DiscussionController } from './controllers/DiscussionController.js';
+
+export const discussionsModuleControllers: Function[] = [
+    DiscussionController,
+];
+
+export const discussionsModuleValidators: Function[] = [];
+
+export const discussionsContainerModules: ContainerModule[] = [
+    new ContainerModule(options => {
+        options.bind(DiscussionController).toSelf().inSingletonScope();
+    }),
+    sharedContainerModule,
+];
+
+export async function setupDiscussionsContainer(): Promise<void> {
+    const container = new Container();
+    await container.load(...discussionsContainerModules);
+    const inversifyAdapter = new InversifyAdapter(container);
+    useContainer(inversifyAdapter);
+}
+
+export const discussionsModuleOptions: RoutingControllersOptions = {
+    controllers: [DiscussionController],
+    middlewares: [],
+    defaultErrorHandler: true,
+    authorizationChecker: async function () {
+        return true;
+    },
+    validation: true,
+};

--- a/frontend/src/app/pages/student/Discussions.tsx
+++ b/frontend/src/app/pages/student/Discussions.tsx
@@ -1,0 +1,660 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { useAuthStore } from "@/store/auth-store";
+import { useUserEnrollments } from "@/hooks/hooks";
+import { bufferToHex } from "@/utils/helpers";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/EmptyState";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  ArrowLeft,
+  MessageSquare,
+  Trash2,
+  Send,
+  Loader2,
+  MessageCircle,
+  Plus
+} from "lucide-react";
+import {
+  useListDiscussionThreads,
+  useGetDiscussionThread,
+  useCreateDiscussionThread,
+  useCreateDiscussionReply,
+  useDeleteDiscussionThread,
+  useDeleteDiscussionReply,
+  type DiscussionThread,
+  type DiscussionReply
+} from "@/hooks/use-discussion";
+
+interface NewThreadFormValues {
+  title: string;
+  body: string;
+}
+
+function formatRelativeTime(dateString: string | undefined): string {
+  if (!dateString) return "";
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  
+  if (Number.isNaN(date.getTime()) || diffMs < 0) {
+    return dateString;
+  }
+  
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+  
+  if (diffSecs < 60) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return "yesterday";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  
+  return date.toLocaleDateString();
+}
+
+export default function DiscussionsPage() {
+  const { user, token } = useAuthStore();
+  const [activeCourseId, setActiveCourseId] = useState<string | null>(null);
+  const [activeCohortId, setActiveCohortId] = useState<string | null>(null);
+  const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
+  const [view, setView] = useState<"list" | "detail" | "create">("list");
+
+  // Load student enrollments to establish course context
+  const { data: enrollmentsData, isLoading: enrollmentsLoading } = useUserEnrollments(1, 100, !!token);
+
+  const enrollments = useMemo(() => {
+    return (enrollmentsData?.enrollments || []).filter(
+      (e: any) => e.status === "ACTIVE" || (e.percentCompleted ?? 0) !== 100
+    );
+  }, [enrollmentsData]);
+
+  // Set initial course and cohort
+  useEffect(() => {
+    if (enrollments.length > 0 && !activeCourseId) {
+      const first = enrollments[0];
+      const courseIdHex = bufferToHex(first.courseId as string);
+      const cohortIdHex = first.cohortId
+        ? (typeof first.cohortId === "string" ? first.cohortId : bufferToHex(first.cohortId as any))
+        : "";
+      setActiveCourseId(courseIdHex);
+      setActiveCohortId(cohortIdHex || null);
+    }
+  }, [enrollments, activeCourseId]);
+
+  const activeCourseName = useMemo(() => {
+    if (!activeCourseId) return "";
+    const current = enrollments.find(e => bufferToHex(e.courseId as string) === activeCourseId);
+    return current?.course?.name || "Selected Course";
+  }, [enrollments, activeCourseId]);
+
+  const handleCourseChange = (courseIdHex: string) => {
+    const selected = enrollments.find(e => bufferToHex(e.courseId as string) === courseIdHex);
+    if (selected) {
+      const cohortIdHex = selected.cohortId
+        ? (typeof selected.cohortId === "string" ? selected.cohortId : bufferToHex(selected.cohortId as any))
+        : "";
+      setActiveCourseId(courseIdHex);
+      setActiveCohortId(cohortIdHex || null);
+      setActiveThreadId(null);
+      setView("list");
+    }
+  };
+
+  // Discussions API integrations
+  const {
+    threads,
+    setThreads,
+    loading: threadsLoading,
+    error: threadsError,
+    refetch: refetchThreads
+  } = useListDiscussionThreads(activeCourseId, activeCohortId);
+
+  const {
+    thread,
+    replies,
+    setReplies,
+    setThread,
+    loading: detailLoading,
+    error: detailError,
+    refetch: refetchThread
+  } = useGetDiscussionThread(activeThreadId);
+
+  const { createThread } = useCreateDiscussionThread();
+  const { createReply } = useCreateDiscussionReply();
+  const { deleteThread } = useDeleteDiscussionThread();
+  const { deleteReply } = useDeleteDiscussionReply();
+
+  // Create Thread Form setup
+  const { register: registerThread, handleSubmit: handleSubmitThread, reset: resetThreadForm, formState: { errors: threadErrors } } = useForm<NewThreadFormValues>({
+    defaultValues: { title: "", body: "" }
+  });
+
+  // Reply Form setup
+  const { register: registerReply, handleSubmit: handleSubmitReply, reset: resetReplyForm } = useForm<{ replyBody: string }>({
+    defaultValues: { replyBody: "" }
+  });
+
+  const handlePostThread = async (data: NewThreadFormValues) => {
+    if (!activeCourseId) {
+      toast.error("No course context selected");
+      return;
+    }
+
+    const tempId = `temp-${Date.now()}`;
+    const optimisticThread: DiscussionThread = {
+      _id: tempId,
+      courseId: activeCourseId,
+      cohortId: activeCohortId,
+      title: data.title,
+      body: data.body,
+      author: {
+        uid: user?.uid || user?.id || "me",
+        name: user?.name || "Student",
+        avatar: user?.avatar
+      },
+      replyCount: 0,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastActivityAt: new Date().toISOString()
+    };
+
+    // Prepend Optimistic Thread
+    setThreads(prev => [optimisticThread, ...prev]);
+    setView("list");
+    resetThreadForm();
+
+    try {
+      const response = await createThread({
+        courseId: activeCourseId,
+        cohortId: activeCohortId,
+        title: data.title,
+        body: data.body
+      });
+      // Replace optimistic thread with real data
+      setThreads(prev => prev.map(t => (t._id === tempId ? response : t)));
+      toast.success("Thread posted successfully");
+    } catch (err: any) {
+      // Rollback
+      setThreads(prev => prev.filter(t => t._id !== tempId));
+      toast.error(err.message || "Failed to post thread. Placed back to editor.");
+      // Put content back into form
+      resetThreadForm({ title: data.title, body: data.body });
+      setView("create");
+    }
+  };
+
+  const handlePostReply = async (data: { replyBody: string }) => {
+    if (!activeThreadId || !data.replyBody.trim()) return;
+
+    const tempId = `temp-reply-${Date.now()}`;
+    const optimisticReply: DiscussionReply = {
+      _id: tempId,
+      threadId: activeThreadId,
+      body: data.replyBody,
+      author: {
+        uid: user?.uid || user?.id || "me",
+        name: user?.name || "Student",
+        avatar: user?.avatar
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+
+    // Append Optimistic Reply
+    setReplies(prev => [...prev, optimisticReply]);
+    if (thread) {
+      setThread({
+        ...thread,
+        replyCount: thread.replyCount + 1
+      });
+    }
+    resetReplyForm();
+
+    try {
+      const response = await createReply(activeThreadId, data.replyBody);
+      setReplies(prev => prev.map(r => (r._id === tempId ? response : r)));
+    } catch (err: any) {
+      // Rollback reply
+      setReplies(prev => prev.filter(r => r._id !== tempId));
+      if (thread) {
+        setThread({
+          ...thread,
+          replyCount: Math.max(0, thread.replyCount - 1)
+        });
+      }
+      toast.error(err.message || "Failed to submit reply");
+      resetReplyForm({ replyBody: data.replyBody });
+    }
+  };
+
+  const handleDeleteThread = async (threadIdToDelete: string) => {
+    const threadToDelete = threads.find(t => t._id === threadIdToDelete);
+    if (!threadToDelete) return;
+
+    if (!confirm("Are you sure you want to delete this discussion thread?")) return;
+
+    // Optimistic Deletion
+    setThreads(prev => prev.filter(t => t._id !== threadIdToDelete));
+    if (activeThreadId === threadIdToDelete) {
+      setActiveThreadId(null);
+      setView("list");
+    }
+
+    try {
+      await deleteThread(threadIdToDelete);
+      toast.success("Thread deleted successfully");
+    } catch (err: any) {
+      // Revert optimistic delete
+      setThreads(prev => [threadToDelete, ...prev].sort((a, b) => {
+        return new Date(b.lastActivityAt || b.createdAt).getTime() - new Date(a.lastActivityAt || a.createdAt).getTime();
+      }));
+      toast.error(err.message || "Failed to delete thread");
+    }
+  };
+
+  const handleDeleteReply = async (replyIdToDelete: string) => {
+    const replyToDelete = replies.find(r => r._id === replyIdToDelete);
+    if (!replyToDelete) return;
+
+    if (!confirm("Are you sure you want to delete this reply?")) return;
+
+    // Optimistic Deletion
+    setReplies(prev => prev.filter(r => r._id !== replyIdToDelete));
+    if (thread) {
+      setThread({ ...thread, replyCount: Math.max(0, thread.replyCount - 1) });
+    }
+
+    try {
+      await deleteReply(replyIdToDelete);
+    } catch (err: any) {
+      // Revert optimistic delete
+      setReplies(prev => [...prev, replyToDelete]);
+      if (thread) {
+        setThread({ ...thread, replyCount: thread.replyCount + 1 });
+      }
+      toast.error(err.message || "Failed to delete reply");
+    }
+  };
+
+  if (enrollmentsLoading) {
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Discussion Forum" description="Loading forum contexts..." />
+        <div className="space-y-4">
+          <Skeleton className="h-10 w-[240px]" />
+          <Skeleton className="h-[200px] w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (enrollments.length === 0) {
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Discussion Forum" description="Collaborate with your classmates." />
+        <EmptyState
+          title="No Course Enrollments Found"
+          description="You need to be enrolled in a course to access discussion forums."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 pb-12">
+      {/* Forum Course Select and Header */}
+      <PageHeader
+        title="Discussion Forum"
+        description={`Active Class Forum: ${activeCourseName}`}
+        actions={
+          <div className="flex items-center gap-2">
+            <Select value={activeCourseId || ""} onValueChange={handleCourseChange}>
+              <SelectTrigger className="w-[200px] bg-white dark:bg-[#17171a] border-border text-foreground">
+                <SelectValue placeholder="Select Course" />
+              </SelectTrigger>
+              <SelectContent>
+                {enrollments.map(e => {
+                  const idHex = bufferToHex(e.courseId as string);
+                  return (
+                    <SelectItem key={idHex} value={idHex}>
+                      {e.course?.name || "Unnamed Course"}
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+
+            {view === "list" && (
+              <Button
+                onClick={() => setView("create")}
+                className="bg-primary text-primary-foreground hover:bg-accent hover:text-accent-foreground font-semibold"
+              >
+                <Plus className="mr-1.5 h-4 w-4" />
+                New Thread
+              </Button>
+            )}
+          </div>
+        }
+      />
+
+      {/* VIEW: THREAD LIST */}
+      {view === "list" && (
+        <div className="space-y-4">
+          {threadsLoading ? (
+            <div className="space-y-3">
+              {[1, 2, 3].map(n => (
+                <Card key={n} className="border border-border">
+                  <CardContent className="p-4 space-y-3">
+                    <div className="flex gap-2 items-center">
+                      <Skeleton className="h-5 w-5 rounded-full" />
+                      <Skeleton className="h-4 w-24" />
+                    </div>
+                    <Skeleton className="h-5 w-[60%]" />
+                    <div className="flex gap-4">
+                      <Skeleton className="h-4 w-12" />
+                      <Skeleton className="h-4 w-20" />
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : threadsError ? (
+            <div className="p-6 text-center text-destructive border border-destructive/20 rounded-lg bg-destructive/5">
+              {threadsError}
+            </div>
+          ) : threads.length === 0 ? (
+            <EmptyState
+              title="No discussions yet"
+              description="Be the first to start a discussion thread for this class!"
+              actionText="Start a Thread"
+              onAction={() => setView("create")}
+            />
+          ) : (
+            <div className="grid gap-3">
+              {threads.map(t => (
+                <Card
+                  key={t._id}
+                  className="border border-border hover:border-primary/40 dark:hover:border-primary/40 cursor-pointer transition-all bg-white dark:bg-[#17171a]"
+                  onClick={() => {
+                    setActiveThreadId(t._id);
+                    setView("detail");
+                  }}
+                >
+                  <CardContent className="p-4 flex items-start justify-between gap-4">
+                    <div className="space-y-2 min-w-0 flex-1">
+                      <h3 className="font-semibold text-foreground text-sm sm:text-base truncate group-hover:text-primary">
+                        {t.title}
+                      </h3>
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
+                        <div className="flex items-center gap-1.5">
+                          <Avatar className="h-5 w-5 border border-border/20">
+                            <AvatarImage src={t.author.avatar} alt={t.author.name} />
+                            <AvatarFallback className="bg-primary/10 text-[9px] font-bold text-primary">
+                              {t.author.name.charAt(0).toUpperCase()}
+                            </AvatarFallback>
+                          </Avatar>
+                          <span className="font-medium text-foreground/80">{t.author.name}</span>
+                        </div>
+                        <span>•</span>
+                        <span title={new Date(t.createdAt).toLocaleString()}>
+                          active {formatRelativeTime(t.lastActivityAt || t.createdAt)}
+                        </span>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-4 shrink-0">
+                      <div className="flex items-center gap-1 text-muted-foreground">
+                        <MessageSquare className="h-4 w-4" />
+                        <span className="text-xs font-semibold">{t.replyCount}</span>
+                      </div>
+                      {(user?.uid === t.author.uid || user?.id === t.author.uid) && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 text-muted-foreground hover:text-destructive hover:bg-destructive/5"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleDeleteThread(t._id);
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* VIEW: CREATE THREAD */}
+      {view === "create" && (
+        <Card className="border border-border bg-white dark:bg-[#17171a]">
+          <CardContent className="p-6">
+            <div className="flex items-center gap-2 mb-6">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-1 text-muted-foreground"
+                onClick={() => setView("list")}
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back to List
+              </Button>
+              <h2 className="text-base font-bold text-foreground">Create New Discussion Thread</h2>
+            </div>
+
+            <form onSubmit={handleSubmitThread(handlePostThread)} className="space-y-4">
+              <div className="space-y-1.5">
+                <Input
+                  placeholder="Thread Title"
+                  className={threadErrors.title ? "border-destructive focus-visible:ring-destructive" : ""}
+                  {...registerThread("title", {
+                    required: "A title is required to start a thread",
+                    maxLength: { value: 120, message: "Title cannot exceed 120 characters" }
+                  })}
+                />
+                {threadErrors.title && (
+                  <p className="text-xs text-destructive">{threadErrors.title.message}</p>
+                )}
+              </div>
+
+              <div className="space-y-1.5">
+                <Textarea
+                  placeholder="Tell us what is on your mind... Add details, questions, or links."
+                  className={`min-h-[160px] ${threadErrors.body ? "border-destructive focus-visible:ring-destructive" : ""}`}
+                  {...registerThread("body", { required: "Thread content/body is required" })}
+                />
+                {threadErrors.body && (
+                  <p className="text-xs text-destructive">{threadErrors.body.message}</p>
+                )}
+              </div>
+
+              <div className="flex justify-end gap-3 pt-2">
+                <Button variant="outline" type="button" onClick={() => setView("list")}>
+                  Cancel
+                </Button>
+                <Button type="submit" className="bg-primary text-primary-foreground hover:bg-accent font-semibold">
+                  Publish Thread
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* VIEW: THREAD DETAILS & REPLIES */}
+      {view === "detail" && (
+        <div className="space-y-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1 text-muted-foreground hover:text-foreground"
+            onClick={() => {
+              setActiveThreadId(null);
+              setView("list");
+            }}
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Discussions
+          </Button>
+
+          {detailLoading && !thread ? (
+            <Card className="border border-border">
+              <CardContent className="p-6 space-y-4">
+                <Skeleton className="h-6 w-[40%]" />
+                <Skeleton className="h-4 w-[25%]" />
+                <Skeleton className="h-20 w-full" />
+              </CardContent>
+            </Card>
+          ) : detailError ? (
+            <div className="p-6 text-center text-destructive border border-destructive/20 rounded-lg bg-destructive/5">
+              {detailError}
+            </div>
+          ) : !thread ? (
+            <EmptyState title="Thread Not Found" description="The thread may have been deleted or moved." />
+          ) : (
+            <div className="space-y-6">
+              {/* Main Post Thread Card */}
+              <Card className="border border-border bg-white dark:bg-[#17171a] shadow-sm">
+                <CardContent className="p-6 space-y-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex items-center gap-3">
+                      <Avatar className="h-9 w-9 border border-border/20">
+                        <AvatarImage src={thread.author.avatar} alt={thread.author.name} />
+                        <AvatarFallback className="bg-primary/10 text-xs font-bold text-primary">
+                          {thread.author.name.charAt(0).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <h4 className="text-sm font-semibold text-foreground">{thread.author.name}</h4>
+                        <p
+                          className="text-[11px] text-muted-foreground"
+                          title={new Date(thread.createdAt).toLocaleString()}
+                        >
+                          posted {formatRelativeTime(thread.createdAt)}
+                        </p>
+                      </div>
+                    </div>
+
+                    {(user?.uid === thread.author.uid || user?.id === thread.author.uid) && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground hover:text-destructive hover:bg-destructive/5"
+                        onClick={() => handleDeleteThread(thread._id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <h2 className="text-base sm:text-lg font-bold text-foreground leading-tight">
+                      {thread.title}
+                    </h2>
+                    <p className="text-sm text-foreground/90 whitespace-pre-wrap leading-relaxed">
+                      {thread.body}
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Replies Divider / Counter */}
+              <div className="flex items-center gap-2 border-b pb-2">
+                <MessageCircle className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-semibold text-foreground">
+                  {replies.length} {replies.length === 1 ? "Reply" : "Replies"}
+                </span>
+              </div>
+
+              {/* Replies List */}
+              <div className="space-y-3">
+                {replies.map(r => (
+                  <Card key={r._id} className="border border-border bg-white dark:bg-[#17171a]/55">
+                    <CardContent className="p-4 space-y-3">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex items-center gap-2.5">
+                          <Avatar className="h-7 w-7 border border-border/20">
+                            <AvatarImage src={r.author.avatar} alt={r.author.name} />
+                            <AvatarFallback className="bg-primary/10 text-[10px] font-bold text-primary">
+                              {r.author.name.charAt(0).toUpperCase()}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div>
+                            <span className="text-xs font-semibold text-foreground">{r.author.name}</span>
+                            <span
+                              className="text-[10px] text-muted-foreground ml-2"
+                              title={new Date(r.createdAt).toLocaleString()}
+                            >
+                              {formatRelativeTime(r.createdAt)}
+                            </span>
+                          </div>
+                        </div>
+
+                        {(user?.uid === r.author.uid || user?.id === r.author.uid) && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-muted-foreground hover:text-destructive hover:bg-destructive/5"
+                            onClick={() => handleDeleteReply(r._id)}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                      </div>
+
+                      <p className="text-xs sm:text-sm text-foreground/90 whitespace-pre-wrap leading-relaxed">
+                        {r.body}
+                      </p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+
+              {/* Reply Composer Card */}
+              <Card className="border border-border bg-white dark:bg-[#17171a] shadow-sm">
+                <CardContent className="p-4">
+                  <form onSubmit={handleSubmitReply(handlePostReply)} className="flex gap-2 items-end">
+                    <div className="flex-1">
+                      <Textarea
+                        placeholder="Write a reply..."
+                        className="min-h-[80px] text-sm resize-none focus-visible:ring-primary"
+                        {...registerReply("replyBody", { required: true })}
+                      />
+                    </div>
+                    <Button
+                      type="submit"
+                      size="icon"
+                      className="h-10 w-10 shrink-0 bg-primary text-primary-foreground hover:bg-accent"
+                    >
+                      <Send className="h-4 w-4" />
+                    </Button>
+                  </form>
+                </CardContent>
+              </Card>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/routes/router.tsx
+++ b/frontend/src/app/routes/router.tsx
@@ -70,6 +70,7 @@ import StudentSubmissions from '@/app/pages/student/hp-system/submissions'
 import StudentMyLedgerPage from '@/app/pages/student/hp-system/student-ledger'
 import StudentActivityDetail from '@/app/pages/student/hp-system/activity-detail'
 import NotificationsPage from '@/app/pages/shared/NotificationsPage'
+import DiscussionsPage from '@/app/pages/student/Discussions'
 
 // Root route with error and notFound handling
 const rootRoute = new RootRoute({
@@ -536,6 +537,13 @@ const studentMySubmissionsRoute = new Route({
   component: StudentMySubmissions,
 });
 
+// Student discussions route
+const studentDiscussionsRoute = new Route({
+  getParentRoute: () => studentLayoutRoute,
+  path: '/discussions',
+  component: DiscussionsPage,
+});
+
 // Student cohorts route
 const studentHpSystemCohortsRoute = new Route({
   getParentRoute: () => studentLayoutRoute,
@@ -724,6 +732,7 @@ const routeTree = rootRoute.addChildren([
     studentHpSystemSubmissionsRoute,
     studentHpSystemLedgerRoute,
     studentNotificationsRoute,
+    studentDiscussionsRoute,
   ]),
   coursePageRoute,
 ]);

--- a/frontend/src/components/student-sidebar/nav-items.tsx
+++ b/frontend/src/components/student-sidebar/nav-items.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Flag, BookOpen, Megaphone, FileText, SquareTerminal, type LucideIcon } from "lucide-react";
+import { LayoutDashboard, Flag, BookOpen, Megaphone, FileText, SquareTerminal, MessageSquare, type LucideIcon } from "lucide-react";
 
 export type StudentNavItem = {
   /** Stable identifier — used for keys and conditional logic. */
@@ -23,4 +23,5 @@ export const STUDENT_NAV_ITEMS: StudentNavItem[] = [
   { key: "hp-system", title: "HP System", to: "/student/hp-system/cohorts", icon: SquareTerminal, requires: "hpSystem" },
   { key: "announcements", title: "Announcements", to: "/student/announcements", icon: Megaphone, indicator: "announcements" },
   { key: "submissions", title: "My Submissions", to: "/student/submissions", icon: FileText },
+  { key: "discussions", title: "Discussion Forum", to: "/student/discussions", icon: MessageSquare },
 ];

--- a/frontend/src/hooks/use-discussion.ts
+++ b/frontend/src/hooks/use-discussion.ts
@@ -1,0 +1,257 @@
+import { useState, useEffect, useCallback } from "react";
+
+export interface DiscussionReply {
+  _id: string;
+  threadId: string;
+  body: string;
+  author: {
+    uid: string;
+    name: string;
+    avatar?: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DiscussionThread {
+  _id: string;
+  courseId: string;
+  cohortId: string;
+  title: string;
+  body: string;
+  author: {
+    uid: string;
+    name: string;
+    avatar?: string;
+  };
+  replyCount: number;
+  createdAt: string;
+  updatedAt: string;
+  lastActivityAt: string;
+  replies?: DiscussionReply[];
+}
+
+const getHeaders = () => {
+  const token = localStorage.getItem("firebase-auth-token");
+  return {
+    "Content-Type": "application/json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+};
+
+export function useListDiscussionThreads(courseId: string | null, cohortId: string | null) {
+  const [threads, setThreads] = useState<DiscussionThread[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchThreads = useCallback(async () => {
+    if (!courseId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ courseId });
+      if (cohortId) params.append("cohortId", cohortId);
+
+      const url = `${import.meta.env.VITE_BASE_URL}/discussions/threads?${params.toString()}`;
+      const response = await fetch(url, {
+        method: "GET",
+        headers: getHeaders(),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load threads: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      // Sort most-recent-first (by lastActivityAt or createdAt)
+      const sorted = (Array.isArray(data) ? data : []).sort((a, b) => {
+        const timeA = new Date(a.lastActivityAt || a.createdAt).getTime();
+        const timeB = new Date(b.lastActivityAt || b.createdAt).getTime();
+        return timeB - timeA;
+      });
+      setThreads(sorted);
+    } catch (err: any) {
+      setError(err.message || "Failed to load discussions");
+    } finally {
+      setLoading(false);
+    }
+  }, [courseId, cohortId]);
+
+  useEffect(() => {
+    void fetchThreads();
+  }, [fetchThreads]);
+
+  return { threads, setThreads, loading, error, refetch: fetchThreads };
+}
+
+export function useGetDiscussionThread(threadId: string | null) {
+  const [thread, setThread] = useState<DiscussionThread | null>(null);
+  const [replies, setReplies] = useState<DiscussionReply[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchThreadDetails = useCallback(async () => {
+    if (!threadId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/discussions/threads/${threadId}`;
+      const response = await fetch(url, {
+        method: "GET",
+        headers: getHeaders(),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load thread details: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      setThread(data);
+      // Flat list of replies - backend detail GET typically includes nested replies
+      setReplies(data.replies || []);
+    } catch (err: any) {
+      setError(err.message || "Failed to load thread details");
+    } finally {
+      setLoading(false);
+    }
+  }, [threadId]);
+
+  useEffect(() => {
+    void fetchThreadDetails();
+  }, [fetchThreadDetails]);
+
+  return { thread, replies, setReplies, setThread, loading, error, refetch: fetchThreadDetails };
+}
+
+export function useCreateDiscussionThread() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const createThread = async (payload: {
+    courseId: string;
+    cohortId: string;
+    title: string;
+    body: string;
+  }): Promise<DiscussionThread> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/discussions/threads`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: getHeaders(),
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        let serverMsg = "";
+        try {
+          const errBody = await response.json();
+          serverMsg = errBody.message || errBody.error || "";
+        } catch { /* ignored */ }
+        throw new Error(serverMsg || `Failed to create thread: ${response.statusText}`);
+      }
+
+      return await response.json();
+    } catch (err: any) {
+      setError(err.message || "Failed to create thread");
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { createThread, loading, error };
+}
+
+export function useCreateDiscussionReply() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const createReply = async (threadId: string, body: string): Promise<DiscussionReply> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/discussions/threads/${threadId}/replies`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: getHeaders(),
+        body: JSON.stringify({ body }),
+      });
+
+      if (!response.ok) {
+        let serverMsg = "";
+        try {
+          const errBody = await response.json();
+          serverMsg = errBody.message || errBody.error || "";
+        } catch { /* ignored */ }
+        throw new Error(serverMsg || `Failed to reply: ${response.statusText}`);
+      }
+
+      return await response.json();
+    } catch (err: any) {
+      setError(err.message || "Failed to submit reply");
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { createReply, loading, error };
+}
+
+export function useDeleteDiscussionThread() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deleteThread = async (threadId: string): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/discussions/threads/${threadId}`;
+      const response = await fetch(url, {
+        method: "DELETE",
+        headers: getHeaders(),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to delete thread: ${response.statusText}`);
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to delete thread");
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { deleteThread, loading, error };
+}
+
+export function useDeleteDiscussionReply() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deleteReply = async (replyId: string): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${import.meta.env.VITE_BASE_URL}/discussions/replies/${replyId}`;
+      const response = await fetch(url, {
+        method: "DELETE",
+        headers: getHeaders(),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to delete reply: ${response.statusText}`);
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to delete reply");
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { deleteReply, loading, error };
+}


### PR DESCRIPTION
### What
Adds a Discussion Forum section to the course sidebar, letting students
in the same course + cohort ask and answer each other's questions.
Instructors/admins can view and moderate (pin/delete).

### Why
Students currently have no in-app way to get peer help on doubts tied
to their specific cohort. This adds a lightweight, scoped Q&A space
without touching proctoring, quizzes, or grading.

### Scope
- New backend module: thread + reply CRUD, cohort-membership enforced
  server-side on every read and write.
- New frontend section: sidebar entry, thread list, thread detail,
  new-thread composer — rendered in the existing course main panel,
  same color palette/components as the rest of the course UI.

### Explicitly out of scope (v1)
Upvotes, nested replies, attachments, notifications, forum search,
accepted-answer marking — noted as follow-ups.

### How to test
1. `vibe start frontend backend`
2. Log in as a student enrolled in [course]/[cohort A]; open the course,
   click Discussion Forum, create a thread, reply from a second account
   in the same cohort.
3. Log in as a student in [cohort B] of the same course; confirm you do
   NOT see cohort A's threads.
4. Log in as the course instructor; confirm threads from both cohorts
   are visible and you can delete a thread.
<img width="1917" height="868" alt="Screenshot 2026-07-18 231224" src="https://github.com/user-attachments/assets/42b1a54f-b802-4d22-9d9f-dc031c451f21" />
<img width="1917" height="870" alt="Screenshot 2026-07-18 231314" src="https://github.com/user-attachments/assets/380b08c0-eb6f-44b6-a26b-d7daf0eefbee" />
<img width="1917" height="873" alt="Screenshot 2026-07-18 232955" src="https://github.com/user-attachments/assets/2be6e653-08ad-4a86-88c4-2584cfa14975" />
