### PR TITLE
feat(integrations): expose course version progress to external applic…

### DIFF
--- a/backend/src/modules/users/controllers/IntegrationController.ts
+++ b/backend/src/modules/users/controllers/IntegrationController.ts
@@ -102,6 +102,54 @@ class IntegrationController {
       limit,
     );
   }
+
+  @OpenAPI({
+    summary: 'Get the progress roster for a course version',
+    description:
+      'Returns a paginated roster of every active learner on the given course ' +
+      'version together with how far through they are — including learners ' +
+      'who have not finished. Authenticate with the `X-API-Key` header. ' +
+      'Pass `cohortId` to scope the roster to a single cohort: on a ' +
+      'multi-cohort version, omitting it returns every cohort and a learner ' +
+      'enrolled in two cohorts appears once per cohort. Use `page` and ' +
+      '`limit` (max 200) to page through learners.',
+  })
+  @Get('/courses/:courseId/versions/:versionId/progress')
+  @HttpCode(200)
+  async getCourseVersionProgress(
+    @Param('courseId') courseId: string,
+    @Param('versionId') versionId: string,
+    @QueryParam('cohortId') cohortId?: string,
+    @QueryParam('page') page = 1,
+    @QueryParam('limit') limit = 50,
+  ): Promise<{
+    page: number;
+    limit: number;
+    totalLearners: number;
+    totalPages: number;
+    cohortId: string | null;
+    learners: Array<{
+      userId: string;
+      email: string;
+      name: string;
+      courseVersionId: string;
+      cohortId: string | null;
+      percentCompleted: number;
+      completedItems: number;
+      totalItems: number;
+      completed: boolean;
+      completedAt?: Date;
+      enrolledAt?: Date;
+    }>;
+  }> {
+    return await this.enrollmentService.getCourseVersionProgress(
+      courseId,
+      versionId,
+      cohortId,
+      page,
+      limit,
+    );
+  }
 }
 
 export { IntegrationController };

--- a/backend/src/modules/users/services/EnrollmentService.ts
+++ b/backend/src/modules/users/services/EnrollmentService.ts
@@ -3050,4 +3050,73 @@ export class EnrollmentService extends BaseService {
       candidates,
     };
   }
+
+  /**
+   * Returns the paginated progress roster for one course version — every
+   * active student with a completion percentage, not just those who finished.
+   * Backs the server-to-server integration endpoint.
+   *
+   * An unknown course/version or an empty cohort yields an empty page rather
+   * than an error: "nobody has started yet" is a valid answer, not a fault.
+   */
+  async getCourseVersionProgress(
+    courseId: string,
+    courseVersionId: string,
+    cohortId: string | undefined,
+    page: number,
+    limit: number,
+  ): Promise<{
+    page: number;
+    limit: number;
+    totalLearners: number;
+    totalPages: number;
+    cohortId: string | null;
+    learners: Array<{
+      userId: string;
+      email: string;
+      name: string;
+      courseVersionId: string;
+      cohortId: string | null;
+      percentCompleted: number;
+      completedItems: number;
+      totalItems: number;
+      completed: boolean;
+      completedAt?: Date;
+      enrolledAt?: Date;
+    }>;
+  }> {
+    if (!ObjectId.isValid(courseId)) {
+      throw new BadRequestError(`Invalid courseId: ${courseId}`);
+    }
+    if (!ObjectId.isValid(courseVersionId)) {
+      throw new BadRequestError(`Invalid courseVersionId: ${courseVersionId}`);
+    }
+    // Reject rather than silently ignore: a typo'd cohortId that fell through
+    // would return every cohort's rows and look like correct data.
+    if (cohortId && !ObjectId.isValid(cohortId)) {
+      throw new BadRequestError(`Invalid cohortId: ${cohortId}`);
+    }
+
+    const safePage = Math.max(1, Math.floor(page) || 1);
+    const safeLimit = Math.min(Math.max(1, Math.floor(limit) || 50), 200);
+    const skip = (safePage - 1) * safeLimit;
+
+    const { total, learners } =
+      await this.enrollmentRepo.getCourseProgressRoster(
+        courseId,
+        courseVersionId,
+        cohortId,
+        skip,
+        safeLimit,
+      );
+
+    return {
+      page: safePage,
+      limit: safeLimit,
+      totalLearners: total,
+      totalPages: Math.ceil(total / safeLimit),
+      cohortId: cohortId ?? null,
+      learners,
+    };
+  }
 }

--- a/backend/src/modules/users/tests/EnrollmentService.courseVersionProgress.test.ts
+++ b/backend/src/modules/users/tests/EnrollmentService.courseVersionProgress.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { BadRequestError } from 'routing-controllers';
+import { ObjectId } from 'mongodb';
+import { EnrollmentService } from '#users/services/EnrollmentService.js';
+
+/**
+ * Unit tests for EnrollmentService.getCourseVersionProgress — the validation
+ * and pagination wrapper around EnrollmentRepository.getCourseProgressRoster
+ * that backs the server-to-server progress integration endpoint.
+ * Bypasses DI and stubs only enrollmentRepo, same approach as
+ * EnrollmentService.courseCompletions.test.ts.
+ */
+function makeService(
+  getCourseProgressRoster: (
+    courseId: string,
+    courseVersionId: string,
+    cohortId: string | undefined,
+    skip: number,
+    limit: number,
+  ) => Promise<any>,
+) {
+  const service: any = Object.create(EnrollmentService.prototype);
+  service.enrollmentRepo = { getCourseProgressRoster };
+  return service as EnrollmentService;
+}
+
+describe('EnrollmentService.getCourseVersionProgress', () => {
+  const courseId = new ObjectId().toString();
+  const versionId = new ObjectId().toString();
+  const cohortId = new ObjectId().toString();
+
+  const neverCalled = makeService(async () => {
+    throw new Error('repository should not be called');
+  });
+
+  it('rejects a non-ObjectId courseId before touching the repository', async () => {
+    await expect(
+      (neverCalled as any).getCourseVersionProgress('nope', versionId, undefined, 1, 50),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it('rejects a non-ObjectId versionId before touching the repository', async () => {
+    await expect(
+      (neverCalled as any).getCourseVersionProgress(courseId, 'nope', undefined, 1, 50),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it('rejects a malformed cohortId rather than silently returning every cohort', async () => {
+    await expect(
+      (neverCalled as any).getCourseVersionProgress(courseId, versionId, 'nope', 1, 50),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it('converts page/limit into skip and threads cohortId through', async () => {
+    let seen: any = null;
+    const service: any = makeService(async (cid, vid, cohort, skip, limit) => {
+      seen = { cid, vid, cohort, skip, limit };
+      return { total: 0, learners: [] };
+    });
+
+    await service.getCourseVersionProgress(courseId, versionId, cohortId, 3, 20);
+
+    expect(seen).toEqual({
+      cid: courseId,
+      vid: versionId,
+      cohort: cohortId,
+      skip: 40,
+      limit: 20,
+    });
+  });
+
+  it('clamps limit to 200 and floors page at 1', async () => {
+    let seen: any = null;
+    const service: any = makeService(async (_c, _v, _co, skip, limit) => {
+      seen = { skip, limit };
+      return { total: 0, learners: [] };
+    });
+
+    await service.getCourseVersionProgress(courseId, versionId, undefined, 0, 5000);
+
+    expect(seen).toEqual({ skip: 0, limit: 200 });
+  });
+
+  it('returns an empty page instead of throwing when nobody has started', async () => {
+    const service: any = makeService(async () => ({ total: 0, learners: [] }));
+
+    const result = await service.getCourseVersionProgress(
+      courseId,
+      versionId,
+      cohortId,
+      1,
+      50,
+    );
+
+    expect(result.totalLearners).toBe(0);
+    expect(result.totalPages).toBe(0);
+    expect(result.learners).toEqual([]);
+    expect(result.cohortId).toBe(cohortId);
+  });
+
+  it('computes totalPages and echoes partially-complete learners through', async () => {
+    const learners = [
+      {
+        userId: 'u1',
+        email: 'a@b.com',
+        name: 'A B',
+        courseVersionId: versionId,
+        cohortId,
+        percentCompleted: 42,
+        completedItems: 21,
+        totalItems: 50,
+        completed: false,
+      },
+    ];
+    const service: any = makeService(async () => ({ total: 101, learners }));
+
+    const result = await service.getCourseVersionProgress(
+      courseId,
+      versionId,
+      cohortId,
+      2,
+      50,
+    );
+
+    expect(result).toEqual({
+      page: 2,
+      limit: 50,
+      totalLearners: 101,
+      totalPages: 3,
+      cohortId,
+      learners,
+    });
+  });
+
+  it('reports a null cohortId when the caller did not scope to one', async () => {
+    const service: any = makeService(async () => ({ total: 0, learners: [] }));
+
+    const result = await service.getCourseVersionProgress(
+      courseId,
+      versionId,
+      undefined,
+      1,
+      50,
+    );
+
+    expect(result.cohortId).toBeNull();
+  });
+});

--- a/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/EnrollmentRepository.ts
@@ -6173,4 +6173,179 @@ export class EnrollmentRepository {
 
     return { total, candidates: candidates as any };
   }
+
+  /**
+   * Returns the paginated progress roster for one course version: every active
+   * STUDENT enrollment with its completion percentage, whether or not the
+   * learner has finished. Unlike {@link getCourseCompletions} this does not
+   * filter on `completed: true`, so partially-through learners are included.
+   *
+   * `cohortId` is honoured when supplied — on a multi-cohort version, omitting
+   * it returns every cohort's rows and a learner enrolled in two cohorts
+   * appears once per cohort, so callers that care about a single cohort must
+   * pass it. Backs the server-to-server integration endpoint.
+   */
+  async getCourseProgressRoster(
+    courseId: string,
+    courseVersionId: string,
+    cohortId: string | undefined,
+    skip: number,
+    limit: number,
+  ): Promise<{
+    total: number;
+    learners: Array<{
+      userId: string;
+      email: string;
+      name: string;
+      courseVersionId: string;
+      cohortId: string | null;
+      percentCompleted: number;
+      completedItems: number;
+      totalItems: number;
+      completed: boolean;
+      completedAt?: Date;
+      enrolledAt?: Date;
+    }>;
+  }> {
+    await this.init();
+
+    const courseIdObj = ObjectId.isValid(courseId)
+      ? new ObjectId(courseId)
+      : null;
+    const versionIdObj = ObjectId.isValid(courseVersionId)
+      ? new ObjectId(courseVersionId)
+      : null;
+    const cohortIdObj =
+      cohortId && ObjectId.isValid(cohortId) ? new ObjectId(cohortId) : null;
+
+    // Malformed ids can never match; return the empty page rather than letting
+    // an unguarded `new ObjectId()` throw a BSONError 500.
+    if (!courseIdObj || !versionIdObj) {
+      return { total: 0, learners: [] };
+    }
+
+    const matchStage: Record<string, unknown> = {
+      role: { $regex: /^student$/i },
+      status: { $regex: /^active$/i },
+      isDeleted: { $ne: true },
+      courseId: { $in: [courseId, courseIdObj] },
+      courseVersionId: { $in: [courseVersionId, versionIdObj] },
+      ...(cohortIdObj ? { cohortId: cohortIdObj } : {}),
+    };
+
+    const [countResult] = await this.enrollmentCollection
+      .aggregate([{ $match: matchStage }, { $count: 'total' }])
+      .toArray();
+    const total: number = countResult?.total ?? 0;
+
+    const learners = await this.enrollmentCollection
+      .aggregate([
+        { $match: matchStage },
+        // Stable ordering for pagination: furthest along first, then a
+        // tiebreaker so a learner never repeats or vanishes across pages.
+        { $sort: { percentCompleted: -1, userId: 1 } },
+        { $skip: skip },
+        { $limit: limit },
+        {
+          $lookup: {
+            from: 'users',
+            let: { uid: { $toObjectId: '$userId' } },
+            pipeline: [
+              { $match: { $expr: { $eq: ['$_id', '$$uid'] } } },
+              { $project: { firstName: 1, lastName: 1, email: 1 } },
+            ],
+            as: 'user',
+          },
+        },
+        { $unwind: { path: '$user', preserveNullAndEmptyArrays: true } },
+        {
+          $lookup: {
+            from: 'newCourseVersion',
+            let: { vid: { $toObjectId: '$courseVersionId' } },
+            pipeline: [
+              { $match: { $expr: { $eq: ['$_id', '$$vid'] } } },
+              { $project: { totalItems: 1 } },
+            ],
+            as: 'version',
+          },
+        },
+        { $unwind: { path: '$version', preserveNullAndEmptyArrays: true } },
+        // `completed` / `completedAt` live on the progress doc, not the
+        // enrollment, and are cohort-scoped the same way.
+        {
+          $lookup: {
+            from: 'progress',
+            let: {
+              uid: '$userId',
+              cid: '$courseId',
+              cvid: '$courseVersionId',
+            },
+            pipeline: [
+              {
+                $match: {
+                  $expr: {
+                    $and: [
+                      { $eq: [{ $toString: '$userId' }, { $toString: '$$uid' }] },
+                      {
+                        $eq: [{ $toString: '$courseId' }, { $toString: '$$cid' }],
+                      },
+                      {
+                        $eq: [
+                          { $toString: '$courseVersionId' },
+                          { $toString: '$$cvid' },
+                        ],
+                      },
+                      ...(cohortIdObj
+                        ? [{ $eq: ['$cohortId', cohortIdObj] }]
+                        : []),
+                    ],
+                  },
+                  isDeleted: { $ne: true },
+                },
+              },
+              { $project: { _id: 0, completed: 1, completedAt: 1 } },
+            ],
+            as: 'progress',
+          },
+        },
+        { $unwind: { path: '$progress', preserveNullAndEmptyArrays: true } },
+        {
+          $project: {
+            _id: 0,
+            userId: { $toString: '$userId' },
+            email: '$user.email',
+            name: {
+              $trim: {
+                input: {
+                  $concat: [
+                    { $ifNull: ['$user.firstName', ''] },
+                    ' ',
+                    { $ifNull: ['$user.lastName', ''] },
+                  ],
+                },
+              },
+            },
+            courseVersionId: { $toString: '$courseVersionId' },
+            cohortId: {
+              $cond: [
+                { $ifNull: ['$cohortId', false] },
+                { $toString: '$cohortId' },
+                null,
+              ],
+            },
+            // An enrollment with no progress event yet has no percentCompleted
+            // field at all; coerce so callers always see a number.
+            percentCompleted: { $ifNull: ['$percentCompleted', 0] },
+            completedItems: { $ifNull: ['$completedItemsCount', 0] },
+            totalItems: { $ifNull: ['$version.totalItems', 0] },
+            completed: { $ifNull: ['$progress.completed', false] },
+            completedAt: '$progress.completedAt',
+            enrolledAt: '$enrollmentDate',
+          },
+        },
+      ])
+      .toArray();
+
+    return { total, learners: learners as any };
+  }
 }


### PR DESCRIPTION
## Problem

Applications outside ViBe cannot read progress values for Summership (or any) courses.

The only API-key-authenticated surface, `IntegrationController`, exposes **completions only** — its aggregation matches `completed: true`, so a learner 80% through a course is absent from the response, indistinguishable from one who never started.

Every endpoint that carries real progress numbers (`/percentage`, `/modules`, `/current-path`, `/leaderboard`) is unreachable server-to-server, by three independent gates:

1. `@Authorized()` requires a Firebase per-user ID token; an API key gets you nothing.
2. The userId is read from the token, never the request (`user._id.toString()`), so even a valid learner token only ever returns that one learner — no roster.
3. CASL abilities are enrollment-scoped; a caller with no enrollment gets `ForbiddenError`.

The `/leaderboard/no-auth` route looks like the intended escape hatch, but despite its name it still carries `@Authorized()` and returns **401**. Its ability check is also broken independently: the subject is built as `{ courseId, versionId }` with no `userId`, while a STUDENT's grant is `userBounded` — a condition on `userId` cannot match a subject lacking it, so enrolled students would get 403 even after the 401 was fixed.

## Change

Adds a third route to the existing `X-API-Key` integration surface:

