### PR TITLE
fix(ui): checkbox border visibility issue

### DIFF
--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -12,7 +12,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-muted-foreground/50 dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border-2 shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}


### PR DESCRIPTION
Closes #1239

## Root cause
The shared `Checkbox` component's unchecked border color (`border-input`) is only ~8-10% lightness away from the page background in both themes:
- Light: background 100% lightness, border 90%
- Dark: background 7% lightness, border 15%

Essentially invisible by design, not a rendering bug — noticed on the Ethical Consent page, but this is the shared component used app-wide (quizzes, feedback forms, enrollment/ejection tables, flag "don't show again," policy acknowledgements, etc.).

## Before / After

Before 
<img width="376" height="371" alt="before" src="https://github.com/user-attachments/assets/31bdbbb5-548b-4620-be76-da49cbd92365" />

After
<img width="374" height="377" alt="after" src="https://github.com/user-attachments/assets/4e807edb-8d91-426d-a83b-46b4bf8334ad" />


## Fix
Switched to `border-muted-foreground/50` with a 2px border — much better contrast against the background in both themes (`muted-foreground` is 40% lightness in light mode, 64% in dark mode).

## Verification
- Audited all 22 `<Checkbox>` usages across the codebase — only one passes a custom `className`, and it's a margin utility, not a style override, so the fix applies uniformly everywhere with nothing fighting it.
- Confirmed the compiled CSS renders the new classes correctly in both light and dark mode.
- Verified live in production, in the real Ethical Consent modal (the page this was first noticed on) — the unchecked boxes are now clearly visible against the dark background.

## Test plan
- [x] Visual verification in both themes, using real compiled CSS.
- [x] Verified live on production (Ethical Consent modal, real webcam session flow).
- [x] Confirmed no other checkbox usage overrides the border styling.
