### PR TITLE
fix(ci): replace external Atlas dependency with in-memory MongoDB for…

### DIFF
--- a/backend/src/modules/anomalies/tests/AnomalyController.test.ts
+++ b/backend/src/modules/anomalies/tests/AnomalyController.test.ts
@@ -23,6 +23,19 @@ import { notificationsContainerModule } from '#root/modules/notifications/contai
 import { quizzesContainerModule } from '#root/modules/quizzes/container.js';
 import { usersContainerModule } from '#root/modules/users/container.js';
 import { anomaliesContainerModule } from '../container.js';
+import { settingContainerModule } from '#root/modules/setting/container.js';
+import { courseRegistrationContainerModule } from '#root/modules/courseRegistration/container.js';
+import { projectsContainerModule } from '#root/modules/projects/container.js';
+import { reportsContainerModule } from '#root/modules/reports/container.js';
+import { hpSystemContainerModule } from '#root/modules/hpSystem/container.js';
+import { ejectionPolicyContainerModule } from '#root/modules/ejectionPolicy/container.js';
+import { emotionsContainerModule } from '#root/modules/emotions/container.js';
+import { genAIContainerModule } from '#root/modules/genAI/container.js';
+import { studentQuestionsContainerModule } from '#root/modules/studentQuestions/container.js';
+import { announcementsContainerModule } from '#root/modules/announcements/container.js';
+import { auditTrailsContainerModule } from '#root/modules/auditTrails/container.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
 import { AnomalyData, NewAnomalyData } from '../classes/validators/AnomalyValidators.js';
 import { AnomalyType } from '../classes/transformers/Anomaly.js';
 const ContainerModules: ContainerModule[] = [
@@ -32,7 +45,18 @@ const ContainerModules: ContainerModule[] = [
   authContainerModule,
   notificationsContainerModule,
   usersContainerModule,
-  quizzesContainerModule
+  quizzesContainerModule,
+  settingContainerModule,
+  courseRegistrationContainerModule,
+  projectsContainerModule,
+  reportsContainerModule,
+  hpSystemContainerModule,
+  ejectionPolicyContainerModule,
+  emotionsContainerModule,
+  genAIContainerModule,
+  studentQuestionsContainerModule,
+  announcementsContainerModule,
+  auditTrailsContainerModule,
 ]
 const validImageBuffer = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
   'base64',);
@@ -46,6 +70,8 @@ describe('Anomaly Controller Integration Tests', () => {
     await container.load(...ContainerModules);
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
     app = useExpressServer(appInstance, {
       controllers: [AnomalyController, AuthController, CourseController, CourseVersionController, ModuleController, SectionController, ItemController],
       validation: true,

--- a/backend/src/modules/auth/classes/validators/AuthValidators.ts
+++ b/backend/src/modules/auth/classes/validators/AuthValidators.ts
@@ -70,8 +70,8 @@ class SignUpBody {
     type: 'string',
   })
   @IsString()
-  @IsNotEmpty()
-  recaptchaToken: string;
+  @IsOptional()
+  recaptchaToken?: string;
 
   @JSONSchema({
     title: 'Profile Image',
@@ -332,8 +332,8 @@ class LoginBody {
     type: 'string',
   })
   @IsString()
-  @IsNotEmpty()
-  recaptchaToken: string;
+  @IsOptional()
+  recaptchaToken?: string;
 }
 
 class LoginResponse {

--- a/backend/src/modules/auth/controllers/AuthController.ts
+++ b/backend/src/modules/auth/controllers/AuthController.ts
@@ -64,8 +64,9 @@ export class AuthController {
   async signup(@Body({ options: { limit: '10mb' } }) body: SignUpBody, @Req() req: any) {
     const { recaptchaToken, ...signUpData } = body;
 
-    // Verify reCAPTCHA token
-    if (!recaptchaToken) {
+    // Verify reCAPTCHA token (only enforced when reCAPTCHA is actually enabled,
+    // matching verifyRecaptcha's own bypass for IS_RECAPTCHA_ENABLED !== 'true').
+    if (process.env.IS_RECAPTCHA_ENABLED === 'true' && !recaptchaToken) {
       throw new HttpError(400, 'reCAPTCHA verification is required');
     }
 

--- a/backend/src/modules/auth/tests/AuthController.test.ts
+++ b/backend/src/modules/auth/tests/AuthController.test.ts
@@ -1,10 +1,31 @@
 import 'reflect-metadata';
 import request from 'supertest';
 import Express from 'express';
-import {useExpressServer} from 'routing-controllers';
+import {useExpressServer, useContainer} from 'routing-controllers';
+import {Container} from 'inversify';
+import {InversifyAdapter} from '#root/inversify-adapter.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
 import {faker} from '@faker-js/faker';
 import {SignUpBody} from '#auth/classes/validators/AuthValidators.js';
-import {setupAuthContainer} from '#auth/index.js';
+import {authContainerModule} from '#auth/container.js';
+import {sharedContainerModule} from '#root/container.js';
+import {usersContainerModule} from '#root/modules/users/container.js';
+import {coursesContainerModule} from '#root/modules/courses/container.js';
+import {quizzesContainerModule} from '#root/modules/quizzes/container.js';
+import {notificationsContainerModule} from '#root/modules/notifications/container.js';
+import {anomaliesContainerModule} from '#root/modules/anomalies/container.js';
+import {settingContainerModule} from '#root/modules/setting/container.js';
+import {courseRegistrationContainerModule} from '#root/modules/courseRegistration/container.js';
+import {projectsContainerModule} from '#root/modules/projects/container.js';
+import {reportsContainerModule} from '#root/modules/reports/container.js';
+import {hpSystemContainerModule} from '#root/modules/hpSystem/container.js';
+import {ejectionPolicyContainerModule} from '#root/modules/ejectionPolicy/container.js';
+import {emotionsContainerModule} from '#root/modules/emotions/container.js';
+import {genAIContainerModule} from '#root/modules/genAI/container.js';
+import {studentQuestionsContainerModule} from '#root/modules/studentQuestions/container.js';
+import {announcementsContainerModule} from '#root/modules/announcements/container.js';
+import {auditTrailsContainerModule} from '#root/modules/auditTrails/container.js';
 import {describe, it, expect, beforeAll, beforeEach} from 'vitest';
 import {HttpErrorHandler} from '#shared/index.js';
 import {AuthController} from '../controllers/AuthController.js';
@@ -14,7 +35,31 @@ describe('Auth Controller Integration Tests', () => {
   let app;
 
   beforeAll(async () => {
-    await setupAuthContainer();
+    const container = new Container();
+    await container.load(
+      sharedContainerModule,
+      authContainerModule,
+      usersContainerModule,
+      coursesContainerModule,
+      quizzesContainerModule,
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+    );
+    const inversifyAdapter = new InversifyAdapter(container);
+    useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
     app = useExpressServer(appInstance, {
       controllers: [AuthController],
       validation: true,

--- a/backend/src/modules/courses/tests/CourseController.test.ts
+++ b/backend/src/modules/courses/tests/CourseController.test.ts
@@ -8,6 +8,25 @@ import {coursesContainerModules, coursesModuleOptions, setupCoursesContainer} fr
 import { InversifyAdapter } from '#root/inversify-adapter.js';
 import { Container } from 'inversify';
 import * as Current from '#root/shared/functions/currentUserChecker.js';
+import { sharedContainerModule } from '#root/container.js';
+import { authContainerModule } from '#root/modules/auth/container.js';
+import { usersContainerModule } from '#root/modules/users/container.js';
+import { quizzesContainerModule } from '#root/modules/quizzes/container.js';
+import { notificationsContainerModule } from '#root/modules/notifications/container.js';
+import { anomaliesContainerModule } from '#root/modules/anomalies/container.js';
+import { settingContainerModule } from '#root/modules/setting/container.js';
+import { courseRegistrationContainerModule } from '#root/modules/courseRegistration/container.js';
+import { projectsContainerModule } from '#root/modules/projects/container.js';
+import { reportsContainerModule } from '#root/modules/reports/container.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import { hpSystemContainerModule } from '#root/modules/hpSystem/container.js';
+import { ejectionPolicyContainerModule } from '#root/modules/ejectionPolicy/container.js';
+import { emotionsContainerModule } from '#root/modules/emotions/container.js';
+import { genAIContainerModule } from '#root/modules/genAI/container.js';
+import { studentQuestionsContainerModule } from '#root/modules/studentQuestions/container.js';
+import { announcementsContainerModule } from '#root/modules/announcements/container.js';
+import { auditTrailsContainerModule } from '#root/modules/auditTrails/container.js';
 
 describe('Course Controller Integration Tests', () => {
   const App = Express();
@@ -33,9 +52,30 @@ describe('Course Controller Integration Tests', () => {
 
   beforeAll(async () => {
     const container = new Container();
-    await container.load(...coursesContainerModules);
+    await container.load(
+      ...coursesContainerModules,
+      sharedContainerModule,
+      authContainerModule,
+      usersContainerModule,
+      quizzesContainerModule,
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+    );
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
 
     // Create the spy BEFORE using it in options
     currentUserCheckerSpy = vi.spyOn(Current, 'currentUserChecker').mockImplementation(

--- a/backend/src/modules/courses/tests/CourseVersionController.test.ts
+++ b/backend/src/modules/courses/tests/CourseVersionController.test.ts
@@ -9,6 +9,25 @@ import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 import { currentUserChecker } from '#root/shared/functions/currentUserChecker.js';
 import { InversifyAdapter } from '#root/inversify-adapter.js';
 import { Container } from 'inversify';
+import { sharedContainerModule } from '#root/container.js';
+import { authContainerModule } from '#root/modules/auth/container.js';
+import { usersContainerModule } from '#root/modules/users/container.js';
+import { quizzesContainerModule } from '#root/modules/quizzes/container.js';
+import { notificationsContainerModule } from '#root/modules/notifications/container.js';
+import { anomaliesContainerModule } from '#root/modules/anomalies/container.js';
+import { settingContainerModule } from '#root/modules/setting/container.js';
+import { courseRegistrationContainerModule } from '#root/modules/courseRegistration/container.js';
+import { projectsContainerModule } from '#root/modules/projects/container.js';
+import { reportsContainerModule } from '#root/modules/reports/container.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import { hpSystemContainerModule } from '#root/modules/hpSystem/container.js';
+import { ejectionPolicyContainerModule } from '#root/modules/ejectionPolicy/container.js';
+import { emotionsContainerModule } from '#root/modules/emotions/container.js';
+import { genAIContainerModule } from '#root/modules/genAI/container.js';
+import { studentQuestionsContainerModule } from '#root/modules/studentQuestions/container.js';
+import { announcementsContainerModule } from '#root/modules/announcements/container.js';
+import { auditTrailsContainerModule } from '#root/modules/auditTrails/container.js';
 
 describe('Course Version Controller Integration Tests', () => {
   const App = Express();
@@ -17,9 +36,30 @@ describe('Course Version Controller Integration Tests', () => {
   beforeAll(async () => {
     process.env.NODE_ENV = 'test';
     const container = new Container();
-    await container.load(...coursesContainerModules);
+    await container.load(
+      ...coursesContainerModules,
+      sharedContainerModule,
+      authContainerModule,
+      usersContainerModule,
+      quizzesContainerModule,
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+    );
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
     const options: RoutingControllersOptions = {
       controllers: coursesModuleOptions.controllers,
       middlewares: coursesModuleOptions.middlewares,

--- a/backend/src/modules/courses/tests/ItemsController.test.ts
+++ b/backend/src/modules/courses/tests/ItemsController.test.ts
@@ -1,5 +1,24 @@
 import { coursesContainerModules, coursesModuleOptions, setupCoursesContainer } from '../index.js';
 import { useExpressServer, useContainer, RoutingControllersOptions } from 'routing-controllers';
+import { sharedContainerModule } from '#root/container.js';
+import { authContainerModule } from '#root/modules/auth/container.js';
+import { usersContainerModule } from '#root/modules/users/container.js';
+import { quizzesContainerModule } from '#root/modules/quizzes/container.js';
+import { notificationsContainerModule } from '#root/modules/notifications/container.js';
+import { anomaliesContainerModule } from '#root/modules/anomalies/container.js';
+import { settingContainerModule } from '#root/modules/setting/container.js';
+import { courseRegistrationContainerModule } from '#root/modules/courseRegistration/container.js';
+import { projectsContainerModule } from '#root/modules/projects/container.js';
+import { reportsContainerModule } from '#root/modules/reports/container.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import { hpSystemContainerModule } from '#root/modules/hpSystem/container.js';
+import { ejectionPolicyContainerModule } from '#root/modules/ejectionPolicy/container.js';
+import { emotionsContainerModule } from '#root/modules/emotions/container.js';
+import { genAIContainerModule } from '#root/modules/genAI/container.js';
+import { studentQuestionsContainerModule } from '#root/modules/studentQuestions/container.js';
+import { announcementsContainerModule } from '#root/modules/announcements/container.js';
+import { auditTrailsContainerModule } from '#root/modules/auditTrails/container.js';
 import Express from 'express';
 import request from 'supertest';
 import {
@@ -59,9 +78,30 @@ describe('Item Controller Integration Tests', () => {
   beforeAll(async () => {
     process.env.NODE_ENV = 'test';
     const container = new Container();
-    await container.load(...coursesContainerModules);
+    await container.load(
+      ...coursesContainerModules,
+      sharedContainerModule,
+      authContainerModule,
+      usersContainerModule,
+      quizzesContainerModule,
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+    );
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
     const options: RoutingControllersOptions = {
       controllers: controllers,
       middlewares: coursesModuleOptions.middlewares,

--- a/backend/src/modules/courses/tests/ModuleController.test.ts
+++ b/backend/src/modules/courses/tests/ModuleController.test.ts
@@ -1,5 +1,27 @@
-import {coursesModuleOptions, setupCoursesContainer} from '../index.js';
-import {useExpressServer} from 'routing-controllers';
+import {coursesModuleOptions} from '../index.js';
+import {coursesContainerModule} from '../container.js';
+import {useExpressServer, useContainer} from 'routing-controllers';
+import {Container} from 'inversify';
+import {InversifyAdapter} from '#root/inversify-adapter.js';
+import {sharedContainerModule} from '#root/container.js';
+import {authContainerModule} from '#root/modules/auth/container.js';
+import {usersContainerModule} from '#root/modules/users/container.js';
+import {quizzesContainerModule} from '#root/modules/quizzes/container.js';
+import {notificationsContainerModule} from '#root/modules/notifications/container.js';
+import {anomaliesContainerModule} from '#root/modules/anomalies/container.js';
+import {settingContainerModule} from '#root/modules/setting/container.js';
+import {courseRegistrationContainerModule} from '#root/modules/courseRegistration/container.js';
+import {projectsContainerModule} from '#root/modules/projects/container.js';
+import {reportsContainerModule} from '#root/modules/reports/container.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {hpSystemContainerModule} from '#root/modules/hpSystem/container.js';
+import {ejectionPolicyContainerModule} from '#root/modules/ejectionPolicy/container.js';
+import {emotionsContainerModule} from '#root/modules/emotions/container.js';
+import {genAIContainerModule} from '#root/modules/genAI/container.js';
+import {studentQuestionsContainerModule} from '#root/modules/studentQuestions/container.js';
+import {announcementsContainerModule} from '#root/modules/announcements/container.js';
+import {auditTrailsContainerModule} from '#root/modules/auditTrails/container.js';
 import Express from 'express';
 import request from 'supertest';
 import {
@@ -24,7 +46,31 @@ describe('Module Controller Integration Tests', () => {
 
   beforeAll(async () => {
     process.env.NODE_ENV = 'test';
-    await setupCoursesContainer();
+    const container = new Container();
+    await container.load(
+      sharedContainerModule,
+      authContainerModule,
+      usersContainerModule,
+      coursesContainerModule,
+      quizzesContainerModule,
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+    );
+    const inversifyAdapter = new InversifyAdapter(container);
+    useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
     app = useExpressServer(App, coursesModuleOptions);
   });
 

--- a/backend/src/modules/courses/tests/SectionController.test.ts
+++ b/backend/src/modules/courses/tests/SectionController.test.ts
@@ -1,6 +1,28 @@
 import Express from 'express';
-import {useExpressServer} from 'routing-controllers';
-import {coursesModuleOptions, setupCoursesContainer} from '../index.js';
+import {useExpressServer, useContainer} from 'routing-controllers';
+import {coursesModuleOptions} from '../index.js';
+import {coursesContainerModule} from '../container.js';
+import {Container} from 'inversify';
+import {InversifyAdapter} from '#root/inversify-adapter.js';
+import {sharedContainerModule} from '#root/container.js';
+import {authContainerModule} from '#root/modules/auth/container.js';
+import {usersContainerModule} from '#root/modules/users/container.js';
+import {quizzesContainerModule} from '#root/modules/quizzes/container.js';
+import {notificationsContainerModule} from '#root/modules/notifications/container.js';
+import {anomaliesContainerModule} from '#root/modules/anomalies/container.js';
+import {settingContainerModule} from '#root/modules/setting/container.js';
+import {courseRegistrationContainerModule} from '#root/modules/courseRegistration/container.js';
+import {projectsContainerModule} from '#root/modules/projects/container.js';
+import {reportsContainerModule} from '#root/modules/reports/container.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {hpSystemContainerModule} from '#root/modules/hpSystem/container.js';
+import {ejectionPolicyContainerModule} from '#root/modules/ejectionPolicy/container.js';
+import {emotionsContainerModule} from '#root/modules/emotions/container.js';
+import {genAIContainerModule} from '#root/modules/genAI/container.js';
+import {studentQuestionsContainerModule} from '#root/modules/studentQuestions/container.js';
+import {announcementsContainerModule} from '#root/modules/announcements/container.js';
+import {auditTrailsContainerModule} from '#root/modules/auditTrails/container.js';
 import request from 'supertest';
 import {describe, expect, it, beforeAll} from 'vitest';
 
@@ -10,7 +32,31 @@ describe('Section Controller Integration Tests', () => {
 
   beforeAll(async () => {
     process.env.NODE_ENV = 'test';
-    await setupCoursesContainer();
+    const container = new Container();
+    await container.load(
+      sharedContainerModule,
+      authContainerModule,
+      usersContainerModule,
+      coursesContainerModule,
+      quizzesContainerModule,
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+    );
+    const inversifyAdapter = new InversifyAdapter(container);
+    useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
     app = useExpressServer(App, coursesModuleOptions);
   });
 

--- a/backend/src/modules/notifications/tests/InviteController.test.ts
+++ b/backend/src/modules/notifications/tests/InviteController.test.ts
@@ -18,13 +18,41 @@ import { authContainerModule } from '#root/modules/auth/container.js';
 import { authModuleControllers } from '#root/modules/auth/index.js';
 import { usersModuleControllers } from '#root/modules/users/index.js';
 import { FirebaseAuthService } from '#root/modules/auth/services/FirebaseAuthService.js';
+import { quizzesContainerModule } from '#root/modules/quizzes/container.js';
+import { anomaliesContainerModule } from '#root/modules/anomalies/container.js';
+import { settingContainerModule } from '#root/modules/setting/container.js';
+import { courseRegistrationContainerModule } from '#root/modules/courseRegistration/container.js';
+import { projectsContainerModule } from '#root/modules/projects/container.js';
+import { reportsContainerModule } from '#root/modules/reports/container.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import { hpSystemContainerModule } from '#root/modules/hpSystem/container.js';
+import { ejectionPolicyContainerModule } from '#root/modules/ejectionPolicy/container.js';
+import { emotionsContainerModule } from '#root/modules/emotions/container.js';
+import { genAIContainerModule } from '#root/modules/genAI/container.js';
+import { studentQuestionsContainerModule } from '#root/modules/studentQuestions/container.js';
+import { announcementsContainerModule } from '#root/modules/announcements/container.js';
+import { auditTrailsContainerModule } from '#root/modules/auditTrails/container.js';
 
 const notificationsContainerModules: ContainerModule[] = [
   notificationsContainerModule,
   sharedContainerModule,
   usersContainerModule,
   coursesContainerModule,
-  authContainerModule
+  authContainerModule,
+  quizzesContainerModule,
+  anomaliesContainerModule,
+  settingContainerModule,
+  courseRegistrationContainerModule,
+  projectsContainerModule,
+  reportsContainerModule,
+  hpSystemContainerModule,
+  ejectionPolicyContainerModule,
+  emotionsContainerModule,
+  genAIContainerModule,
+  studentQuestionsContainerModule,
+  announcementsContainerModule,
+  auditTrailsContainerModule
 ];
 
 describe('InviteController', () => {
@@ -38,6 +66,8 @@ describe('InviteController', () => {
     await container.load(...notificationsContainerModules);
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
     app = Express();
     const options: RoutingControllersOptions = {
       controllers: [...(notificationsModuleOptions.controllers as Function[]), ...(coursesModuleControllers as Function[]), ...(authModuleControllers as Function[]), ...(usersModuleControllers as Function[])],

--- a/backend/src/modules/quizzes/tests/AttemptController.test.ts
+++ b/backend/src/modules/quizzes/tests/AttemptController.test.ts
@@ -32,6 +32,20 @@ import {
 } from './SamleQuestionBody.js';
 import { FirebaseAuthService } from '#root/modules/auth/services/FirebaseAuthService.js';
 import { notificationsContainerModule } from '#root/modules/notifications/container.js';
+import { anomaliesContainerModule } from '#root/modules/anomalies/container.js';
+import { settingContainerModule } from '#root/modules/setting/container.js';
+import { courseRegistrationContainerModule } from '#root/modules/courseRegistration/container.js';
+import { projectsContainerModule } from '#root/modules/projects/container.js';
+import { reportsContainerModule } from '#root/modules/reports/container.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import { hpSystemContainerModule } from '#root/modules/hpSystem/container.js';
+import { ejectionPolicyContainerModule } from '#root/modules/ejectionPolicy/container.js';
+import { emotionsContainerModule } from '#root/modules/emotions/container.js';
+import { genAIContainerModule } from '#root/modules/genAI/container.js';
+import { studentQuestionsContainerModule } from '#root/modules/studentQuestions/container.js';
+import { announcementsContainerModule } from '#root/modules/announcements/container.js';
+import { auditTrailsContainerModule } from '#root/modules/auditTrails/container.js';
 
 describe('AttemptController', async () => {
   const appInstance = Express();
@@ -47,10 +61,24 @@ describe('AttemptController', async () => {
       coursesContainerModule,
       usersContainerModule,
       authContainerModule,
-      notificationsContainerModule
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule
     );
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
 
     const options: RoutingControllersOptions = {
       controllers: [

--- a/backend/src/modules/quizzes/tests/QuestionBankController.test.ts
+++ b/backend/src/modules/quizzes/tests/QuestionBankController.test.ts
@@ -7,6 +7,23 @@ import {
 } from 'routing-controllers';
 import {quizzesContainerModule} from '../container.js';
 import {coursesContainerModule} from '#root/modules/courses/container.js';
+import {authContainerModule} from '#root/modules/auth/container.js';
+import {usersContainerModule} from '#root/modules/users/container.js';
+import {notificationsContainerModule} from '#root/modules/notifications/container.js';
+import {anomaliesContainerModule} from '#root/modules/anomalies/container.js';
+import {settingContainerModule} from '#root/modules/setting/container.js';
+import {courseRegistrationContainerModule} from '#root/modules/courseRegistration/container.js';
+import {projectsContainerModule} from '#root/modules/projects/container.js';
+import {reportsContainerModule} from '#root/modules/reports/container.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {hpSystemContainerModule} from '#root/modules/hpSystem/container.js';
+import {ejectionPolicyContainerModule} from '#root/modules/ejectionPolicy/container.js';
+import {emotionsContainerModule} from '#root/modules/emotions/container.js';
+import {genAIContainerModule} from '#root/modules/genAI/container.js';
+import {studentQuestionsContainerModule} from '#root/modules/studentQuestions/container.js';
+import {announcementsContainerModule} from '#root/modules/announcements/container.js';
+import {auditTrailsContainerModule} from '#root/modules/auditTrails/container.js';
 import {Container} from 'inversify';
 import {InversifyAdapter} from '#root/inversify-adapter.js';
 import {quizzesModuleOptions} from '../index.js';
@@ -25,9 +42,26 @@ describe('QuestionBankController', {timeout: 30000}, () => {
       sharedContainerModule,
       quizzesContainerModule,
       coursesContainerModule,
+      authContainerModule,
+      usersContainerModule,
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
     );
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
     const options: RoutingControllersOptions = {
       controllers: [
         ...(quizzesModuleOptions.controllers as Function[]),

--- a/backend/src/modules/quizzes/tests/QuestionController.test.ts
+++ b/backend/src/modules/quizzes/tests/QuestionController.test.ts
@@ -1,7 +1,29 @@
-import {useExpressServer, RoutingControllersOptions} from 'routing-controllers';
+import {useExpressServer, useContainer, RoutingControllersOptions} from 'routing-controllers';
 import request from 'supertest';
 import Express from 'express';
-import {quizzesModuleOptions, setupQuizzesContainer} from '../index.js';
+import {quizzesModuleOptions} from '../index.js';
+import {quizzesContainerModule} from '../container.js';
+import {Container} from 'inversify';
+import {InversifyAdapter} from '#root/inversify-adapter.js';
+import {sharedContainerModule} from '#root/container.js';
+import {authContainerModule} from '#root/modules/auth/container.js';
+import {usersContainerModule} from '#root/modules/users/container.js';
+import {coursesContainerModule} from '#root/modules/courses/container.js';
+import {notificationsContainerModule} from '#root/modules/notifications/container.js';
+import {anomaliesContainerModule} from '#root/modules/anomalies/container.js';
+import {settingContainerModule} from '#root/modules/setting/container.js';
+import {courseRegistrationContainerModule} from '#root/modules/courseRegistration/container.js';
+import {projectsContainerModule} from '#root/modules/projects/container.js';
+import {reportsContainerModule} from '#root/modules/reports/container.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {hpSystemContainerModule} from '#root/modules/hpSystem/container.js';
+import {ejectionPolicyContainerModule} from '#root/modules/ejectionPolicy/container.js';
+import {emotionsContainerModule} from '#root/modules/emotions/container.js';
+import {genAIContainerModule} from '#root/modules/genAI/container.js';
+import {studentQuestionsContainerModule} from '#root/modules/studentQuestions/container.js';
+import {announcementsContainerModule} from '#root/modules/announcements/container.js';
+import {auditTrailsContainerModule} from '#root/modules/auditTrails/container.js';
 import {describe, it, expect, beforeAll, beforeEach, vi} from 'vitest';
 import {
   DESquestionData,
@@ -32,8 +54,31 @@ describe('Progress Controller Integration Tests', {timeout: 30000}, () => {
   beforeAll(async () => {
     //Set env variables
     process.env.NODE_ENV = 'test';
-    // setupQuizzesModuleDependencies();
-    await setupQuizzesContainer();
+    const container = new Container();
+    await container.load(
+      sharedContainerModule,
+      authContainerModule,
+      usersContainerModule,
+      coursesContainerModule,
+      quizzesContainerModule,
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+    );
+    const inversifyAdapter = new InversifyAdapter(container);
+    useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
 
     // Create the Express app with routing-controllers configuration
     const options: RoutingControllersOptions = {

--- a/backend/src/modules/quizzes/tests/QuizController.test.ts
+++ b/backend/src/modules/quizzes/tests/QuizController.test.ts
@@ -20,6 +20,20 @@ import {beforeAll, describe, it, expect, beforeEach, vi} from 'vitest';
 import {ItemType} from '#root/shared/interfaces/models.js';
 import {FirebaseAuthService} from '#root/modules/auth/services/FirebaseAuthService.js';
 import {notificationsContainerModule} from '#root/modules/notifications/container.js';
+import {anomaliesContainerModule} from '#root/modules/anomalies/container.js';
+import {settingContainerModule} from '#root/modules/setting/container.js';
+import {courseRegistrationContainerModule} from '#root/modules/courseRegistration/container.js';
+import {projectsContainerModule} from '#root/modules/projects/container.js';
+import {reportsContainerModule} from '#root/modules/reports/container.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {hpSystemContainerModule} from '#root/modules/hpSystem/container.js';
+import {ejectionPolicyContainerModule} from '#root/modules/ejectionPolicy/container.js';
+import {emotionsContainerModule} from '#root/modules/emotions/container.js';
+import {genAIContainerModule} from '#root/modules/genAI/container.js';
+import {studentQuestionsContainerModule} from '#root/modules/studentQuestions/container.js';
+import {announcementsContainerModule} from '#root/modules/announcements/container.js';
+import {auditTrailsContainerModule} from '#root/modules/auditTrails/container.js';
 
 describe('QuizController', {timeout: 30000}, () => {
   const appInstance = Express();
@@ -36,9 +50,23 @@ describe('QuizController', {timeout: 30000}, () => {
       usersContainerModule,
       authContainerModule,
       notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
     );
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
 
     const options: RoutingControllersOptions = {
       controllers: [

--- a/backend/src/modules/reports/test/reportController.test.ts
+++ b/backend/src/modules/reports/test/reportController.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import {
   useExpressServer,
+  useContainer,
   Action,
   RoutingControllersOptions,
 } from 'routing-controllers';
@@ -11,8 +12,26 @@ import {faker} from '@faker-js/faker';
 import {reportsContainerModules, reportsModuleOptions} from '../index.js';
 import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
 import {InversifyAdapter} from '#root/inversify-adapter.js';
-import {useContainer} from 'class-validator';
 import {ReportBody} from '../classes/index.js';
+import {sharedContainerModule} from '#root/container.js';
+import {authContainerModule} from '#root/modules/auth/container.js';
+import {usersContainerModule} from '#root/modules/users/container.js';
+import {coursesContainerModule} from '#root/modules/courses/container.js';
+import {quizzesContainerModule} from '#root/modules/quizzes/container.js';
+import {notificationsContainerModule} from '#root/modules/notifications/container.js';
+import {anomaliesContainerModule} from '#root/modules/anomalies/container.js';
+import {settingContainerModule} from '#root/modules/setting/container.js';
+import {courseRegistrationContainerModule} from '#root/modules/courseRegistration/container.js';
+import {projectsContainerModule} from '#root/modules/projects/container.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {hpSystemContainerModule} from '#root/modules/hpSystem/container.js';
+import {ejectionPolicyContainerModule} from '#root/modules/ejectionPolicy/container.js';
+import {emotionsContainerModule} from '#root/modules/emotions/container.js';
+import {genAIContainerModule} from '#root/modules/genAI/container.js';
+import {studentQuestionsContainerModule} from '#root/modules/studentQuestions/container.js';
+import {announcementsContainerModule} from '#root/modules/announcements/container.js';
+import {auditTrailsContainerModule} from '#root/modules/auditTrails/container.js';
 
 describe('Report Controller Integration Test', () => {
   const App = Express();
@@ -37,9 +56,30 @@ describe('Report Controller Integration Test', () => {
 
   beforeAll(async () => {
     const container = new Container();
-    await container.load(...reportsContainerModules);
+    await container.load(
+      ...reportsContainerModules,
+      sharedContainerModule,
+      authContainerModule,
+      usersContainerModule,
+      coursesContainerModule,
+      quizzesContainerModule,
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
+    );
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
 
     currentUserCheckerSpy = vi
       .spyOn(Current, 'currentUserChecker')

--- a/backend/src/modules/users/tests/EnrollementController.test.ts
+++ b/backend/src/modules/users/tests/EnrollementController.test.ts
@@ -42,6 +42,20 @@ import {coursesModuleControllers} from '#root/modules/courses/index.js';
 import {authModuleControllers} from '#root/modules/auth/index.js';
 import {quizzesContainerModule} from '#root/modules/quizzes/container.js';
 import {notificationsContainerModule} from '#root/modules/notifications/container.js';
+import {anomaliesContainerModule} from '#root/modules/anomalies/container.js';
+import {settingContainerModule} from '#root/modules/setting/container.js';
+import {courseRegistrationContainerModule} from '#root/modules/courseRegistration/container.js';
+import {projectsContainerModule} from '#root/modules/projects/container.js';
+import {reportsContainerModule} from '#root/modules/reports/container.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {hpSystemContainerModule} from '#root/modules/hpSystem/container.js';
+import {ejectionPolicyContainerModule} from '#root/modules/ejectionPolicy/container.js';
+import {emotionsContainerModule} from '#root/modules/emotions/container.js';
+import {genAIContainerModule} from '#root/modules/genAI/container.js';
+import {studentQuestionsContainerModule} from '#root/modules/studentQuestions/container.js';
+import {announcementsContainerModule} from '#root/modules/announcements/container.js';
+import {auditTrailsContainerModule} from '#root/modules/auditTrails/container.js';
 import {FirebaseAuthService} from '#root/modules/auth/services/FirebaseAuthService.js';
 import {authorizationChecker} from '#root/shared/index.js';
 import * as current from '#root/shared/functions/currentUserChecker.js';
@@ -70,9 +84,23 @@ describe('Enrollment Controller Integration Tests', () => {
       coursesContainerModule,
       quizzesContainerModule,
       notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule,
     );
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
     vi.spyOn(current, 'currentUserChecker').mockImplementation(
       async (action: Action) => {
         if (action.request.headers.authorization) {

--- a/backend/src/modules/users/tests/ProgressController.test.ts
+++ b/backend/src/modules/users/tests/ProgressController.test.ts
@@ -34,6 +34,20 @@ import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 import { FirebaseAuthService } from '#root/modules/auth/services/FirebaseAuthService.js';
 import { quizzesContainerModule } from '#root/modules/quizzes/container.js';
 import { notificationsContainerModule } from '#root/modules/notifications/container.js';
+import { anomaliesContainerModule } from '#root/modules/anomalies/container.js';
+import { settingContainerModule } from '#root/modules/setting/container.js';
+import { courseRegistrationContainerModule } from '#root/modules/courseRegistration/container.js';
+import { projectsContainerModule } from '#root/modules/projects/container.js';
+import { reportsContainerModule } from '#root/modules/reports/container.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { MongoDatabase } from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import { hpSystemContainerModule } from '#root/modules/hpSystem/container.js';
+import { ejectionPolicyContainerModule } from '#root/modules/ejectionPolicy/container.js';
+import { emotionsContainerModule } from '#root/modules/emotions/container.js';
+import { genAIContainerModule } from '#root/modules/genAI/container.js';
+import { studentQuestionsContainerModule } from '#root/modules/studentQuestions/container.js';
+import { announcementsContainerModule } from '#root/modules/announcements/container.js';
+import { auditTrailsContainerModule } from '#root/modules/auditTrails/container.js';
 
 describe('Progress Controller Integration Tests', { timeout: 90000 }, () => {
   const appInstance = Express();
@@ -53,10 +67,24 @@ describe('Progress Controller Integration Tests', { timeout: 90000 }, () => {
       usersContainerModule,
       coursesContainerModule,
       quizzesContainerModule,
-      notificationsContainerModule
+      notificationsContainerModule,
+      anomaliesContainerModule,
+      settingContainerModule,
+      courseRegistrationContainerModule,
+      projectsContainerModule,
+      reportsContainerModule,
+      hpSystemContainerModule,
+      ejectionPolicyContainerModule,
+      emotionsContainerModule,
+      genAIContainerModule,
+      studentQuestionsContainerModule,
+      announcementsContainerModule,
+      auditTrailsContainerModule
     );
     const inversifyAdapter = new InversifyAdapter(container);
     useContainer(inversifyAdapter);
+    const db = container.get<MongoDatabase>(GLOBAL_TYPES.Database);
+    await db.connect();
     app = useExpressServer(appInstance, {
       controllers: [
         ...(usersModuleOptions.controllers as Function[]),

--- a/backend/src/shared/database/providers/mongo/MongoDatabase.ts
+++ b/backend/src/shared/database/providers/mongo/MongoDatabase.ts
@@ -41,11 +41,6 @@ export class MongoDatabase implements IDatabase<Db> {
     }
 
     this.client = new MongoClient(uri, {
-      ssl: true,
-      tls: true,
-      tlsAllowInvalidCertificates: false,
-      tlsAllowInvalidHostnames: false,
-
       retryWrites: true,
 
       // 🔹 CONNECTION POOL

--- a/backend/test/globalSetup.ts
+++ b/backend/test/globalSetup.ts
@@ -1,0 +1,21 @@
+import { MongoMemoryReplSet } from 'mongodb-memory-server';
+
+/**
+ * Ephemeral, in-process MongoDB for the test suite — replaces the external
+ * Atlas cluster + per-run IP allowlisting previously used in CI. Runs as a
+ * single-node replica set (not a plain standalone) because the app relies on
+ * multi-document transactions, which standalone MongoDB doesn't support.
+ *
+ * Needs no secrets/credentials, so it works identically for same-repo and
+ * fork PRs — unlike the Atlas-backed setup it replaces.
+ */
+let replSet: MongoMemoryReplSet;
+
+export async function setup() {
+  replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+  process.env.DB_URL = replSet.getUri();
+}
+
+export async function teardown() {
+  await replSet.stop();
+}

--- a/backend/vite.config.ts
+++ b/backend/vite.config.ts
@@ -38,5 +38,6 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts'],
     hookTimeout: 30000,
+    globalSetup: ['./test/globalSetup.ts'],
   }
 });


### PR DESCRIPTION
… backend tests

The Jest CI job depended on 4 secrets (DB_URL, ATLAS_PUBLIC_KEY, ATLAS_PRIVATE_KEY, ATLAS_PROJECT_ID) that no longer exist at either the repo or environment level, so the test job has been silently failing on every PR regardless of branch or author. The Atlas + per-run IP-allowlist design also meant fork PRs could never get real CI signal even once secrets were restored, since GitHub withholds secrets from fork-triggered runs by design.

Replaces it with an in-process MongoMemoryReplSet (single-node replica set, since the app relies on multi-document transactions) started via a Vitest globalSetup. Needs zero secrets and works identically for same-repo and fork PRs.

Getting the suite to actually run against this surfaced several pre-existing bugs that had been masked by the test job never really executing:

- MongoDatabase hardcoded ssl/tls unconditionally, breaking any non-Atlas connection (including local dev).
- AuthController required a recaptchaToken even when reCAPTCHA is disabled, and the DTO validators marked it @IsNotEmpty() regardless - 400ing every integration-test signup.
- reportController.test.ts imported useContainer from 'class-validator' instead of 'routing-controllers' (same name, unrelated function), so its DI container was never actually wired in.
- 14 test files hand-roll their own DI container and had drifted out of sync with CourseRepository's growing dependency list (anomalies, setting, courseRegistration, projects, reports, hpSystem, etc.), and none of them called db.connect() before use.
