### PR TITLE
feat(integrations): add per-course completions endpoint

### DIFF
--- a/backend/src/modules/users/INTEGRATIONS_API.md
+++ b/backend/src/modules/users/INTEGRATIONS_API.md
@@ -1,0 +1,80 @@
+# Integrations API
+
+Server-to-server endpoints in `IntegrationController.ts` for external
+applications that need to pull learner/completion data out of ViBe. These are
+**not** for logged-in learners — they authenticate the *calling application*
+via a shared secret, not a per-user Firebase token.
+
+## Authentication
+
+Every request must include:
+
+```
+X-API-Key: <shared secret>
+```
+
+The secret is configured via the `INTEGRATION_API_KEY` environment variable
+per environment (local `.env`, staging, production — each gets its own
+value). If the server has no key configured, every request is rejected
+(fail-closed). Requests with a missing or wrong key get `401 Unauthorized`.
+
+## `GET /integrations/courses/:courseId/completions`
+
+Returns candidates who have completed one specific course: an active
+`STUDENT` enrollment on that course with a matching `progress` record where
+`completed: true`.
+
+**Path param**
+
+| Name | Type | Description |
+|---|---|---|
+| `courseId` | Mongo ObjectId string | The course to query. Invalid format → `400`. |
+
+**Query params**
+
+| Name | Default | Notes |
+|---|---|---|
+| `page` | `1` | 1-indexed. |
+| `limit` | `50` | Clamped to a max of `200`. |
+
+**Response `200`**
+
+```json
+{
+  "page": 1,
+  "limit": 50,
+  "totalCandidates": 2,
+  "totalPages": 1,
+  "candidates": [
+    {
+      "userId": "6a...",
+      "email": "learner@example.com",
+      "name": "Learner Name",
+      "courseVersionId": "6a...",
+      "completedAt": "2026-02-01T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+Candidates are sorted by `completedAt` ascending (earliest finisher first).
+A learner whose enrollment is no longer `ACTIVE` (unenrolled/ejected after
+completing) is excluded, even if their `progress.completed` is still `true`.
+
+**Example**
+
+```bash
+curl -H "X-API-Key: $INTEGRATION_API_KEY" \
+  "https://<host>/api/integrations/courses/<courseId>/completions?page=1&limit=50"
+```
+
+## `GET /integrations/learners/completions`
+
+Platform-wide roster: every active `STUDENT` learner, each with the full list
+of courses they've completed. Paginated by *learner*, not by completion —
+prefer the course-scoped endpoint above when you only care about one course.
+
+**Query params:** `page` (default `1`), `limit` (default `50`, max `200`).
+
+See the controller's `@OpenAPI` annotations (also served live at `/reference`)
+for its full response shape.

--- a/backend/src/modules/users/controllers/IntegrationController.ts
+++ b/backend/src/modules/users/controllers/IntegrationController.ts
@@ -6,6 +6,7 @@ import {
   JsonController,
   Get,
   HttpCode,
+  Param,
   QueryParam,
   UseBefore,
 } from 'routing-controllers';
@@ -63,6 +64,40 @@ class IntegrationController {
     }>;
   }> {
     return await this.enrollmentService.getLearnersWithCompletedCourses(
+      page,
+      limit,
+    );
+  }
+
+  @OpenAPI({
+    summary: 'List candidates who completed a specific course',
+    description:
+      'Returns a paginated roster of candidates who have completed the ' +
+      'given course (identified by `courseId`). Authenticate with the ' +
+      '`X-API-Key` header. Use `page` and `limit` (max 200) to page through ' +
+      'candidates.',
+  })
+  @Get('/courses/:courseId/completions')
+  @HttpCode(200)
+  async getCourseCompletions(
+    @Param('courseId') courseId: string,
+    @QueryParam('page') page = 1,
+    @QueryParam('limit') limit = 50,
+  ): Promise<{
+    page: number;
+    limit: number;
+    totalCandidates: number;
+    totalPages: number;
+    candidates: Array<{
+      userId: string;
+      email: string;
+      name: string;
+      courseVersionId: string;
+      completedAt?: Date;
+    }>;
+  }> {
+    return await this.enrollmentService.getCourseCompletions(
+      courseId,
       page,
       limit,
     );

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -2996,4 +2996,48 @@ export class EnrollmentService extends BaseService {
       learners,
     };
   }
+
+  /**
+   * Returns a paginated roster of candidates who have completed a single,
+   * specific course. Backs the server-to-server integration endpoint.
+   */
+  async getCourseCompletions(
+    courseId: string,
+    page: number,
+    limit: number,
+  ): Promise<{
+    page: number;
+    limit: number;
+    totalCandidates: number;
+    totalPages: number;
+    candidates: Array<{
+      userId: string;
+      email: string;
+      name: string;
+      courseVersionId: string;
+      completedAt?: Date;
+    }>;
+  }> {
+    if (!ObjectId.isValid(courseId)) {
+      throw new BadRequestError(`Invalid courseId: ${courseId}`);
+    }
+
+    const safePage = Math.max(1, Math.floor(page) || 1);
+    const safeLimit = Math.min(Math.max(1, Math.floor(limit) || 50), 200);
+    const skip = (safePage - 1) * safeLimit;
+
+    const { total, candidates } = await this.enrollmentRepo.getCourseCompletions(
+      courseId,
+      skip,
+      safeLimit,
+    );
+
+    return {
+      page: safePage,
+      limit: safeLimit,
+      totalCandidates: total,
+      totalPages: Math.ceil(total / safeLimit),
+      candidates,
+    };
+  }
 }

--- a/backend/src/modules/users/tests/EnrollmentRepository.courseCompletions.test.ts
+++ b/backend/src/modules/users/tests/EnrollmentRepository.courseCompletions.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { MongoDatabase } from '#shared/database/providers/mongo/MongoDatabase.js';
+import { EnrollmentRepository } from '#shared/database/providers/mongo/repositories/EnrollmentRepository.js';
+
+/**
+ * Repository-level tests for EnrollmentRepository.getCourseCompletions,
+ * which backs the `/integrations/courses/:courseId/completions` endpoint.
+ * Runs against the in-memory Mongo replica set started in test/globalSetup.ts.
+ */
+describe('EnrollmentRepository.getCourseCompletions', () => {
+  let db: MongoDatabase;
+  let repo: EnrollmentRepository;
+
+  const courseId = new ObjectId();
+  const otherCourseId = new ObjectId();
+  const courseVersionId = new ObjectId();
+
+  const finisher = { _id: new ObjectId(), email: 'finisher@example.com', firstName: 'Fin', lastName: 'Isher' };
+  const finisher2 = { _id: new ObjectId(), email: 'finisher2@example.com', firstName: 'Fin2', lastName: 'Isher2' };
+  const activeLearner = { _id: new ObjectId(), email: 'active@example.com', firstName: 'Act', lastName: 'Ive' };
+  const ejectedFinisher = { _id: new ObjectId(), email: 'ejected@example.com', firstName: 'Eje', lastName: 'Cted' };
+  const otherCourseFinisher = { _id: new ObjectId(), email: 'othercourse@example.com', firstName: 'Other', lastName: 'Course' };
+
+  beforeAll(async () => {
+    db = new MongoDatabase(process.env.DB_URL, 'enrollment_repo_course_completions_test');
+    await db.connect();
+    repo = new EnrollmentRepository(db);
+
+    const users = await db.getCollection('users');
+    await users.insertMany([finisher, finisher2, activeLearner, ejectedFinisher, otherCourseFinisher] as any);
+
+    const enrollments = await db.getCollection('enrollment');
+    await enrollments.insertMany([
+      {
+        userId: finisher._id,
+        courseId,
+        courseVersionId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        enrollmentDate: new Date('2026-01-01'),
+        percentCompleted: 100,
+        isDeleted: false,
+      },
+      {
+        userId: finisher2._id,
+        courseId,
+        courseVersionId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        enrollmentDate: new Date('2026-01-01'),
+        percentCompleted: 100,
+        isDeleted: false,
+      },
+      {
+        userId: activeLearner._id,
+        courseId,
+        courseVersionId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        enrollmentDate: new Date('2026-01-01'),
+        percentCompleted: 40,
+        isDeleted: false,
+      },
+      // Completed the course, but the enrollment itself is no longer active
+      // (e.g. unenrolled/ejected afterwards) — should NOT be reported.
+      {
+        userId: ejectedFinisher._id,
+        courseId,
+        courseVersionId,
+        role: 'STUDENT',
+        status: 'INACTIVE',
+        enrollmentDate: new Date('2026-01-01'),
+        percentCompleted: 100,
+        isDeleted: false,
+      },
+      // Completed a *different* course — should not leak into this course's results.
+      {
+        userId: otherCourseFinisher._id,
+        courseId: otherCourseId,
+        courseVersionId,
+        role: 'STUDENT',
+        status: 'ACTIVE',
+        enrollmentDate: new Date('2026-01-01'),
+        percentCompleted: 100,
+        isDeleted: false,
+      },
+    ] as any);
+
+    const progress = await db.getCollection('progress');
+    await progress.insertMany([
+      {
+        userId: finisher._id,
+        courseId,
+        courseVersionId,
+        completed: true,
+        completedAt: new Date('2026-02-01'),
+      },
+      {
+        userId: finisher2._id,
+        courseId,
+        courseVersionId,
+        completed: true,
+        completedAt: new Date('2026-02-15'),
+      },
+      {
+        userId: activeLearner._id,
+        courseId,
+        courseVersionId,
+        completed: false,
+      },
+      {
+        userId: ejectedFinisher._id,
+        courseId,
+        courseVersionId,
+        completed: true,
+        completedAt: new Date('2026-02-05'),
+      },
+      {
+        userId: otherCourseFinisher._id,
+        courseId: otherCourseId,
+        courseVersionId,
+        completed: true,
+        completedAt: new Date('2026-02-10'),
+      },
+    ] as any);
+  });
+
+  afterAll(async () => {
+    await db.disconnect();
+  });
+
+  it('returns only active-enrollment candidates who completed the given course, earliest first', async () => {
+    const { total, candidates } = await repo.getCourseCompletions(
+      courseId.toString(),
+      0,
+      50,
+    );
+
+    expect(total).toBe(2);
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]).toMatchObject({
+      userId: finisher._id.toString(),
+      email: 'finisher@example.com',
+      name: 'Fin Isher',
+      courseVersionId: courseVersionId.toString(),
+    });
+    expect(new Date(candidates[0].completedAt).toISOString()).toBe(
+      new Date('2026-02-01').toISOString(),
+    );
+    expect(candidates[1].userId).toBe(finisher2._id.toString());
+  });
+
+  it('excludes learners who have not completed the course', async () => {
+    const { candidates } = await repo.getCourseCompletions(courseId.toString(), 0, 50);
+    expect(candidates.some(c => c.userId === activeLearner._id.toString())).toBe(false);
+  });
+
+  it('excludes completions tied to an inactive enrollment', async () => {
+    const { candidates } = await repo.getCourseCompletions(courseId.toString(), 0, 50);
+    expect(candidates.some(c => c.userId === ejectedFinisher._id.toString())).toBe(false);
+  });
+
+  it('scopes results to the requested course only', async () => {
+    const { total, candidates } = await repo.getCourseCompletions(
+      otherCourseId.toString(),
+      0,
+      50,
+    );
+    expect(total).toBe(1);
+    expect(candidates[0].userId).toBe(otherCourseFinisher._id.toString());
+  });
+
+  it('paginates via skip/limit', async () => {
+    const page1 = await repo.getCourseCompletions(courseId.toString(), 0, 1);
+    expect(page1.total).toBe(2);
+    expect(page1.candidates).toHaveLength(1);
+    expect(page1.candidates[0].userId).toBe(finisher._id.toString());
+
+    const page2 = await repo.getCourseCompletions(courseId.toString(), 1, 1);
+    expect(page2.candidates).toHaveLength(1);
+    expect(page2.candidates[0].userId).toBe(finisher2._id.toString());
+
+    const page3 = await repo.getCourseCompletions(courseId.toString(), 2, 1);
+    expect(page3.candidates).toHaveLength(0);
+  });
+
+  it('returns an empty result for a course with no completions', async () => {
+    const { total, candidates } = await repo.getCourseCompletions(
+      new ObjectId().toString(),
+      0,
+      50,
+    );
+    expect(total).toBe(0);
+    expect(candidates).toHaveLength(0);
+  });
+});

--- a/backend/src/modules/users/tests/EnrollmentService.courseCompletions.test.ts
+++ b/backend/src/modules/users/tests/EnrollmentService.courseCompletions.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { BadRequestError } from 'routing-controllers';
+import { ObjectId } from 'mongodb';
+import { EnrollmentService } from '#users/services/EnrollmentService.js';
+
+/**
+ * Unit tests for EnrollmentService.getCourseCompletions — the pagination
+ * clamping and validation wrapper around EnrollmentRepository.getCourseCompletions.
+ * Bypasses DI and stubs only enrollmentRepo, same approach as
+ * ProgressService.leaderboard.test.ts.
+ */
+function makeService(getCourseCompletions: (courseId: string, skip: number, limit: number) => Promise<any>) {
+  const service: any = Object.create(EnrollmentService.prototype);
+  service.enrollmentRepo = { getCourseCompletions };
+  return service as EnrollmentService;
+}
+
+describe('EnrollmentService.getCourseCompletions', () => {
+  const validCourseId = new ObjectId().toString();
+
+  it('rejects a non-ObjectId courseId before touching the repository', async () => {
+    const service = makeService(async () => {
+      throw new Error('should not be called');
+    });
+
+    await expect(
+      service.getCourseCompletions('not-a-valid-id', 1, 50),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it('converts page/limit into skip and passes safe defaults through', async () => {
+    let seen: any = null;
+    const service = makeService(async (courseId, skip, limit) => {
+      seen = { courseId, skip, limit };
+      return { total: 0, candidates: [] };
+    });
+
+    await service.getCourseCompletions(validCourseId, 3, 20);
+
+    expect(seen).toEqual({ courseId: validCourseId, skip: 40, limit: 20 });
+  });
+
+  it('clamps limit to 200 and floors page at 1', async () => {
+    let seen: any = null;
+    const service = makeService(async (courseId, skip, limit) => {
+      seen = { skip, limit };
+      return { total: 0, candidates: [] };
+    });
+
+    await service.getCourseCompletions(validCourseId, 0, 5000);
+
+    expect(seen).toEqual({ skip: 0, limit: 200 });
+  });
+
+  it('computes totalPages from the repository total and echoes candidates through', async () => {
+    const candidates = [{ userId: 'u1', email: 'a@b.com', name: 'A B', courseVersionId: 'v1', completedAt: new Date() }];
+    const service = makeService(async () => ({ total: 101, candidates }));
+
+    const result = await service.getCourseCompletions(validCourseId, 2, 50);
+
+    expect(result.page).toBe(2);
+    expect(result.limit).toBe(50);
+    expect(result.totalCandidates).toBe(101);
+    expect(result.totalPages).toBe(3);
+    expect(result.candidates).toBe(candidates);
+  });
+});

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -6017,4 +6017,122 @@ export class EnrollmentRepository {
 
     return { total, learners: learners as any };
   }
+
+  /**
+   * Returns the paginated roster of candidates who have completed one
+   * specific course (an active STUDENT enrollment on that course with a
+   * matching `progress` record where `completed: true`).
+   *
+   * Used by the server-to-server integration endpoint so external
+   * applications can pull completions for a single course.
+   */
+  async getCourseCompletions(
+    courseId: string,
+    skip: number,
+    limit: number,
+  ): Promise<{
+    total: number;
+    candidates: Array<{
+      userId: string;
+      email: string;
+      name: string;
+      courseVersionId: string;
+      completedAt?: Date;
+    }>;
+  }> {
+    await this.init();
+
+    const matchStage = {
+      role: { $regex: /^student$/i },
+      status: { $regex: /^active$/i },
+      isDeleted: { $ne: true },
+      $expr: { $eq: [{ $toString: '$courseId' }, courseId] },
+    };
+
+    const progressLookup = {
+      $lookup: {
+        from: 'progress',
+        let: {
+          uid: '$userId',
+          cid: '$courseId',
+          cvid: '$courseVersionId',
+        },
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  { $eq: [{ $toString: '$userId' }, { $toString: '$$uid' }] },
+                  { $eq: [{ $toString: '$courseId' }, { $toString: '$$cid' }] },
+                  {
+                    $eq: [
+                      { $toString: '$courseVersionId' },
+                      { $toString: '$$cvid' },
+                    ],
+                  },
+                ],
+              },
+              completed: true,
+              isDeleted: { $ne: true },
+            },
+          },
+          { $project: { _id: 0, completedAt: 1 } },
+        ],
+        as: 'progress',
+      },
+    };
+
+    const [countResult] = await this.enrollmentCollection
+      .aggregate([
+        { $match: matchStage },
+        progressLookup,
+        { $match: { 'progress.0': { $exists: true } } },
+        { $count: 'total' },
+      ])
+      .toArray();
+    const total: number = countResult?.total ?? 0;
+
+    const candidates = await this.enrollmentCollection
+      .aggregate([
+        { $match: matchStage },
+        progressLookup,
+        { $match: { 'progress.0': { $exists: true } } },
+        { $unwind: '$progress' },
+        { $sort: { 'progress.completedAt': 1, userId: 1 } },
+        { $skip: skip },
+        { $limit: limit },
+        {
+          $lookup: {
+            from: 'users',
+            localField: 'userId',
+            foreignField: '_id',
+            as: 'user',
+          },
+        },
+        { $unwind: '$user' },
+        {
+          $project: {
+            _id: 0,
+            userId: { $toString: '$userId' },
+            courseVersionId: { $toString: '$courseVersionId' },
+            email: '$user.email',
+            name: {
+              $trim: {
+                input: {
+                  $concat: [
+                    { $ifNull: ['$user.firstName', ''] },
+                    ' ',
+                    { $ifNull: ['$user.lastName', ''] },
+                  ],
+                },
+              },
+            },
+            completedAt: '$progress.completedAt',
+          },
+        },
+      ])
+      .toArray();
+
+    return { total, candidates: candidates as any };
+  }
 }


### PR DESCRIPTION
External applications need to pull the roster of candidates who completed a specific course (e.g. Foundation Course For Farm Advisors) rather than the whole-platform learner roster the existing /integrations/learners/completions endpoint returns. Adds GET /integrations/courses/:courseId/completions on the same API-key server-to-server auth, scoped to one course's active-enrollment completers.
