### PR TITLE
fix(courses): stop module/section deletes timing out on watch-time ca…

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/CourseRepository.ts
@@ -972,12 +972,10 @@ export class CourseRepository implements ICourseRepository {
         );
         if (items) {
           try {
-            for (const item of items.items) {
-              await this.progressRepo.deleteWatchTimeByItemId(
-                item._id.toString(),
-                session,
-              );
-            }
+            await this.progressRepo.deleteWatchTimeByItemIds(
+              (items.items || []).map(item => item._id),
+              session,
+            );
           } catch (err) {
             console.error('Error deleting watch time by item ID:', err);
             throw new InternalServerError('Failed to delete item watch time');
@@ -1096,38 +1094,31 @@ export class CourseRepository implements ICourseRepository {
           section => new ObjectId(section.itemsGroupId),
         );
 
-        // Get item ids from item groups before deletion and delete watch time by item id
-        for (const itemGroupId of itemGroupsIds) {
-          const items = await this.itemsGroupCollection.findOne(
-            { _id: itemGroupId },
+        // Get item ids from item groups before deletion and delete watch time
+        // for all of them in a single batched update
+        const itemGroups = await this.itemsGroupCollection
+          .find({ _id: { $in: itemGroupsIds } }, { session })
+          .toArray();
+
+        const itemIds = itemGroups.flatMap(group =>
+          (group.items || []).map(item => item._id),
+        );
+        await this.progressRepo.deleteWatchTimeByItemIds(itemIds, session);
+
+        if (itemGroups.length > 0) {
+          const itemDeletionResult = await this.itemsGroupCollection.updateMany(
+            {
+              _id: { $in: itemGroupsIds },
+            },
+            {
+              $set: { isDeleted: true, deletedAt: new Date() },
+            },
             { session },
           );
 
-          if (items) {
-            // Delete watch time by item id
-            await Promise.all(
-              items.items.map(item =>
-                this.progressRepo.deleteWatchTimeByItemId(
-                  item._id.toString(),
-                  session,
-                )
-              )
-            );
+          if (itemDeletionResult.matchedCount !== itemGroups.length) {
+            throw new InternalServerError('Failed to delete item groups');
           }
-        }
-
-        const itemDeletionResult = await this.itemsGroupCollection.updateMany(
-          {
-            _id: { $in: itemGroupsIds },
-          },
-          {
-            $set: { isDeleted: true, deletedAt: new Date() },
-          },
-          { session },
-        );
-
-        if (itemDeletionResult.modifiedCount === 0) {
-          throw new InternalServerError('Failed to delete item groups');
         }
       }
 

--- a/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ProgressRepository.ts
@@ -78,6 +78,19 @@ class ProgressRepository {
     }
 
     try {
+      // Deletion cascades (module/section/item) update watch time by itemId
+      // alone; without this index each update scans the whole collection.
+      await this.watchTimeCollection.createIndex(
+        {
+          itemId: 1,
+        },
+        { background: true },
+      );
+    } catch (e) {
+      // Index already exists
+    }
+
+    try {
       await this.attemptCollection.createIndex(
         {
           userId: 1,
@@ -225,9 +238,17 @@ class ProgressRepository {
     itemId: string,
     session?: ClientSession,
   ): Promise<void> {
+    await this.deleteWatchTimeByItemIds([itemId], session);
+  }
+
+  async deleteWatchTimeByItemIds(
+    itemIds: (string | ObjectId)[],
+    session?: ClientSession,
+  ): Promise<void> {
     await this.init();
+    if (itemIds.length === 0) return;
     await this.watchTimeCollection.updateMany(
-      { itemId: new ObjectId(itemId) },
+      { itemId: { $in: itemIds.map(id => new ObjectId(id)) } },
       { $set: { isDeleted: true, deletedAt: new Date() } },
       { session },
     );


### PR DESCRIPTION
…scade

Module deletion flagged watch-time rows one updateMany per item; with no itemId index on watchTime (~3.9M docs) each call was a full collection scan, blowing the driver socket timeout and aborting the transaction.

- add deleteWatchTimeByItemIds: single $in updateMany for all items, same isDeleted semantics the nightly progress recompute relies on
- batch the module and section delete cascades through it
- create {itemId:1} index on watchTime in ProgressRepository.init()
- make the item-group guard matchedCount-based so re-attempted deletes stay idempotent instead of 500ing

