### PR TITLE
fix(items): raise CSV upload body limit to 10mb

### DIFF
--- a/backend/src/modules/courses/controllers/ItemController.ts
+++ b/backend/src/modules/courses/controllers/ItemController.ts
@@ -974,7 +974,7 @@ Accessible to:
   })
   async processCSVtoItem(
     @Params() params: CourseVersionModuleSectionParams,
-    @Body() body: CSVItemBody,
+    @Body({options: {limit: '10mb'}}) body: CSVItemBody,
     @Ability(getItemAbility) {user, ability},
     @Req() req: Request,
   ) {


### PR DESCRIPTION
The items/csv endpoint used the default 100kb body-parser limit, so larger CSV imports (segments + MCQs) failed with 'request entity too large'. Use the same 10mb override already applied in AuthController and UserController.

