### PR TITLE
fix(setting): route decorators to bookSlot instead of formatBooking

### DIFF
--- a/backend/src/modules/setting/controllers/SlotBookingController.ts
+++ b/backend/src/modules/setting/controllers/SlotBookingController.ts
@@ -55,14 +55,6 @@ class SlotBookingController {
     private readonly slotBookingService: SlotBookingService,
   ) {}
 
-  @OpenAPI({
-    summary: 'Book a time slot',
-    description:
-      'A student books a time slot for a study day (default today). Booking for day D opens at 9 AM IST on D-2, and each slot stays bookable until its own start time on D, subject to the slot capacity cap and their per-day allowance.',
-  })
-  @Authorized()
-  @Post('/book')
-  @HttpCode(200)
   private formatBooking(b: any) {
     if (!b) return b;
     return {
@@ -76,6 +68,14 @@ class SlotBookingController {
     };
   }
 
+  @OpenAPI({
+    summary: 'Book a time slot',
+    description:
+      'A student books a time slot for a study day (default today). Booking for day D opens at 9 AM IST on D-2, and each slot stays bookable until its own start time on D, subject to the slot capacity cap and their per-day allowance.',
+  })
+  @Authorized()
+  @Post('/book')
+  @HttpCode(200)
   async bookSlot(
     @Body() body: BookSlotRequestBody,
     @CurrentUser() user: IUser,


### PR DESCRIPTION
**Summary**
Students got a 404 when booking a time slot. #1159 inserted a new private formatBooking helper directly between the @Authorized() / @Post('/book') / @HttpCode(200) decorators and the bookSlot method they were meant to decorate, without moving the decorators down. Decorators bind to whichever declaration follows them, so:

POST /slot-bookings/book got wired to formatBooking (an undecorated helper called with no args, which returns undefined).
bookSlot — the method with the actual booking logic — had no HTTP decorators, so routing-controllers never registered it as a route.
routing-controllers treats an undefined action result as unhandled and throws its default NotFoundError, which is the 404 students hit.
**Fix**
Move @OpenAPI(...) / @Authorized() / @Post('/book') / @HttpCode(200) off formatBooking and onto bookSlot, where they belong. formatBooking remains a plain private helper (still called correctly at line 95 inside bookSlot).