### PR TITLE
Fix/CSV item-upload correctness bugs and scope AI question generation

### DIFF
--- a/backend/src/modules/courses/services/ItemService.ts
+++ b/backend/src/modules/courses/services/ItemService.ts
@@ -1447,6 +1447,25 @@ export class ItemService extends BaseService {
                 .get(timestamp)!)
             : previousEndTime + 300;
 
+          if (timestamp !== undefined && Number.isNaN(endTime)) {
+            throw new Error(
+              `Segment ${segmentNumber} has an invalid timestamp "${timestamp}". Expected "MM:SS" format.`,
+            );
+          }
+
+          // A video segment's timestamp marks where its context ends, so segments
+          // must be strictly increasing; otherwise this segment's video would
+          // start after (or at) the point it's supposed to end.
+          if (endTime <= previousEndTime) {
+            throw new Error(
+              `Segment ${segmentNumber}'s timestamp (${this._formatSecondsToHHMMSS(
+                endTime,
+              )}) must be after the previous segment's end time (${this._formatSecondsToHHMMSS(
+                previousEndTime,
+              )}). Segments must appear in increasing chronological order.`,
+            );
+          }
+
           // Create video item
           const videoItem = await this.createItem(
             versionId,
@@ -1517,7 +1536,10 @@ export class ItemService extends BaseService {
 
           // Process questions
           for (const question of segmentQuestions) {
-            const options = [
+            // Index against the full, unfiltered A-D array so the letter in
+            // "Correct Answer" always lines up with its own column, even when
+            // an earlier option is blank.
+            const allOptions = [
               {
                 text: question['Option A'] || '',
                 explanation: question['Expln-A'] || '',
@@ -1534,17 +1556,19 @@ export class ItemService extends BaseService {
                 text: question['Option D'] || '',
                 explanation: question['Expln-D'] || '',
               },
-            ].filter(opt => opt.text);
+            ];
 
             const correctAnswer = question['Correct Answer']?.toUpperCase();
             const correctOptionIndex = correctAnswer
               ? correctAnswer.charCodeAt(0) - 65
               : -1;
 
-            if (
-              correctOptionIndex >= 0 &&
-              correctOptionIndex < options.length
-            ) {
+            const correctOption =
+              correctOptionIndex >= 0 && correctOptionIndex < allOptions.length
+                ? allOptions[correctOptionIndex]
+                : undefined;
+
+            if (correctOption && correctOption.text) {
               const questionBody = {
                 question: {
                   text: question.Question || '',
@@ -1558,13 +1582,12 @@ export class ItemService extends BaseService {
                 },
                 solution: {
                   correctLotItem: {
-                    text: options[correctOptionIndex].text,
+                    text: correctOption.text,
                     explaination:
-                      options[correctOptionIndex].explanation ||
-                      'No explanation provided',
+                      correctOption.explanation || 'No explanation provided',
                   },
-                  incorrectLotItems: options
-                    .filter((_, i) => i !== correctOptionIndex)
+                  incorrectLotItems: allOptions
+                    .filter((opt, i) => i !== correctOptionIndex && opt.text)
                     .map(opt => ({
                       text: opt.text,
                       explaination:

--- a/backend/src/modules/quizzes/classes/validators/QuestionValidator.ts
+++ b/backend/src/modules/quizzes/classes/validators/QuestionValidator.ts
@@ -22,6 +22,7 @@ import {
   IsBoolean,
   IsOptional,
   IsMongoId,
+  IsIn,
   IsInt,
   Max,
   Min,
@@ -649,6 +650,28 @@ class GenerateAIQuestionsBody {
   @IsString()
   @IsOptional()
   text?: string;
+
+  @IsMongoId()
+  @IsOptional()
+  courseId?: string;
+
+  @IsMongoId()
+  @IsOptional()
+  versionId?: string;
+
+  @IsIn(['beginner', 'intermediate', 'advanced'])
+  @IsOptional()
+  difficulty?: 'beginner' | 'intermediate' | 'advanced';
+
+  @IsString()
+  @Length(0, 300)
+  @IsOptional()
+  focusAreas?: string;
+
+  @IsString()
+  @Length(0, 300)
+  @IsOptional()
+  avoidTopics?: string;
 }
 
 export {

--- a/backend/src/modules/quizzes/controllers/QuestionController.ts
+++ b/backend/src/modules/quizzes/controllers/QuestionController.ts
@@ -48,6 +48,8 @@ import { AuditAction, AuditCategory, OutComeStatus } from '#root/modules/auditTr
 import { ObjectId } from 'mongodb';
 import { setAuditTrail } from '#root/utils/setAuditTrail.js';
 import { QuestionBankService } from '../services/QuestionBankService.js';
+import { USERS_TYPES } from '#root/modules/users/types.js';
+import { EnrollmentRepository } from '#root/shared/index.js';
 
 @OpenAPI({
   tags: ['Questions'],
@@ -60,7 +62,10 @@ class QuestionController {
     private readonly questionService: QuestionService,
 
     @inject(QUIZZES_TYPES.QuestionBankService)
-    private readonly questionBankService: QuestionBankService
+    private readonly questionBankService: QuestionBankService,
+
+    @inject(USERS_TYPES.EnrollmentRepo)
+    private readonly enrollmentRepository: EnrollmentRepository,
   ) {}
 
   @OpenAPI({
@@ -407,7 +412,7 @@ class QuestionController {
     description: `Generates questions based on the provided topic or content.<br/>
     It returns the generated questions array.`,
   })
-  // @Authorized()
+  @Authorized()
   @Post('/generate-csv-res')
   @ResponseSchema(BadRequestErrorResponse, {
     description: 'Invalid request body or insufficient data',
@@ -419,8 +424,41 @@ class QuestionController {
   })
   async generateAIQuestions(
     @Body() body: GenerateAIQuestionsBody,
+    @Ability(getQuestionAbility) {ability, user},
   ): Promise<{success: boolean; response: TranscriptResponse[]}> {
-    let {text} = body;
+    if (!ability.can(QuestionActions.Create, 'Question')) {
+      throw new ForbiddenError(
+        'You do not have permission to generate questions',
+      );
+    }
+
+    const userId = user._id.toString();
+    let {text, courseId, versionId, difficulty, focusAreas, avoidTopics} =
+      body;
+
+    // The INSTRUCTOR/MANAGER "Create Question" ability above is granted
+    // globally, not per-course, so it alone doesn't stop an instructor from
+    // passing an arbitrary courseId and pulling that course's name/description
+    // into their prompt. Explicitly confirm enrollment in the requested course
+    // before letting its metadata be fetched. Admins (full "manage" ability)
+    // are exempt, matching how course access is treated elsewhere.
+    if (courseId && !ability.can('manage', 'Question')) {
+      const enrollments = await this.enrollmentRepository.getAllEnrollments(
+        userId,
+      );
+      const hasCourseAccess = enrollments.some(
+        enrollment =>
+          enrollment.courseId?.toString() === courseId &&
+          (!versionId ||
+            enrollment.courseVersionId?.toString() === versionId) &&
+          ['INSTRUCTOR', 'MANAGER'].includes(enrollment.role),
+      );
+      if (!hasCourseAccess) {
+        throw new ForbiddenError(
+          'You do not have permission to generate questions for this course',
+        );
+      }
+    }
 
     const timestampRegex =
       /\b\d{2};\d{2};\d{2};\d{2}\s*-\s*\d{2};\d{2};\d{2};\d{2}\b/;
@@ -479,20 +517,19 @@ class QuestionController {
    
 
     let allSegments: TranscriptResponse[] = [];
-    // for (const chunk of chunks) {
-    //   const segments = await this.questionService.generateQuestionsWithAI(
-    //     'userId',
-    //     chunk,
-    //   );
-    //   allSegments = allSegments.concat(segments);
-    // }
 
     if(chunks && chunks.length > 90)
       throw new BadRequestError(`Given segments are too large, please try reducing content.`)
 
     const results = await Promise.all(
       chunks.map(chunk =>
-        this.questionService.generateQuestionsWithAI('userId', chunk),
+        this.questionService.generateQuestionsWithAI(userId, chunk, {
+          courseId,
+          versionId,
+          difficulty,
+          focusAreas,
+          avoidTopics,
+        }),
       ),
     );
 

--- a/backend/src/modules/quizzes/services/QuestionService.ts
+++ b/backend/src/modules/quizzes/services/QuestionService.ts
@@ -18,6 +18,15 @@ import {aiConfig} from '#root/config/ai.js';
 import {Anthropic} from '@anthropic-ai/sdk';
 import {TranscriptResponse} from '#root/shared/index.js';
 import JSON5 from 'json5';
+import {ICourseRepository} from '#root/shared/database/interfaces/ICourseRepository.js';
+
+interface AIQuestionGenerationContext {
+  courseId?: string;
+  versionId?: string;
+  difficulty?: 'beginner' | 'intermediate' | 'advanced';
+  focusAreas?: string;
+  avoidTopics?: string;
+}
 
 @injectable()
 class QuestionService extends BaseService {
@@ -36,10 +45,71 @@ class QuestionService extends BaseService {
     @inject(QUIZZES_TYPES.QuizRepo)
     private quizRepository: QuizRepository,
 
+    @inject(GLOBAL_TYPES.CourseRepo)
+    private courseRepository: ICourseRepository,
+
     @inject(GLOBAL_TYPES.Database)
     private database: MongoDatabase, // Replace with actual database type if needed
   ) {
     super(database);
+  }
+
+  /**
+   * Best-effort: instructor-supplied context is a quality hint, not a
+   * requirement, so a lookup failure (bad id, deleted course, etc.) must not
+   * block question generation.
+   */
+  private async _buildCourseContextBlock(
+    context: AIQuestionGenerationContext | undefined,
+    session: ClientSession,
+  ): Promise<string> {
+    if (!context) return '';
+
+    const lines: string[] = [];
+
+    if (context.courseId) {
+      try {
+        const course = await this.courseRepository.read(
+          context.courseId,
+          session,
+        );
+        if (course?.name) lines.push(`Course: ${course.name}`);
+        if (course?.description)
+          lines.push(`Course description: ${course.description}`);
+      } catch {
+        // ignore — proceed without course metadata
+      }
+    }
+
+    if (context.versionId) {
+      try {
+        const version = await this.courseRepository.readVersion(
+          context.versionId,
+          session,
+        );
+        if (version?.description)
+          lines.push(`Version description: ${version.description}`);
+      } catch {
+        // ignore — proceed without version metadata
+      }
+    }
+
+    if (context.difficulty)
+      lines.push(`Target difficulty: ${context.difficulty}`);
+    if (context.focusAreas) lines.push(`Emphasize: ${context.focusAreas}`);
+    if (context.avoidTopics) lines.push(`Avoid: ${context.avoidTopics}`);
+
+    if (lines.length === 0) return '';
+
+    return `
+    ================================
+    COURSE CONTEXT
+    ================================
+    Use this context to keep questions relevant to the course, but still
+    generate them ONLY from the transcript content below — do not invent
+    facts about the course that aren't in the transcript.
+    ${lines.join('\n    ')}
+`;
   }
 
   private async _getQuestionSkipCount(
@@ -298,12 +368,18 @@ class QuestionService extends BaseService {
   public async generateQuestionsWithAI(
     userId: string,
     text: string,
+    context?: AIQuestionGenerationContext,
   ): Promise<TranscriptResponse[]> {
     return this._withTransaction(async session => {
       try {
         if (!text || text.trim().length === 0) {
           throw new BadRequestError('Input text cannot be empty');
         }
+
+        const courseContextBlock = await this._buildCourseContextBlock(
+          context,
+          session,
+        );
 
         const prompt = `
     You are an expert MERN stack educator and question-generation specialist. You will generate high-quality Multiple Choice Questions (MCQs) based ONLY on the provided video transcript text.
@@ -351,7 +427,7 @@ class QuestionService extends BaseService {
     - No extra fields outside the schema
     - MUST be valid JSON that can be parsed directly
     - Every field must be present and always a string where required
-
+${courseContextBlock}
     ================================
     CONTENT RULES
     ================================

--- a/frontend/src/app/pages/teacher/teacher-course-page.tsx
+++ b/frontend/src/app/pages/teacher/teacher-course-page.tsx
@@ -1715,6 +1715,8 @@ function TeacherCourseContent() {
       <QuestionUploadDialog
         open={showCSVUpload}
         onOpenChange={setShowCSVUpload}
+        courseId={courseId}
+        versionId={versionId}
         onUploadComplete={async (youtubeUrl: string, csvFile: File) => {
           // Let errors propagate so QuestionUploadDialog can report the real
           // failure rather than showing a false "Content uploaded" success.

--- a/frontend/src/components/question-upload-dialog.tsx
+++ b/frontend/src/components/question-upload-dialog.tsx
@@ -21,6 +21,11 @@ interface QuestionUploadDialogProps {
   onUploadComplete: (youtubeURL: string,  csvFile:File) => Promise<void>
   moduleId?: string;
   sectionId?: string;
+  // Used to pull in course context (name/description) server-side and to scope
+  // the "generate questions" ability check. Only relevant to the AI-assisted
+  // (Smart Upload) path.
+  courseId?: string;
+  versionId?: string;
   // "video-segments" (default): existing flow that pairs a YouTube URL with a segmented CSV.
   // "quiz-questions": upload a CSV of questions to populate a single quiz; hides the YouTube URL
   // field, the Smart Upload button, and uses the quiz-questions CSV template + help text.
@@ -44,6 +49,8 @@ export const QuestionUploadDialog = ({
   open,
   onOpenChange,
   onUploadComplete,
+  courseId,
+  versionId,
   mode = "video-segments",
 }: QuestionUploadDialogProps) => {
   const isQuizQuestionsMode = mode === "quiz-questions";
@@ -64,6 +71,11 @@ export const QuestionUploadDialog = ({
   const [generalError, setGeneralError] = useState("")
   const [messageIndex, setMessageIndex] = useState(0);
 
+  // Optional context to steer the AI generation prompt toward this course.
+  const [difficulty, setDifficulty] = useState<"beginner" | "intermediate" | "advanced" | "">("");
+  const [focusAreas, setFocusAreas] = useState("");
+  const [avoidTopics, setAvoidTopics] = useState("");
+
   const [showAdvancedFlow, setShowAdvancedFlow] = useState(false)
 
   const { mutateAsync: generateQuestions, data, error: generateQuestionsError, isPending } = useGenerateAIQuestions();
@@ -78,6 +90,9 @@ export const QuestionUploadDialog = ({
     setGeneratedCSV("");
     setCustomCSVFile(null);
     setUseCustomCSV(false);
+    setDifficulty("");
+    setFocusAreas("");
+    setAvoidTopics("");
   };
 
   const handleClose = () => {
@@ -214,7 +229,14 @@ const handleGenerateLLMResponse = async () => {
     setStep("generating");
 
     const response = await generateQuestions({
-      body: { text: textContent }
+      body: {
+        text: textContent,
+        courseId,
+        versionId,
+        difficulty: difficulty || undefined,
+        focusAreas: focusAreas.trim() || undefined,
+        avoidTopics: avoidTopics.trim() || undefined,
+      }
     });
 
     toast.success("Question generation completed");
@@ -661,6 +683,50 @@ const handleGenerateLLMResponse = async () => {
                     </p>
                   )}
                 </div>
+
+                <div className="space-y-4 rounded-lg border p-4">
+                  <Label className="text-sm font-semibold">Question context (optional)</Label>
+                  <p className="text-xs text-muted-foreground -mt-2">
+                    Helps the AI tailor questions to this course. Questions are still generated only from the transcript above.
+                  </p>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="difficulty">Target difficulty</Label>
+                    <Select value={difficulty || undefined} onValueChange={(val) => setDifficulty(val as typeof difficulty)}>
+                      <SelectTrigger id="difficulty">
+                        <span>{difficulty ? difficulty[0].toUpperCase() + difficulty.slice(1) : "Select difficulty"}</span>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="beginner">Beginner</SelectItem>
+                        <SelectItem value="intermediate">Intermediate</SelectItem>
+                        <SelectItem value="advanced">Advanced</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="focus-areas">Emphasize</Label>
+                    <Input
+                      id="focus-areas"
+                      placeholder="e.g. debugging workflow, not syntax"
+                      value={focusAreas}
+                      maxLength={300}
+                      onChange={(e) => setFocusAreas(e.target.value)}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="avoid-topics">Avoid</Label>
+                    <Input
+                      id="avoid-topics"
+                      placeholder="e.g. deployment, covered in another module"
+                      value={avoidTopics}
+                      maxLength={300}
+                      onChange={(e) => setAvoidTopics(e.target.value)}
+                    />
+                  </div>
+                </div>
+
                 {generalError && (
                     <p className="text-red-500 text-sm mt-2">{generalError}</p>
                   )}

--- a/frontend/src/hooks/hooks.ts
+++ b/frontend/src/hooks/hooks.ts
@@ -5251,6 +5251,11 @@ export const useHideItem = (): {
 
 export interface GenerateAIQuestionsBody {
   text?: string;
+  courseId?: string;
+  versionId?: string;
+  difficulty?: 'beginner' | 'intermediate' | 'advanced';
+  focusAreas?: string;
+  avoidTopics?: string;
 }
 
 export const useGenerateAIQuestions = (): {


### PR DESCRIPTION
Two related fixes to the "Add Item → Upload CSV" / "Smart Upload (Claude AI)" flow on the teacher course page:

1. CSV → item correctness bugs (ItemService.processCSVAndCreateItems)

Blank Option A-D cells were filtered out before indexing into them by the Correct Answer letter. A blank option before the correct one silently shifted the index, so the wrong option got marked correct in the created question — with no error surfaced. Fixed by indexing against the full, unfiltered A-D array and only dropping blanks when building the incorrect-options list.
Video segments are sliced using each segment's timestamp as its end time (context-before-timestamp semantics). There was no guard against out-of-order or unparseable timestamps, which could silently produce a video item with startTime > endTime. Now these fail the upload with a clear per-segment error.
2. AI question generation (/quizzes/questions/generate-csv-res) had no real access control

@Authorized() was commented out and the caller's user ID was a hardcoded 'userId' placeholder — the endpoint was reachable by anyone, misattributing generated questions.
Re-enabled auth, added the same Create Question ability check used elsewhere, and now use the real authenticated user.
Since the underlying INSTRUCTOR/MANAGER ability is granted globally (not per-course), added an explicit enrollment check: if a courseId is passed, the caller must actually be enrolled as INSTRUCTOR/MANAGER in that course (and version, if given) before its metadata can be used. Admins are exempt.
3. Instructor-supplied context for the prompt

Added an optional "Question context" panel to the Smart Upload wizard (target difficulty, what to emphasize, what to avoid).
courseId/versionId are passed through so the backend can best-effort fetch the course/version name + description and splice a COURSE CONTEXT block into the Claude prompt — scoped as steering only. A failed metadata lookup never blocks generation.