### PR TITLE
feat(courses): import and export a course bundle from the UI

### DIFF
--- a/frontend/src/app/pages/teacher/AddCoursePage.tsx
+++ b/frontend/src/app/pages/teacher/AddCoursePage.tsx
@@ -3,13 +3,15 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Loader2, BookOpen, Plus, AlertCircle, CheckCircle, Rocket, GitBranch, HelpCircle, Lightbulb, Info, GraduationCap, Activity  } from "lucide-react";
+import { Loader2, BookOpen, Plus, AlertCircle, CheckCircle, Rocket, GitBranch, HelpCircle, Lightbulb, Info, GraduationCap, Activity, Upload  } from "lucide-react";
 import { useCreateCourse } from "@/hooks/hooks";
 import { Label } from "@/components/ui/label";
 import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import ImportCourseBundle from "./components/ImportCourseBundle";
 
 const MAX_DESCRIPTION_LENGTH = 1000;
 
@@ -129,7 +131,19 @@ export default function CreateCourse() {
       <div className="max-w-4xl mx-auto py-4 space-y-8">
         <CreateCourseHeader />
 
-        <div className="space-y-8">
+        <Tabs defaultValue="create" className="space-y-8">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="create">
+              <Plus className="h-4 w-4 mr-2" />
+              Create new
+            </TabsTrigger>
+            <TabsTrigger value="import">
+              <Upload className="h-4 w-4 mr-2" />
+              Import bundle
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="create" className="space-y-8">
 
           <CourseMetaForm
             courseDescription={courseDescription}
@@ -180,7 +194,12 @@ export default function CreateCourse() {
             />
           )}
 
-        </div>
+          </TabsContent>
+
+          <TabsContent value="import">
+            <ImportCourseBundle />
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   );
@@ -294,7 +313,7 @@ export const CreateCourseHeader = () => {
               d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>
-          Only administrators can create new courses.
+          Only administrators can create or import courses.
         </p>
       </div>
     </div>

--- a/frontend/src/app/pages/teacher/components/ImportCourseBundle.tsx
+++ b/frontend/src/app/pages/teacher/components/ImportCourseBundle.tsx
@@ -1,0 +1,271 @@
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  AlertCircle,
+  CheckCircle,
+  FileJson,
+  Info,
+  Loader2,
+  Upload,
+  X,
+} from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  BUNDLE_CARRIES,
+  BUNDLE_OMITS,
+  CourseBundle,
+  importCourseBundle,
+  parseCourseBundle,
+  summariseBundle,
+} from "@/lib/course-transfer";
+
+type PickedBundle = {
+  file: File;
+  bundle: CourseBundle;
+  summary: ReturnType<typeof summariseBundle>;
+};
+
+/**
+ * Uploads a .vibe.json bundle exported from another ViBe server and creates the
+ * course here. The importing admin becomes the instructor of the new course.
+ */
+export default function ImportCourseBundle() {
+  const [picked, setPicked] = useState<PickedBundle | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isImporting, setIsImporting] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const acceptFile = async (file: File) => {
+    setError(null);
+    try {
+      const bundle = await parseCourseBundle(file);
+      setPicked({ file, bundle, summary: summariseBundle(bundle) });
+    } catch (err: any) {
+      setPicked(null);
+      const message = err?.message || "Could not read that file";
+      setError(message);
+      toast.error(message, { position: "top-right", duration: 5000 });
+    }
+  };
+
+  const handleImport = async () => {
+    if (!picked) return;
+    setIsImporting(true);
+    setError(null);
+    try {
+      const result = await importCourseBundle(picked.bundle);
+      queryClient.invalidateQueries({
+        queryKey: ["get", "/users/enrollments"],
+        exact: false,
+      });
+      toast.success(result.message || `Imported "${result.name}"`, {
+        position: "top-right",
+        duration: 5000,
+      });
+      setTimeout(() => {
+        navigate({ to: "/teacher" });
+      }, 1500);
+    } catch (err: any) {
+      const message = err?.message || "Failed to import the course";
+      setError(message);
+      toast.error(message, { position: "top-right", duration: 5000 });
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <Card className="bg-card/95 backdrop-blur-sm border-border/50">
+        <CardContent className="p-6 space-y-6">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+              <FileJson className="h-5 w-5 text-primary" />
+              Import a course bundle
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Pick a <span className="font-mono text-xs">.vibe.json</span> file exported from a
+              course version on another ViBe server. A new course is created here and you become
+              its instructor.
+            </p>
+          </div>
+
+          {/* Drop zone */}
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={() => fileInputRef.current?.click()}
+            onKeyDown={e => {
+              if (e.key === "Enter" || e.key === " ") fileInputRef.current?.click();
+            }}
+            onDragOver={e => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragLeave={() => setIsDragging(false)}
+            onDrop={e => {
+              e.preventDefault();
+              setIsDragging(false);
+              const file = e.dataTransfer.files?.[0];
+              if (file) acceptFile(file);
+            }}
+            className={`flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed p-8 text-center transition-colors cursor-pointer ${
+              isDragging
+                ? "border-primary bg-primary/5"
+                : "border-border hover:border-primary/50 hover:bg-muted/30"
+            }`}
+          >
+            <Upload className="h-6 w-6 text-muted-foreground" />
+            <span className="text-sm font-medium text-foreground">
+              Drop a bundle here, or click to choose a file
+            </span>
+            <span className="text-xs text-muted-foreground">
+              JSON exported from a course version
+            </span>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              onChange={e => {
+                const file = e.target.files?.[0];
+                if (file) acceptFile(file);
+                // Let the same file be picked again after a failed import.
+                e.target.value = "";
+              }}
+            />
+          </div>
+
+          {/* Picked bundle summary */}
+          {picked && (
+            <div className="rounded-xl border border-border/60 bg-muted/20 p-4 space-y-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="font-semibold text-foreground truncate">
+                    {picked.bundle.course.name}
+                  </p>
+                  <p className="text-sm text-muted-foreground truncate">
+                    Version {picked.bundle.version.version} &middot; {picked.file.name}
+                  </p>
+                  {picked.bundle.exportedAt && (
+                    <p className="text-xs text-muted-foreground">
+                      Exported {new Date(picked.bundle.exportedAt).toLocaleString()}
+                    </p>
+                  )}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => {
+                    setPicked(null);
+                    setError(null);
+                  }}
+                  disabled={isImporting}
+                  aria-label="Remove selected bundle"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+
+              <div className="grid grid-cols-2 sm:grid-cols-5 gap-2">
+                {[
+                  { label: "Modules", value: picked.summary.modules },
+                  { label: "Sections", value: picked.summary.sections },
+                  { label: "Items", value: picked.summary.items },
+                  { label: "Banks", value: picked.summary.questionBanks },
+                  { label: "Questions", value: picked.summary.questions },
+                ].map(stat => (
+                  <div
+                    key={stat.label}
+                    className="rounded-lg bg-background/60 border border-border/50 p-2 text-center"
+                  >
+                    <div className="text-lg font-semibold text-foreground">{stat.value}</div>
+                    <div className="text-xs text-muted-foreground">{stat.label}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="flex items-start gap-3 p-4 rounded-xl bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400">
+              <AlertCircle className="h-5 w-5 shrink-0 mt-0.5" />
+              <div>
+                <span className="font-semibold text-sm">Import failed</span>
+                <div className="text-sm opacity-90">{error}</div>
+              </div>
+            </div>
+          )}
+
+          <Button
+            className="w-full"
+            size="lg"
+            onClick={handleImport}
+            disabled={!picked || isImporting}
+          >
+            {isImporting ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Importing&hellip; this can take a minute for a large course
+              </>
+            ) : (
+              <>
+                <CheckCircle className="h-4 w-4 mr-2" />
+                Import course
+              </>
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* What travels and what does not */}
+      <Card className="bg-card/95 backdrop-blur-sm border-border/50">
+        <CardContent className="p-6">
+          <div className="flex items-center gap-2 mb-4">
+            <Info className="h-4 w-4 text-primary" />
+            <h3 className="font-semibold text-foreground">What a bundle carries</h3>
+          </div>
+          <div className="grid sm:grid-cols-2 gap-6">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Included
+              </p>
+              <ul className="space-y-1.5">
+                {BUNDLE_CARRIES.map(entry => (
+                  <li key={entry} className="flex items-start gap-2 text-sm text-foreground">
+                    <CheckCircle className="h-4 w-4 mt-0.5 shrink-0 text-green-600 dark:text-green-500" />
+                    {entry}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Not included
+              </p>
+              <ul className="space-y-1.5">
+                {BUNDLE_OMITS.map(entry => (
+                  <li key={entry} className="flex items-start gap-2 text-sm text-muted-foreground">
+                    <X className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+                    {entry}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+          <p className="mt-4 text-xs text-muted-foreground italic">
+            The imported course is always created non-public, and linear progression always comes
+            up enabled — switch it off afterwards if the original had it off.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/app/pages/teacher/components/expandable-question-card.tsx
+++ b/frontend/src/app/pages/teacher/components/expandable-question-card.tsx
@@ -1177,8 +1177,7 @@ const ExpandableQuestionCard: React.FC<ExpandableQuestionCardProps> = ({
                     <Edit2 className="h-4 w-4 mr-2" />
                     Edit Question
                   </Button>
-                ) : null
-                )}
+                ) : null}
               </div>
             </div>
           </CollapsibleContent>

--- a/frontend/src/app/pages/teacher/course-page.tsx
+++ b/frontend/src/app/pages/teacher/course-page.tsx
@@ -29,6 +29,7 @@ import {
   RotateCcw,
   FlagTriangleRight,
   Copy,
+  Download,
   UserCheck,
   Headphones,
   ExternalLink,
@@ -74,6 +75,7 @@ import type { RawEnrollment } from "@/types/course.types"
 import { components } from "@/types/schema"
 import { useAnomalyStore } from "@/store/anomaly-store"
 import { ProjectSubmissionsDownloadButton } from "./components/ProjectSubmissionsDownloadButton"
+import { downloadCourseBundle } from "@/lib/course-transfer"
 import { toast } from "sonner"
 import ConfirmationModal from "./components/confirmation-modal"
 import { AnnouncementModal } from "@/components/announcements/AnnouncementModal"
@@ -1219,6 +1221,7 @@ function VersionCard({
   const { setCurrentCourseFlag } = useFlagStore()
   const { setCurrentAnomaly } = useAnomalyStore();
   const [isCopyModalOpen, setIsCopyModalOpen] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
 
   // Edit state variables 
   const [editingVersion, setEditingVersion] = useState(false)
@@ -1538,6 +1541,23 @@ function VersionCard({
       toast.error('Failed to generate link. Please try again.');
     }
   };
+  // Downloads the version as a portable bundle for import on another server.
+  const handleExportVersion = async () => {
+    if (!courseId || !selectedVersionId) {
+      toast.error('Failed to find course or version id, try again!');
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const fileName = await downloadCourseBundle(courseId, selectedVersionId);
+      toast.success(`Exported as ${fileName}`);
+    } catch (error: any) {
+      toast.error(error?.message || 'Failed to export this course version');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   const handleCopy = async () => {
     try {
       if (!courseId || !selectedVersionId) {
@@ -1691,6 +1711,15 @@ function VersionCard({
                       <DropdownMenuItem onClick={() => setIsCopyModalOpen(true)}>
                         <Copy className="mr-2 h-4 w-4" />
                         Clone
+                      </DropdownMenuItem>
+
+                      <DropdownMenuItem onClick={handleExportVersion} disabled={isExporting}>
+                        {isExporting ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                          <Download className="mr-2 h-4 w-4" />
+                        )}
+                        Export
                       </DropdownMenuItem>
 
                       <DropdownMenuItem onClick={configureCohorts}>

--- a/frontend/src/lib/course-transfer.ts
+++ b/frontend/src/lib/course-transfer.ts
@@ -1,0 +1,202 @@
+/**
+ * Moving a course between ViBe servers as a JSON bundle.
+ *
+ * Backed by the transfer endpoints:
+ *   GET  /courses/:courseId/version/:versionId/export
+ *   POST /courses/import
+ *
+ * These are not reached through the generated openapi client because the
+ * checked-in schema predates them; they use the same raw-fetch pattern as the
+ * other export downloads in the app.
+ */
+
+/**
+ * Bundle format the client knows how to hand over. Kept in step with
+ * BUNDLE_FORMAT_VERSION in the backend's CourseTransferValidators.
+ */
+export const BUNDLE_FORMAT_VERSION = 1;
+
+export type CourseBundle = {
+  formatVersion: number;
+  exportedAt?: string;
+  source?: {courseId?: string; courseVersionId?: string};
+  course: {name: string; description?: string};
+  version: {version: string; description?: string; supportLink?: string};
+  modules: unknown[];
+  questionBanks: unknown[];
+  settings?: Record<string, unknown>;
+};
+
+export type ImportCourseResult = {
+  courseId: string;
+  versionId: string;
+  name: string;
+  message: string;
+};
+
+/** What the bundle deliberately leaves behind, shown before an import runs. */
+export const BUNDLE_CARRIES = [
+  'Course and version details',
+  'Modules, sections and items in their original order',
+  'Question banks and their questions',
+  'Course settings (proctoring, seek-forward, linear progression)',
+];
+
+export const BUNDLE_OMITS = [
+  'Enrollments, cohorts and invites',
+  'Student progress, watch time and HP',
+  'Announcements and ejection history',
+  'Crowd-sourced student questions',
+  'AI transcripts and segment context',
+];
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem('firebase-auth-token');
+  return token ? {Authorization: `Bearer ${token}`} : {};
+}
+
+async function errorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const body = await response.json();
+    if (Array.isArray(body?.errors) && body.errors.length > 0) {
+      const constraints = body.errors[0]?.constraints;
+      const first = constraints ? Object.values(constraints)[0] : undefined;
+      if (typeof first === 'string') return first;
+    }
+    if (typeof body?.message === 'string') return body.message;
+  } catch {
+    // Non-JSON body (a proxy timeout page, say) — fall through.
+  }
+  return fallback;
+}
+
+function slugify(value: string): string {
+  return (
+    (value || 'course')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') || 'course'
+  );
+}
+
+/**
+ * Downloads a version as a .vibe.json bundle. Resolves to the file name written
+ * so the caller can name it in a toast.
+ */
+export async function downloadCourseBundle(
+  courseId: string,
+  versionId: string,
+): Promise<string> {
+  const baseUrl = import.meta.env.VITE_BASE_URL;
+  const response = await fetch(
+    `${baseUrl}/courses/${courseId}/version/${versionId}/export`,
+    {
+      method: 'GET',
+      headers: {...authHeaders(), 'Content-Type': 'application/json'},
+      credentials: 'include',
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      await errorMessage(response, 'Failed to export this course version'),
+    );
+  }
+
+  const bundle = (await response.json()) as CourseBundle;
+  const fileName = `${slugify(bundle?.course?.name)}-${slugify(
+    bundle?.version?.version,
+  )}.vibe.json`;
+
+  const blob = new Blob([JSON.stringify(bundle)], {type: 'application/json'});
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+
+  return fileName;
+}
+
+/**
+ * Reads a picked file and checks it is a bundle this client can send, so an
+ * unreadable or wrong-format file fails locally rather than after a
+ * multi-megabyte upload.
+ */
+export async function parseCourseBundle(file: File): Promise<CourseBundle> {
+  let bundle: unknown;
+  try {
+    bundle = JSON.parse(await file.text());
+  } catch {
+    throw new Error('That file is not valid JSON. Pick a .vibe.json bundle.');
+  }
+
+  const candidate = bundle as Partial<CourseBundle>;
+  if (
+    !candidate ||
+    typeof candidate !== 'object' ||
+    typeof candidate.formatVersion !== 'number' ||
+    !candidate.course ||
+    !candidate.version ||
+    !Array.isArray(candidate.modules) ||
+    !Array.isArray(candidate.questionBanks)
+  ) {
+    throw new Error(
+      'That file is not a ViBe course bundle. Export one from a course version first.',
+    );
+  }
+
+  if (candidate.formatVersion > BUNDLE_FORMAT_VERSION) {
+    throw new Error(
+      `This bundle uses format version ${candidate.formatVersion}, but this server understands version ${BUNDLE_FORMAT_VERSION}. Upgrade the server before importing.`,
+    );
+  }
+
+  return candidate as CourseBundle;
+}
+
+/** Counts shown in the confirmation summary before the upload. */
+export function summariseBundle(bundle: CourseBundle): {
+  modules: number;
+  sections: number;
+  items: number;
+  questionBanks: number;
+  questions: number;
+} {
+  const modules = (bundle.modules ?? []) as any[];
+  const sections = modules.flatMap(m => (m?.sections ?? []) as any[]);
+  const items = sections.flatMap(s => (s?.items ?? []) as any[]);
+  const banks = (bundle.questionBanks ?? []) as any[];
+
+  return {
+    modules: modules.length,
+    sections: sections.length,
+    items: items.length,
+    questionBanks: banks.length,
+    questions: banks.reduce((sum, b) => sum + (b?.questions?.length ?? 0), 0),
+  };
+}
+
+export async function importCourseBundle(
+  bundle: CourseBundle,
+): Promise<ImportCourseResult> {
+  const baseUrl = import.meta.env.VITE_BASE_URL;
+  const response = await fetch(`${baseUrl}/courses/import`, {
+    method: 'POST',
+    headers: {...authHeaders(), 'Content-Type': 'application/json'},
+    credentials: 'include',
+    body: JSON.stringify(bundle),
+  });
+
+  if (!response.ok) {
+    if (response.status === 403) {
+      throw new Error('Only administrators can import a course.');
+    }
+    throw new Error(await errorMessage(response, 'Failed to import the course'));
+  }
+
+  return (await response.json()) as ImportCourseResult;
+}


### PR DESCRIPTION
The transfer endpoints shipped without any interface, so moving a course between servers meant running exportCourseVersion.ts and importCourseBundle.ts against the database by hand. This puts both halves in front of an admin.

  Export -> version dropdown on the course page, downloads
            <course>-<version>.vibe.json
  Import -> a tab on the Create Course page

Both call the endpoints through raw fetch rather than the generated openapi client: the checked-in schema predates these routes, and regenerating it is a much larger change than this. That is the same pattern the other export downloads already use.

A picked file is parsed and checked before it is sent, so a wrong file fails locally rather than after a multi-megabyte upload: it must be JSON, must carry formatVersion, course, version, modules and questionBanks, and its formatVersion must not be newer than the client understands. What survives that is summarised back to the importer -- course name, version, export date and counts of modules, sections, items, banks and questions -- before anything is uploaded.

The import tab also states what a bundle does not carry (enrollments, cohorts, progress, watch time, HP, announcements, ejection history, crowd questions, AI transcripts) and the two surprises on arrival: the course is always created non-public, and linear progression always comes up enabled.

Also fixes an unrelated stray ")" in expandable-question-card.tsx that closed a JSX expression. It is a parse error, so tsc -b could not pass and type checking was suppressed across the whole frontend.

