### PR TITLE
Feat/course transfer and admin role

### DIFF
--- a/backend/src/modules/courses/abilities/courseAbilities.ts
+++ b/backend/src/modules/courses/abilities/courseAbilities.ts
@@ -7,7 +7,8 @@ export enum CourseActions {
     Create = "create",
     Modify = "modify",
     Delete = "delete",
-    View = "view"
+    View = "view",
+    Export = "export"
 }
 
 // Subjects
@@ -42,9 +43,14 @@ export function setupCourseAbilities(
                 break;
             case 'INSTRUCTOR':
                 // Instructors hold the same permissions as an admin, narrowed
-                // to their own courses — except creating and deleting courses.
+                // to their own courses — except creating and deleting courses,
+                // and exporting one.
                 can('manage', 'Course', courseBounded);
                 cannot(CourseActions.Delete, 'Course', courseBounded);
+                // Exporting lifts an entire course out of the platform, so it
+                // stays with admins and managers. The deny is explicit because
+                // the `manage` grant above would otherwise cover it.
+                cannot(CourseActions.Export, 'Course', courseBounded);
                 break;
             case 'MANAGER':
                 can('manage', 'Course', courseBounded);

--- a/backend/src/modules/courses/controllers/CourseTransferController.ts
+++ b/backend/src/modules/courses/controllers/CourseTransferController.ts
@@ -31,10 +31,6 @@ import {
   ExportCourseVersionParams,
   ImportCourseResponse,
 } from '#courses/classes/validators/CourseTransferValidators.js';
-import {
-  CourseVersionActions,
-  getCourseVersionAbility,
-} from '../abilities/versionAbilities.js';
 import {CourseActions, getCourseAbility} from '../abilities/courseAbilities.js';
 import {CourseNotFoundErrorResponse} from '#courses/classes/validators/CourseValidators.js';
 
@@ -55,8 +51,9 @@ export class CourseTransferController {
 
   @OpenAPI({
     summary: 'Export a course version',
-    description: `Serialises a course version into a self-contained JSON bundle that can be imported on another ViBe server.<br/><br/>${NOT_CARRIED_BY_BUNDLE}<br/><br/>Accessible to:
-- Instructor or Manager of the course version.`,
+    description: `Serialises the named course version into a self-contained JSON bundle that can be imported on another ViBe server. The version to bundle is always given explicitly, and the bundle records which one it was.<br/><br/>${NOT_CARRIED_BY_BUNDLE}<br/><br/>Accessible to:
+- Admins, for any course.
+- Managers of the course.`,
   })
   @Authorized()
   @Get('/:courseId/version/:versionId/export')
@@ -71,16 +68,19 @@ export class CourseTransferController {
   })
   async export(
     @Params() params: ExportCourseVersionParams,
-    @Ability(getCourseVersionAbility) {ability, user},
+    @Ability(getCourseAbility) {ability, user},
     @Req() req: any,
     @Res() res: any,
   ) {
     const {courseId, versionId} = params;
 
-    const versionSubject = subject('CourseVersion', {versionId});
-    if (!ability.can(CourseVersionActions.Modify, versionSubject)) {
+    // Gated at the course level, not the version: exporting is a
+    // whole-course capability held by admins and managers, and deliberately
+    // not by instructors of the course.
+    const courseSubject = subject('Course', {courseId});
+    if (!ability.can(CourseActions.Export, courseSubject)) {
       throw new ForbiddenError(
-        'You do not have permission to export this course version',
+        'You do not have permission to export this course',
       );
     }
 

--- a/backend/src/modules/courses/tests/roleMatrix.test.ts
+++ b/backend/src/modules/courses/tests/roleMatrix.test.ts
@@ -148,6 +148,54 @@ describe('Role matrix: admin vs instructor', () => {
     });
   });
 
+  describe('Export is an admin and manager capability, held at course level', () => {
+    it('lets an admin export any course', () => {
+      const ability = getCourseAbility(admin);
+      expect(ability.can(CourseActions.Export, ownCourse)).toBe(true);
+      expect(ability.can(CourseActions.Export, otherCourse)).toBe(true);
+    });
+
+    it('lets a manager export their own course but not another', () => {
+      const ability = getCourseAbility(manager);
+      expect(ability.can(CourseActions.Export, ownCourse)).toBe(true);
+      expect(ability.can(CourseActions.Export, otherCourse)).toBe(false);
+    });
+
+    it('denies instructors, TAs and students', () => {
+      for (const user of [instructor, ta, student]) {
+        expect(
+          getCourseAbility(user).can(CourseActions.Export, ownCourse),
+        ).toBe(false);
+      }
+    });
+
+    it('does not let an instructor inherit export from their manage grant', () => {
+      // Regression guard: instructors hold `manage` on their own course, which
+      // covers every action unless export is denied explicitly.
+      const ability = getCourseAbility(instructor);
+      expect(ability.can(CourseActions.Modify, ownCourse)).toBe(true);
+      expect(ability.can(CourseActions.Export, ownCourse)).toBe(false);
+    });
+
+    it('still lets someone export a course they manage while instructing another', () => {
+      const both: AuthenticatedUser = {
+        userId: 'u-both',
+        globalRole: 'user',
+        enrollments: [
+          {courseId: COURSE, versionId: VERSION, role: 'INSTRUCTOR'} as any,
+          {
+            courseId: OTHER_COURSE,
+            versionId: OTHER_VERSION,
+            role: 'MANAGER',
+          } as any,
+        ],
+      };
+      const ability = getCourseAbility(both);
+      expect(ability.can(CourseActions.Export, otherCourse)).toBe(true);
+      expect(ability.can(CourseActions.Export, ownCourse)).toBe(false);
+    });
+  });
+
   describe('Students and TAs are unaffected', () => {
     it('keeps students read-only on their own course', () => {
       const ability = getCourseAbility(student);


### PR DESCRIPTION
### 3. Export is admin + manager, at course level

`CourseActions.Export` is checked against the **Course** subject, not the version.
Admins hold it everywhere, managers on their own courses. Instructors get an
explicit deny — they hold `manage` on their own courses, which would otherwise
cover it. Import remains admin-only, since importing creates a course.
