### PR TITLE
docs: add simple V2.0 archive workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,14 @@
 <!-- Description -->
 
+<!--
+V2.0 flow:
+1) Submit this PR to main as usual.
+2) If maintainer adds `v2.0`, archive the branch:
+	git push origin your-branch-name:archive/v2.0/your-branch-name
+3) Close PR with comment:
+	Archived to branch archive/v2.0/your-branch-name for V2.0 release.
+-->
+
 <!-- 
 Mention any related issues here. 
 Use the following sytax:

--- a/archive/README.md
+++ b/archive/README.md
@@ -1,0 +1,20 @@
+# Archive Workflow (V2.0)
+
+Some PRs are approved for the V2.0 release instead of merging into `main` immediately.
+
+Use this process:
+
+1. Submit your PR to `main` as usual.
+2. Maintainer reviews and adds the `v2.0` label.
+3. Archive the branch on GitHub and close the PR:
+
+```bash
+git push origin your-branch-name:archive/v2.0/your-branch-name
+```
+
+Close the PR with this exact comment:
+
+`Archived to branch archive/v2.0/your-branch-name for V2.0 release.`
+
+Why:
+The branch and full commit history stay safe under `archive/v2.0/` and can be restored for V2.0 merge work.

--- a/archive/v2.0/README.md
+++ b/archive/v2.0/README.md
@@ -1,0 +1,11 @@
+# V2.0 Archive Namespace
+
+For PRs labeled `v2.0`, push your branch here:
+
+```bash
+git push origin your-branch-name:archive/v2.0/your-branch-name
+```
+
+Then close the PR with:
+
+`Archived to branch archive/v2.0/your-branch-name for V2.0 release.`


### PR DESCRIPTION
Description:

What this PR does
- Adds a simple archive workflow for PRs approved for V2.0.
- Keeps main clean while preserving full branch history for later merge.

Process documented
1. Submit PR to main as usual.
2. Maintainer adds the v2.0 label.
3. Contributor archives the branch:
   git push origin your-branch-name:archive/v2.0/your-branch-name
4. Contributor closes the PR with:
   Archived to branch archive/v2.0/your-branch-name for V2.0 release.

Why
- Ensures approved work is safely stored under v2.0
- Makes restoration and merge easy when V2.0 work starts.

Impact
- Documentation only.
- No product or runtime behavior changes.