### PR TITLE
fix(enrollments): restore cohort filter and 0-progress fallback on co…

### DIFF
--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -1062,6 +1062,16 @@ export class EnrollmentService extends BaseService {
     cohort?: string,
   ) {
     return this._withTransaction(async (session: ClientSession) => {
+      if (!ObjectId.isValid(courseId) || !ObjectId.isValid(courseVersionId)) {
+        // readVersion below would throw a BSONError (surfacing as a 500) on a
+        // malformed id; treat it the same as an unknown version.
+        return {
+          enrollments: [],
+          totalCount: 0,
+          totalPages: 0,
+          currentPage: 0,
+        };
+      }
       const courseVersion = await this.courseRepo.readVersion(
         courseVersionId,
         session,

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -1567,14 +1567,23 @@ export class EnrollmentRepository {
   ) {
     await this.init();
 
+    if (!ObjectId.isValid(courseId) || !ObjectId.isValid(courseVersionId)) {
+      return {
+        totalDocuments: 0,
+        totalPages: 0,
+        currentPage: limit > 0 ? Math.floor(skip / limit) + 1 : 1,
+        enrollments: [],
+      };
+    }
+
     const baseMatch: any = {
       courseId: { $in: [courseId, new ObjectId(courseId)] },
       courseVersionId: { $in: [courseVersionId, new ObjectId(courseVersionId)] },
     };
 
-    // if (cohort) {
-    //   baseMatch.cohortId = new ObjectId(cohort);
-    // }
+    if (cohort && ObjectId.isValid(cohort)) {
+      baseMatch.cohortId = new ObjectId(cohort);
+    }
     // else if (cohorts && cohorts.length > 0 && filter === 'STUDENT') {
     //   // baseMatch.cohortId = { $in: cohorts };
     // }
@@ -1619,6 +1628,10 @@ export class EnrollmentRepository {
               onNull: null,
             },
           },
+          // Enrollments that never recorded a progress event have no
+          // percentCompleted field; coerce so the value returned to the client
+          // and the progress sort below both see 0 rather than missing.
+          percentCompleted: { $ifNull: ['$percentCompleted', 0] },
         },
       },
       {


### PR DESCRIPTION
GET /users/enrollments/courses/:courseId/versions/:versionId returned wrong data for the instructor progress table:

- The cohort filter was commented out in 925abe8ad (an unrelated HP reward-cron commit), so the cohort query param was accepted, threaded through the service and then ignored. On a multi-cohort version every cohort's enrollment rows were returned, showing learners twice with different percentages. Restored, with an ObjectId.isValid guard so a malformed value no longer throws.

- courseId/courseVersionId were converted with an unguarded new ObjectId(), turning a malformed path param into a BSONError 500. Guarded in the repository and in the service, which reaches CourseRepository.readVersion (also unguarded) first. Both return the existing empty-page shape used for an unknown version.

- percentCompleted was returned raw, so enrollments with no progress event yielded undefined instead of 0. Coerced with $ifNull in the shared aggregation stage so the progress sort sees the same value as the client; previously that sort ordered never-started enrollments on a missing field.

