### PR TITLE
fix(auth): normalize role values when building ability context

### DIFF
--- a/backend/src/shared/functions/AbilityDecorator.ts
+++ b/backend/src/shared/functions/AbilityDecorator.ts
@@ -1,8 +1,37 @@
 import {getFromContainer, createParamDecorator} from 'routing-controllers';
-import {AuthenticatedUser} from '../interfaces/models.js';
+import {AuthenticatedUser, AuthenticatedUserEnrollements} from '../interfaces/models.js';
 import {FirebaseAuthService} from '#root/modules/auth/services/FirebaseAuthService.js';
 import {EnrollmentService} from '#root/modules/users/services/EnrollmentService.js';
 import {MongoAbility} from '@casl/ability';
+
+const VALID_ENROLLMENT_ROLES = ['STUDENT', 'INSTRUCTOR', 'MANAGER', 'TA', 'STAFF'];
+
+/**
+ * `roles` on the raw user doc has been observed as either a scalar string or
+ * an array; normalize defensively so an array-shaped value doesn't silently
+ * fail a strict `=== 'admin'` check.
+ */
+function normalizeGlobalRole(roles: unknown): 'admin' | 'user' {
+  const values = Array.isArray(roles) ? roles : [roles];
+  return values.some(r => typeof r === 'string' && r.toLowerCase() === 'admin')
+    ? 'admin'
+    : 'user';
+}
+
+/**
+ * Enrollment role values in the DB are inconsistently cased (and sometimes
+ * null); normalize to the canonical uppercase enum so a stray `student` or
+ * `instructor` doesn't fall through every ability switch with zero grants.
+ */
+function normalizeEnrollmentRole(
+  role: unknown,
+): AuthenticatedUserEnrollements['role'] | null {
+  if (typeof role !== 'string') return null;
+  const upper = role.toUpperCase();
+  return VALID_ENROLLMENT_ROLES.includes(upper)
+    ? (upper as AuthenticatedUserEnrollements['role'])
+    : null;
+}
 
 /**
  * Parameter decorator that builds and injects user abilities into the controller method
@@ -37,12 +66,16 @@ export function Ability(
       // Create authenticated user object
       const authenticatedUser: AuthenticatedUser = {
         userId: user._id.toString(),
-        globalRole: user.roles,
-        enrollments: enrollments.map(enrollment => ({
-          courseId: enrollment.courseId.toString(),
-          versionId: enrollment.courseVersionId.toString(),
-          role: enrollment.role,
-        })),
+        globalRole: normalizeGlobalRole(user.roles),
+        enrollments: enrollments
+          .map(enrollment => ({
+            courseId: enrollment.courseId.toString(),
+            versionId: enrollment.courseVersionId.toString(),
+            role: normalizeEnrollmentRole(enrollment.role),
+          }))
+          .filter(
+            (e): e is AuthenticatedUserEnrollements => e.role !== null,
+          ),
       };
 
       // Build and return the ability using the provided builder function


### PR DESCRIPTION
Summary

- AbilityDecorator.ts fed raw DB values straight into the CASL ability context without validation. Two related gaps:

1. globalRole was set directly from user.roles, which the schema treats as 'admin' | 'user' but which has been observed array-shaped in practice — an array fails a strict === 'admin' check and silently loses admin rights.
2. enrollment.role values are inconsistently cased in the DB (student/instructor lowercase alongside canonical STUDENT/INSTRUCTOR) or null outright — none of these match any case in the per-module ability switch statements, so affected users got zero permissions with no error.

- Added normalizeGlobalRole() and normalizeEnrollmentRole() to coerce both into their canonical form (or drop the enrollment entirely if unrecognized) before they're used to build permissions.
- This is the single choke point that builds user.enrollments for every ability check in the app, so the fix applies uniformly across all modules without touching each module's ability file.
Why now: while auditing and restricting global admin access to 3 confirmed accounts, we found ~601 enrollment records (~3.6% of all enrollments) silently getting zero permissions due to the casing/null issue, plus the array/scalar fragility on globalRole.
