### PR TITLE
fix(ci): pass INTEGRATION_API_KEY through to Cloud Run deploys

### DIFF
--- a/.github/workflows/deploy-backend-all.yml
+++ b/.github/workflows/deploy-backend-all.yml
@@ -99,6 +99,7 @@ jobs:
             ENABLE_HP_JOB=${{ secrets.ENABLE_HP_JOB }}
             GCP_BACKUP_ACTIVITY_BUCKET=${{ secrets.GCP_BACKUP_ACTIVITY_BUCKET }}
             AI_PROXY_ADDRESS=socks5h://localhost:1055
+            INTEGRATION_API_KEY=${{ secrets.INTEGRATION_API_KEY }}
           flags: --allow-unauthenticated
 
   deploy_production:
@@ -143,4 +144,5 @@ jobs:
             ENABLE_HP_JOB=${{ secrets.ENABLE_HP_JOB }}
             GCP_BACKUP_ACTIVITY_BUCKET=${{ secrets.GCP_BACKUP_ACTIVITY_BUCKET }}
             AI_PROXY_ADDRESS=socks5h://localhost:1055
+            INTEGRATION_API_KEY=${{ secrets.INTEGRATION_API_KEY }}
           flags: --allow-unauthenticated


### PR DESCRIPTION
The /integrations/* endpoints (learners/completions, courses/:courseId/completions) authenticate via a shared X-API-Key secret and fail closed if it's unset. The deploy workflow never forwarded INTEGRATION_API_KEY to Cloud Run, so those endpoints would 500 in staging and production regardless of whether the secret exists in GitHub. Requires an INTEGRATION_API_KEY secret to be added to the Staging and Production GitHub environments separately.
