### PR TITLE
Fix/smart csv timestamp mismatch

### DIFF
--- a/backend/src/modules/quizzes/controllers/QuestionController.ts
+++ b/backend/src/modules/quizzes/controllers/QuestionController.ts
@@ -476,14 +476,7 @@ class QuestionController {
 
     const chunks = chunkTranscriptByTimestamps(text);
 
-    // TEMP DEBUG - remove before commit
-    console.log('=== [DEBUG] Original transcript ===');
-    console.log(text);
-    console.log(`=== [DEBUG] chunkTranscriptByTimestamps produced ${chunks.length} chunk(s) ===`);
-    chunks.forEach((chunk, i) => {
-      console.log(`--- [DEBUG] Chunk ${i} (length ${chunk.length}) ---`);
-      console.log(chunk);
-    });
+   
 
     let allSegments: TranscriptResponse[] = [];
     // for (const chunk of chunks) {

--- a/backend/src/modules/quizzes/controllers/QuestionController.ts
+++ b/backend/src/modules/quizzes/controllers/QuestionController.ts
@@ -475,6 +475,16 @@ class QuestionController {
     };
 
     const chunks = chunkTranscriptByTimestamps(text);
+
+    // TEMP DEBUG - remove before commit
+    console.log('=== [DEBUG] Original transcript ===');
+    console.log(text);
+    console.log(`=== [DEBUG] chunkTranscriptByTimestamps produced ${chunks.length} chunk(s) ===`);
+    chunks.forEach((chunk, i) => {
+      console.log(`--- [DEBUG] Chunk ${i} (length ${chunk.length}) ---`);
+      console.log(chunk);
+    });
+
     let allSegments: TranscriptResponse[] = [];
     // for (const chunk of chunks) {
     //   const segments = await this.questionService.generateQuestionsWithAI(

--- a/backend/src/modules/quizzes/services/QuestionService.ts
+++ b/backend/src/modules/quizzes/services/QuestionService.ts
@@ -421,9 +421,7 @@ class QuestionService extends BaseService {
           apiKey: ANTHROPIC_CRED!,
         });
 
-        // TEMP DEBUG - remove before commit
-        console.log('=== [DEBUG] Chunk text being sent to Claude ===');
-        console.log(text);
+        
 
         const response = await anthropic.messages.create({
           model: ANTHROPIC_MODEL,
@@ -442,9 +440,6 @@ class QuestionService extends BaseService {
           ],
         });
 
-        // TEMP DEBUG - remove before commit
-        console.log('=== [DEBUG] Raw Claude response content ===');
-        console.log(JSON.stringify(response.content, null, 2));
 
         const finalOutput =
           response.content?.map(c => ('text' in c ? c.text : '')).join('') ??

--- a/backend/src/modules/quizzes/services/QuestionService.ts
+++ b/backend/src/modules/quizzes/services/QuestionService.ts
@@ -421,9 +421,13 @@ class QuestionService extends BaseService {
           apiKey: ANTHROPIC_CRED!,
         });
 
+        // TEMP DEBUG - remove before commit
+        console.log('=== [DEBUG] Chunk text being sent to Claude ===');
+        console.log(text);
+
         const response = await anthropic.messages.create({
           model: ANTHROPIC_MODEL,
-          max_tokens: 4000,
+          max_tokens: 8000,
           temperature: 0.0,
           messages: [
             {
@@ -437,6 +441,10 @@ class QuestionService extends BaseService {
             },
           ],
         });
+
+        // TEMP DEBUG - remove before commit
+        console.log('=== [DEBUG] Raw Claude response content ===');
+        console.log(JSON.stringify(response.content, null, 2));
 
         const finalOutput =
           response.content?.map(c => ('text' in c ? c.text : '')).join('') ??


### PR DESCRIPTION
While investigating the Smart CSV timestamp issue , found that max_tokens: 4000 was too low, causing Claude's response to get truncated mid-JSON on longer transcripts (confirmed via repeated local testing). Increased to 8000 — verified multiple successful runs afterward with no truncation.